### PR TITLE
refactor: 统一MCP工具名称为jyc_前缀

### DIFF
--- a/src/mcp/question_tool.rs
+++ b/src/mcp/question_tool.rs
@@ -112,7 +112,7 @@ impl ServerHandler for QuestionToolHandler {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::new(
-                "jiny_question",
+                "jyc_question",
                 env!("CARGO_PKG_VERSION"),
             ))
             .with_instructions("MCP question tool for JYC — sends questions to users via messaging channels and waits for their response")

--- a/src/mcp/reply_tool.rs
+++ b/src/mcp/reply_tool.rs
@@ -109,7 +109,7 @@ impl ServerHandler for ReplyToolHandler {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::new(
-                "jiny_reply",
+                "jyc_reply",
                 env!("CARGO_PKG_VERSION"),
             ))
             .with_instructions("MCP reply tool for JYC — stores replies for delivery by the monitor process")

--- a/src/mcp/vision_tool.rs
+++ b/src/mcp/vision_tool.rs
@@ -127,7 +127,7 @@ impl ServerHandler for VisionToolHandler {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::new(
-                "vision",
+                "jyc_vision",
                 env!("CARGO_PKG_VERSION"),
             ))
             .with_instructions("MCP vision tool — analyzes visual content (images, PDFs, videos, etc.) using an OpenAI-compatible vision API")

--- a/src/services/opencode/prompt_builder.rs
+++ b/src/services/opencode/prompt_builder.rs
@@ -97,11 +97,11 @@ You are in BUILD mode with full tool access.
    - Reply directly with your knowledge. No tools needed.
 
 ## Reply Instructions
-When you have your answer ready, use the jiny_reply_reply_message tool:
+When you have your answer ready, use the jyc_reply_reply_message tool:
 - `message`: Your reply text
 - `attachments`: Optional filenames to attach from the working directory
 After a successful reply, STOP immediately. Do NOT call any other tools or perform further actions.
-CRITICAL: Always use jiny_reply_reply_message tool to send your reply.
+CRITICAL: Always use jyc_reply_reply_message tool to send your reply.
 "#,
         );
     }
@@ -237,7 +237,7 @@ mod tests {
         let prompt = build_system_prompt(tmp.path(), Some("Be helpful."), Some("build"));
 
         assert!(prompt.contains("Be helpful."));
-        assert!(prompt.contains("jiny_reply_reply_message"));
+        assert!(prompt.contains("jyc_reply_reply_message"));
         assert!(prompt.contains("Directory Boundaries"));
         assert!(prompt.contains("BUILD MODE"));
         assert!(!prompt.contains("Previous Session Summary"));
@@ -264,7 +264,7 @@ mod tests {
         assert!(prompt.contains("Be helpful."));
         assert!(prompt.contains("PLAN MODE"));
         assert!(prompt.contains("PROHIBITED: edit, write, bash commands that modify files"));
-        assert!(!prompt.contains("jiny_reply_reply_message"));
+        assert!(!prompt.contains("jyc_reply_reply_message"));
     }
 
     #[tokio::test]

--- a/src/services/opencode/session.rs
+++ b/src/services/opencode/session.rs
@@ -251,7 +251,7 @@ pub async fn ensure_thread_opencode_setup(
 
     // Build MCP tools configuration
     let mut mcp_tools = serde_json::json!({
-        "jiny_reply": {
+        "jyc_reply": {
             "type": "local",
             "command": tool_command,
             "environment": {
@@ -260,7 +260,7 @@ pub async fn ensure_thread_opencode_setup(
             "enabled": true,
             "timeout": 180000
         },
-        "jiny_question": {
+        "jyc_question": {
             "type": "local",
             "command": question_command,
             "enabled": true,
@@ -272,7 +272,7 @@ pub async fn ensure_thread_opencode_setup(
     if let Some(vision) = vision_config {
         if vision.enabled {
             let vision_command = get_vision_tool_command();
-            mcp_tools["vision"] = serde_json::json!({
+            mcp_tools["jyc_vision"] = serde_json::json!({
                 "type": "local",
                 "command": vision_command,
                 "environment": {


### PR DESCRIPTION
## Summary
- `jiny_reply` → `jyc_reply`
- `jiny_question` → `jyc_question`  
- `vision` → `jyc_vision`

统一所有 MCP 工具名称前缀为 `jyc_`