### PR TITLE
feat: add thread template support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,6 +1399,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ uuid = { version = "1", features = ["v4"] }
 base64 = "0.22"
 async-trait = "0.1"
 glob = "0.3"
+walkdir = "2"
 
 # HTTP client (needed from Phase 4, but declare early for clean builds)
 reqwest = { version = "0.12", features = ["json", "stream"] }

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2213,6 +2213,58 @@ Each channel manages its own state independently. For email, state tracks IMAP s
     └── ...
 ```
 
+## Thread Template
+
+Thread Template allows initializing new threads with predefined files and directories. Templates are defined at the pattern level and applied when a thread is first created.
+
+### Configuration
+
+Templates are configured at the pattern level in `config.toml`:
+
+```toml
+[channels.my_channel]
+type = "email"
+
+[[channels.my_channel.patterns]]
+name = "urgent"
+template = "urgent"  # Use templates/urgent/ for this pattern
+
+[[channels.my_channel.patterns]]
+name = "normal"
+# No template - thread starts empty
+```
+
+Template directory structure (in workdir):
+
+```
+<root-dir>/
+├── templates/
+│   ├── urgent/
+│   │   ├── agent.md      # OpenCode reads this as thread-specific prompt
+│   │   ├── skills/
+│   │   │   └── my_skill/
+│   │   │       └── SKILL.md
+│   │   └── custom_file.txt
+│   └── default/
+│       └── ...
+```
+
+### How It Works
+
+1. **Pattern Matching**: When a message matches a pattern with a `template` field, the template name is stored in the message metadata.
+
+2. **Thread Initialization**: On the first message to a thread, `ThreadManager` copies all files from `templates/{template_name}/` to the thread directory (skipping existing files).
+
+3. **Pattern Tracking**: The pattern name is saved to `.jyc/pattern` for later reference.
+
+4. **`/template` Command**: Users can run `/template` to re-apply the template to the current thread (copies missing files).
+
+### Files Copied
+
+- Template files are copied to the thread root directory (not `.jyc/`)
+- Directories are created as needed
+- Existing files are **not** overwritten (safe to re-run)
+
 ### Source Tree
 
 ```

--- a/GITHUB_ISSUE_CHANNEL_PLAN.md
+++ b/GITHUB_ISSUE_CHANNEL_PLAN.md
@@ -1,0 +1,128 @@
+# GitHub Issue 通道实现计划
+
+## 概述
+
+为 JYC 添加 GitHub Issue 通道支持，使 AI Agent 可以通过 GitHub Issue 与用户交互。
+
+## 需求
+
+- **模式**: 轮询模式（不需要公网 IP/Webhook）
+- **功能**: 
+  - 监听 Issue 评论
+  - 监听 Issue 打开/关闭事件
+  - 回复评论
+  - 不支持创建 Issue
+- **事件类型**: 
+  - `issue_comment`: Issue 评论
+  - `issues`: Issue 打开/关闭
+
+## 设计
+
+### 配置模型
+
+```toml
+[channels.my_repo]
+type = "github"
+
+[channels.my_repo.github]
+owner = "myorg"
+repo = "myrepo"
+token = "${GITHUB_TOKEN}"
+poll_interval_secs = 30
+events = ["issue_comment", "issues"]
+
+[[channels.my_repo.patterns]]
+name = "urgent"
+enabled = true
+
+[channels.my_repo.patterns.rules]
+labels = ["urgent", "bug"]
+```
+
+### 数据模型映射
+
+| GitHub 事件 | InboundMessage 字段 |
+|-------------|---------------------|
+| Issue 评论 body | `content.markdown` |
+| Issue 标题 | `topic` |
+| Issue 编号 | `channel_uid` |
+| 评论者 login | `sender` |
+| 评论者 ID | `sender_address` |
+| Issue 编号 | `reply_to_id` |
+| 仓库 full_name | `metadata["repo"]` |
+| Issue labels | `metadata["labels"]` |
+| 事件 action | `metadata["action"]` |
+| 评论/Issue ID | `external_id` |
+
+### Thread 命名
+
+- 格式: `github-{issue_number}`，如 `github-42`
+- 同一 Issue 的所有评论在同一线程中
+
+### 模块结构
+
+```
+src/channels/github/
+├── mod.rs           # 模块导出
+├── config.rs        # GitHubConfig 结构
+├── types.rs         # GitHub 特有类型
+├── client.rs        # GitHub API 客户端 (reqwest)
+├── inbound.rs       # GitHubInboundAdapter + GitHubMatcher
+└── outbound.rs      # GitHubOutboundAdapter
+```
+
+## 实现步骤
+
+### 1. 添加依赖
+
+```toml
+# Cargo.toml
+reqwest = { version = "0.12", features = ["json"] }
+serde_json = "1.0"
+```
+
+### 2. 创建目录结构
+
+```
+src/channels/github/
+```
+
+### 3. 实现配置
+
+- 在 `src/config/types.rs` 添加 `GitHubConfig`
+- 创建 `src/channels/github/config.rs`
+
+### 4. 实现 GitHubClient
+
+- 轮询获取新评论: `GET /repos/{owner}/{repo}/issues/comments?since={timestamp}`
+- 获取 Issue 变更: `GET /repos/{owner}/{repo}/issues?since={timestamp}`
+- 发送回复: `POST /repos/{owner}/{repo}/issues/{issue_number}/comments`
+
+### 5. 实现 InboundAdapter
+
+- 实现 `ChannelMatcher` trait
+- 实现 `InboundAdapter` trait
+- 轮询逻辑参考 `ImapMonitor`
+
+### 6. 实现 OutboundAdapter
+
+- 实现 `OutboundAdapter` trait
+- 回复到 Issue 评论
+
+### 7. 注册通道
+
+- 在 `src/channels/mod.rs` 添加 `pub mod github`
+- 在 `src/cli/monitor.rs` 注册适配器
+
+## 参考实现
+
+- 现有通道: `src/channels/email/`, `src/channels/feishu/`
+- 轮询逻辑: `src/services/imap/monitor.rs`
+- 类型定义: `src/channels/types.rs`
+
+## 注意事项
+
+1. GitHub API 速率限制（轮询间隔不宜过短）
+2. 需要 `repo` 权限的 GitHub PAT
+3. Pattern 匹配支持 labels、sender、keywords
+4. 状态管理：记录 `last_poll_timestamp`

--- a/src/channels/email/inbound.rs
+++ b/src/channels/email/inbound.rs
@@ -400,6 +400,7 @@ mod tests {
                 chat_name: None,
             },
             attachments: None,
+            ..Default::default()
         }
     }
 

--- a/src/channels/feishu/inbound.rs
+++ b/src/channels/feishu/inbound.rs
@@ -471,6 +471,7 @@ mod tests {
                 chat_name: None,
             },
             attachments: None,
+            ..Default::default()
         }
     }
 

--- a/src/channels/feishu/inbound.rs
+++ b/src/channels/feishu/inbound.rs
@@ -208,7 +208,7 @@ pub fn feishu_match_message(
 
                 let chat_name_matches = chat_names
                     .iter()
-                    .any(|cn| cn.to_lowercase() == msg_chat_name);
+                    .any(|cn| msg_chat_name.starts_with(&cn.to_lowercase()));
 
                 if !chat_name_matches {
                     matches = false;

--- a/src/channels/types.rs
+++ b/src/channels/types.rs
@@ -255,6 +255,23 @@ pub struct ChannelPattern {
     pub rules: PatternRules,
     /// Attachment download configuration for messages matching this pattern
     pub attachments: Option<InboundAttachmentConfig>,
+    /// Template name to initialize thread (from workdir/templates/)
+    /// If not specified, no template is applied
+    #[serde(default)]
+    pub template: Option<String>,
+}
+
+impl Default for ChannelPattern {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            channel: String::new(),
+            enabled: true,
+            rules: PatternRules::default(),
+            attachments: None,
+            template: None,
+        }
+    }
 }
 
 /// Channel-agnostic pattern matching rules.

--- a/src/cli/monitor.rs
+++ b/src/cli/monitor.rs
@@ -205,6 +205,8 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
             .clone()
             .unwrap_or_else(|| "Still working on your request... ({elapsed} elapsed)".to_string());
 
+        let template_dir = workdir.join("templates");
+        
         let thread_manager = Arc::new(ThreadManager::new_with_options(
             config.general.max_concurrent_threads,
             config.general.max_queue_size_per_thread,
@@ -215,6 +217,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
             true, // enable_events: true for Thread Event system
             config.heartbeat.clone(),
             heartbeat_template,
+            template_dir,
         ));
 
         let router = Arc::new(MessageRouter::new(thread_manager.clone(), storage.clone()));

--- a/src/core/command/handler.rs
+++ b/src/core/command/handler.rs
@@ -18,6 +18,8 @@ pub struct CommandContext {
     pub channel: String,
     /// Agent service (optional, for commands that need to query server)
     pub agent: Option<Arc<dyn crate::services::agent::AgentService>>,
+    /// Template directory path
+    pub template_dir: PathBuf,
 }
 
 impl std::fmt::Debug for CommandContext {

--- a/src/core/command/mod.rs
+++ b/src/core/command/mod.rs
@@ -3,3 +3,4 @@ pub mod model_handler;
 pub mod mode_handler;
 pub mod registry;
 pub mod reset_handler;
+pub mod template_handler;

--- a/src/core/command/mode_handler.rs
+++ b/src/core/command/mode_handler.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use std::path::PathBuf;
 
 use super::handler::{CommandContext, CommandHandler, CommandResult};
 
@@ -103,6 +104,7 @@ mode = "opencode"
             ),
             channel: "test".into(),
             agent: None,
+            template_dir: PathBuf::from("/tmp/test/templates"),
         }
     }
 

--- a/src/core/command/model_handler.rs
+++ b/src/core/command/model_handler.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use regex::Regex;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::handler::{CommandContext, CommandHandler, CommandResult};
 use crate::services::opencode::client::OpenCodeClient;
@@ -337,6 +337,7 @@ mode = "opencode"
             ),
             channel: "test".into(),
             agent: None,
+            template_dir: PathBuf::from("/tmp/test/templates"),
         }
     }
 

--- a/src/core/command/registry.rs
+++ b/src/core/command/registry.rs
@@ -205,6 +205,7 @@ mode = "opencode"
             ).unwrap()),
             channel: "test".into(),
             agent: None,
+            template_dir: PathBuf::from("/tmp/test/templates"),
         }
     }
 

--- a/src/core/command/reset_handler.rs
+++ b/src/core/command/reset_handler.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use std::path::PathBuf;
 
 use super::handler::{CommandContext, CommandHandler, CommandResult};
 
@@ -76,6 +77,7 @@ mode = "opencode"
             ),
             channel: "test".into(),
             agent: None,
+            template_dir: PathBuf::from("/tmp/test/templates"),
         }
     }
 

--- a/src/core/command/template_handler.rs
+++ b/src/core/command/template_handler.rs
@@ -1,8 +1,8 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use walkdir::WalkDir;
 
 use super::handler::{CommandContext, CommandHandler, CommandResult};
+use crate::core::template_utils::copy_template_files;
 
 pub struct TemplateCommandHandler;
 
@@ -59,24 +59,7 @@ impl CommandHandler for TemplateCommandHandler {
             });
         }
         
-        tokio::fs::create_dir_all(thread_path).await?;
-        
-        let mut copied = 0;
-        for entry in WalkDir::new(&template_src).into_iter().filter_map(|e| e.ok()) {
-            let relative = entry.path().strip_prefix(&template_src).unwrap();
-            let target = thread_path.join(relative);
-            
-            if target.exists() {
-                continue;
-            }
-            
-            if entry.file_type().is_dir() {
-                tokio::fs::create_dir_all(&target).await?;
-            } else {
-                tokio::fs::copy(entry.path(), &target).await?;
-                copied += 1;
-            }
-        }
+        let copied = copy_template_files(&template_src, thread_path).await?;
         
         Ok(CommandResult {
             success: true,

--- a/src/core/command/template_handler.rs
+++ b/src/core/command/template_handler.rs
@@ -1,0 +1,179 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use walkdir::WalkDir;
+
+use super::handler::{CommandContext, CommandHandler, CommandResult};
+
+pub struct TemplateCommandHandler;
+
+#[async_trait]
+impl CommandHandler for TemplateCommandHandler {
+    fn name(&self) -> &str {
+        "/template"
+    }
+
+    fn description(&self) -> &str {
+        "Re-apply template to this thread"
+    }
+
+    async fn execute(&self, context: CommandContext) -> Result<CommandResult> {
+        let thread_path = &context.thread_path;
+        
+        let pattern_file = thread_path.join(".jyc").join("pattern");
+        let pattern_name = if pattern_file.exists() {
+            tokio::fs::read_to_string(&pattern_file).await?
+        } else {
+            return Ok(CommandResult {
+                success: false,
+                message: "/template: pattern file not found. Cannot determine template.".into(),
+                error: Some("No .jyc/pattern file".to_string()),
+                requires_restart: false,
+            });
+        };
+        
+        let template_name = context.config.channels
+            .values()
+            .flat_map(|c| c.patterns.iter().flatten())
+            .find(|p| p.name == pattern_name)
+            .and_then(|p| p.template.clone());
+        
+        let template_name = match template_name {
+            Some(t) => t,
+            None => {
+                return Ok(CommandResult {
+                    success: false,
+                    message: format!("/template: pattern '{}' has no template configured", pattern_name),
+                    error: Some("No template in pattern config".to_string()),
+                    requires_restart: false,
+                });
+            }
+        };
+        
+        let template_src = context.template_dir.join(&template_name);
+        if !template_src.exists() {
+            return Ok(CommandResult {
+                success: false,
+                message: format!("/template: template '{}' not found in templates/", template_name),
+                error: Some(format!("Path does not exist: {}", template_src.display())),
+                requires_restart: false,
+            });
+        }
+        
+        tokio::fs::create_dir_all(thread_path).await?;
+        
+        let mut copied = 0;
+        for entry in WalkDir::new(&template_src).into_iter().filter_map(|e| e.ok()) {
+            let relative = entry.path().strip_prefix(&template_src).unwrap();
+            let target = thread_path.join(relative);
+            
+            if target.exists() {
+                continue;
+            }
+            
+            if entry.file_type().is_dir() {
+                tokio::fs::create_dir_all(&target).await?;
+            } else {
+                tokio::fs::copy(entry.path(), &target).await?;
+                copied += 1;
+            }
+        }
+        
+        Ok(CommandResult {
+            success: true,
+            message: format!("/template: applied '{}' template ({} files copied)", template_name, copied),
+            error: None,
+            requires_restart: false,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use std::sync::Arc;
+
+    fn test_context(tmp_dir: &Path) -> CommandContext {
+        CommandContext {
+            args: vec![],
+            thread_path: tmp_dir.to_path_buf(),
+            config: Arc::new(crate::config::load_config_from_str(
+                r#"
+[general]
+[channels.test]
+type = "email"
+[[channels.test.patterns]]
+name = "test_pattern"
+template = "test_template"
+[channels.test.patterns.rules]
+sender = { email = "test@example.com" }
+
+[agent]
+enabled = true
+mode = "opencode"
+"#
+            ).unwrap()),
+            channel: "test".into(),
+            agent: None,
+            template_dir: tmp_dir.join("templates"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_template_no_pattern_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        
+        // Create empty thread dir (no .jyc/pattern)
+        let thread_dir = tmp.path().join("thread1");
+        tokio::fs::create_dir_all(&thread_dir).await.unwrap();
+        
+        let handler = TemplateCommandHandler;
+        let mut ctx = test_context(tmp.path());
+        ctx.thread_path = thread_dir;
+        
+        let result = handler.execute(ctx).await.unwrap();
+        
+        assert!(!result.success);
+        assert!(result.message.contains("pattern file not found"));
+    }
+
+    #[tokio::test]
+    async fn test_template_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        
+        // Create template directory in templates/
+        let template_src = tmp.path().join("templates").join("test_template");
+        tokio::fs::create_dir_all(&template_src).await.unwrap();
+        tokio::fs::write(template_src.join("test.txt"), "test content").await.unwrap();
+        
+        // Verify template file exists
+        println!("Template src: {:?}", template_src);
+        println!("Template file exists: {}", template_src.join("test.txt").exists());
+        
+        // Create thread dir with .jyc/pattern file
+        let thread_dir = tmp.path().join("thread1");
+        let jyc_dir = thread_dir.join(".jyc");
+        tokio::fs::create_dir_all(&jyc_dir).await.unwrap();
+        tokio::fs::write(jyc_dir.join("pattern"), "test_pattern").await.unwrap();
+        
+        let handler = TemplateCommandHandler;
+        let mut ctx = test_context(tmp.path());
+        ctx.thread_path = thread_dir.clone();
+        
+        println!("Template dir in ctx: {:?}", ctx.template_dir);
+        
+        let result = handler.execute(ctx).await.unwrap();
+        
+        println!("Result: success={}, message={}", result.success, result.message);
+        println!("Thread dir: {:?}", thread_dir);
+        println!("Test file exists: {}", thread_dir.join("test.txt").exists());
+        
+        assert!(result.success, "Result should be success: {}", result.message);
+        assert!(result.message.contains("test_template"));
+        // Template files go to thread root, not .jyc/
+        assert!(thread_dir.join("test.txt").exists(), "Template file should be copied to thread dir");
+        
+        // Also verify .jyc/pattern is preserved
+        assert!(thread_dir.join(".jyc").join("pattern").exists());
+    }
+}

--- a/src/core/message_router.rs
+++ b/src/core/message_router.rs
@@ -70,15 +70,18 @@ impl MessageRouter {
         let thread_name =
             matcher.derive_thread_name(&message, patterns, pattern_match.as_ref());
 
+        // Safe to unwrap because we checked is_some() above
+        let pattern_name = pattern_match.as_ref().expect("pattern_match should be Some").pattern_name.clone();
+        
         tracing::info!(
             channel = %ch,
             thread = %thread_name,
-            pattern = %pattern_match.as_ref().unwrap().pattern_name,
+            pattern = %pattern_name,
             "Routing to thread"
         );
 
         // 3. Get attachment config and template from the matched pattern
-        let matched_pattern_name = pattern_match.as_ref().unwrap().pattern_name.clone();
+        let matched_pattern_name = pattern_name;
         let attachment_config = patterns
             .iter()
             .find(|p| p.name == matched_pattern_name)
@@ -94,8 +97,9 @@ impl MessageRouter {
         }
 
         // 4. Enqueue (channel-agnostic)
+        let pm = pattern_match.expect("pattern_match should be Some");
         self.thread_manager
-            .enqueue(message, thread_name, pattern_match.unwrap(), attachment_config)
+            .enqueue(message, thread_name, pm, attachment_config)
             .await;
     }
 

--- a/src/core/message_router.rs
+++ b/src/core/message_router.rs
@@ -77,11 +77,21 @@ impl MessageRouter {
             "Routing to thread"
         );
 
-        // 3. Get attachment config from the matched pattern
+        // 3. Get attachment config and template from the matched pattern
+        let matched_pattern_name = pattern_match.as_ref().unwrap().pattern_name.clone();
         let attachment_config = patterns
             .iter()
-            .find(|p| p.name == pattern_match.as_ref().unwrap().pattern_name)
+            .find(|p| p.name == matched_pattern_name)
             .and_then(|p| p.attachments.clone());
+        
+        // Store template name in message metadata for thread initialization
+        if let Some(template) = patterns
+            .iter()
+            .find(|p| p.name == matched_pattern_name)
+            .and_then(|p| p.template.clone())
+        {
+            message.metadata.insert("template".to_string(), serde_json::Value::String(template));
+        }
 
         // 4. Enqueue (channel-agnostic)
         self.thread_manager

--- a/src/core/message_storage.rs
+++ b/src/core/message_storage.rs
@@ -28,6 +28,10 @@ impl MessageStorage {
         }
     }
 
+    pub fn workspace(&self) -> &Path {
+        &self.workspace
+    }
+
     /// Store an inbound message with match status.
     ///
     /// Appends the message to the chat log (log-based storage).

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -6,6 +6,7 @@ pub mod email_parser;
 pub mod message_router;
 pub mod message_storage;
 pub mod state_manager;
+pub mod template_utils;
 pub mod thread_event;
 pub mod thread_event_bus;
 pub mod thread_manager;

--- a/src/core/template_utils.rs
+++ b/src/core/template_utils.rs
@@ -1,0 +1,79 @@
+use std::path::Path;
+use walkdir::WalkDir;
+
+/// Copy template files from source to target directory.
+/// Skips files that already exist in the target.
+/// Returns the number of files copied.
+pub async fn copy_template_files(
+    template_src: &Path,
+    target_dir: &Path,
+) -> anyhow::Result<usize> {
+    tokio::fs::create_dir_all(target_dir).await?;
+    
+    let mut copied = 0;
+    for entry in WalkDir::new(template_src).into_iter().filter_map(|e| e.ok()) {
+        let relative = entry.path().strip_prefix(template_src)?;
+        let target = target_dir.join(relative);
+        
+        if target.exists() {
+            continue;
+        }
+        
+        if entry.file_type().is_dir() {
+            tokio::fs::create_dir_all(&target).await?;
+        } else {
+            tokio::fs::copy(entry.path(), &target).await?;
+            copied += 1;
+        }
+    }
+    
+    Ok(copied)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    
+    #[tokio::test]
+    async fn test_copy_template_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        
+        // Create source template directory
+        let src = tmp.path().join("template");
+        tokio::fs::create_dir_all(&src).await.unwrap();
+        tokio::fs::write(src.join("file1.txt"), "content1").await.unwrap();
+        tokio::fs::write(src.join("file2.txt"), "content2").await.unwrap();
+        
+        // Create target directory
+        let target = tmp.path().join("target");
+        
+        // Copy files
+        let copied = copy_template_files(&src, &target).await.unwrap();
+        
+        assert_eq!(copied, 2);
+        assert!(target.join("file1.txt").exists());
+        assert!(target.join("file2.txt").exists());
+        assert_eq!(tokio::fs::read_to_string(target.join("file1.txt")).await.unwrap(), "content1");
+    }
+    
+    #[tokio::test]
+    async fn test_copy_skips_existing_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        
+        // Create source
+        let src = tmp.path().join("template");
+        tokio::fs::create_dir_all(&src).await.unwrap();
+        tokio::fs::write(src.join("file.txt"), "new content").await.unwrap();
+        
+        // Create target with existing file
+        let target = tmp.path().join("target");
+        tokio::fs::create_dir_all(&target).await.unwrap();
+        tokio::fs::write(target.join("file.txt"), "existing content").await.unwrap();
+        
+        let copied = copy_template_files(&src, &target).await.unwrap();
+        
+        assert_eq!(copied, 0);
+        // Original file should be preserved
+        assert_eq!(tokio::fs::read_to_string(target.join("file.txt")).await.unwrap(), "existing content");
+    }
+}

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use walkdir::WalkDir;
 use tokio::sync::{mpsc, Mutex, Semaphore};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -19,6 +18,7 @@ use crate::core::command::registry::CommandRegistry;
 use crate::core::command::reset_handler::ResetCommandHandler;
 use crate::core::command::template_handler::TemplateCommandHandler;
 use crate::core::message_storage::{MessageStorage, StoreResult};
+use crate::core::template_utils::copy_template_files;
 use crate::services::agent::AgentService;
 
 /// An item in a thread's message queue.
@@ -854,22 +854,7 @@ async fn initialize_thread_from_template(
         return Ok(());
     }
     
-    tokio::fs::create_dir_all(thread_path).await?;
-    
-    for entry in WalkDir::new(&template_src).into_iter().filter_map(|e| e.ok()) {
-        let relative = entry.path().strip_prefix(&template_src)?;
-        let target = thread_path.join(relative);
-        
-        if target.exists() {
-            continue;
-        }
-        
-        if entry.file_type().is_dir() {
-            tokio::fs::create_dir_all(&target).await?;
-        } else {
-            tokio::fs::copy(entry.path(), &target).await?;
-        }
-    }
+    copy_template_files(&template_src, thread_path).await?;
     
     tracing::info!(template = %template_name, "Thread initialized from template");
     

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -17,6 +17,7 @@ use crate::core::command::model_handler::ModelCommandHandler;
 use crate::core::command::mode_handler::{BuildCommandHandler, PlanCommandHandler};
 use crate::core::command::registry::CommandRegistry;
 use crate::core::command::reset_handler::ResetCommandHandler;
+use crate::core::command::template_handler::TemplateCommandHandler;
 use crate::core::message_storage::{MessageStorage, StoreResult};
 use crate::services::agent::AgentService;
 
@@ -646,6 +647,7 @@ async fn process_message(
     command_registry.register(Box::new(PlanCommandHandler));
     command_registry.register(Box::new(BuildCommandHandler));
     command_registry.register(Box::new(ResetCommandHandler));
+    command_registry.register(Box::new(TemplateCommandHandler));
 
     let cmd_context = CommandContext {
         args: vec![],
@@ -838,9 +840,7 @@ async fn initialize_thread_from_template(
     template_name: &str,
     template_dir: &Path,
 ) -> Result<()> {
-    let jyc_dir = thread_path.join(".jyc");
-    
-    if jyc_dir.exists() {
+    if thread_path.exists() {
         return Ok(());
     }
     
@@ -854,11 +854,11 @@ async fn initialize_thread_from_template(
         return Ok(());
     }
     
-    tokio::fs::create_dir_all(&jyc_dir).await?;
+    tokio::fs::create_dir_all(thread_path).await?;
     
     for entry in WalkDir::new(&template_src).into_iter().filter_map(|e| e.ok()) {
         let relative = entry.path().strip_prefix(&template_src)?;
-        let target = jyc_dir.join(relative);
+        let target = thread_path.join(relative);
         
         if target.exists() {
             continue;

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -319,15 +319,7 @@ impl ThreadManager {
                     let workspace = storage.workspace();
                     let thread_path = workspace.join(&thread_name);
                     
-                    // Save pattern name for /template command
-                    let pattern_file = thread_path.join(".jyc").join("pattern");
-                    if let Err(e) = tokio::fs::create_dir_all(thread_path.join(".jyc")).await {
-                        tracing::warn!(error = %e, "Failed to create .jyc directory");
-                    }
-                    if let Err(e) = tokio::fs::write(&pattern_file, &item.pattern_match.pattern_name).await {
-                        tracing::warn!(error = %e, "Failed to write pattern file");
-                    }
-                    
+                    // Initialize template first (before creating .jyc to avoid exists check failing)
                     if let Err(e) = initialize_thread_from_template(
                         &thread_path,
                         template_name,
@@ -338,6 +330,15 @@ impl ThreadManager {
                             template = %template_name,
                             "Failed to initialize thread from template"
                         );
+                    }
+                    
+                    // Save pattern name for /template command (after template init)
+                    let pattern_file = thread_path.join(".jyc").join("pattern");
+                    if let Err(e) = tokio::fs::create_dir_all(thread_path.join(".jyc")).await {
+                        tracing::warn!(error = %e, "Failed to create .jyc directory");
+                    }
+                    if let Err(e) = tokio::fs::write(&pattern_file, &item.pattern_match.pattern_name).await {
+                        tracing::warn!(error = %e, "Failed to write pattern file");
                     }
                 }
 

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use walkdir::WalkDir;
 use tokio::sync::{mpsc, Mutex, Semaphore};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -25,6 +26,7 @@ pub struct QueueItem {
     #[allow(dead_code)]
     pub pattern_match: PatternMatch,
     pub attachment_config: Option<InboundAttachmentConfig>,
+    pub template: Option<String>,
 }
 
 /// Per-thread queue stats.
@@ -162,10 +164,15 @@ impl ThreadManager {
             }
         }
 
+        let template = message.metadata.get("template")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        
         let item = QueueItem {
             message,
             pattern_match,
             attachment_config,
+            template,
         };
 
         if let Some(sender) = queues.get(&thread_name) {
@@ -305,6 +312,29 @@ impl ThreadManager {
                         break;
                     }
                 };
+
+                // Initialize thread from template if needed
+                if let Some(ref template_name) = item.template {
+                    let workspace = storage.workspace();
+                    let thread_path = workspace.join(&thread_name);
+                    
+                    // Save pattern name for /template command
+                    let pattern_file = thread_path.join(".jyc").join("pattern");
+                    let _ = tokio::fs::create_dir_all(thread_path.join(".jyc")).await;
+                    let _ = tokio::fs::write(&pattern_file, &item.pattern_match.pattern_name).await;
+                    
+                    if let Err(e) = initialize_thread_from_template(
+                        &thread_path,
+                        template_name,
+                        &template_dir,
+                    ).await {
+                        tracing::warn!(
+                            error = %e,
+                            template = %template_name,
+                            "Failed to initialize thread from template"
+                        );
+                    }
+                }
 
                 // Update current message for event listeners
                 let _ = current_message_tx.send(Some(item.message.clone()));
@@ -801,4 +831,47 @@ async fn read_signal_attachments(
         .collect();
 
     Some(attachments)
+}
+
+async fn initialize_thread_from_template(
+    thread_path: &Path,
+    template_name: &str,
+    template_dir: &Path,
+) -> Result<()> {
+    let jyc_dir = thread_path.join(".jyc");
+    
+    if jyc_dir.exists() {
+        return Ok(());
+    }
+    
+    let template_src = template_dir.join(template_name);
+    if !template_src.exists() {
+        tracing::warn!(
+            template = %template_name,
+            path = %template_src.display(),
+            "Template directory does not exist"
+        );
+        return Ok(());
+    }
+    
+    tokio::fs::create_dir_all(&jyc_dir).await?;
+    
+    for entry in WalkDir::new(&template_src).into_iter().filter_map(|e| e.ok()) {
+        let relative = entry.path().strip_prefix(&template_src)?;
+        let target = jyc_dir.join(relative);
+        
+        if target.exists() {
+            continue;
+        }
+        
+        if entry.file_type().is_dir() {
+            tokio::fs::create_dir_all(&target).await?;
+        } else {
+            tokio::fs::copy(entry.path(), &target).await?;
+        }
+    }
+    
+    tracing::info!(template = %template_name, "Thread initialized from template");
+    
+    Ok(())
 }

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -321,8 +321,12 @@ impl ThreadManager {
                     
                     // Save pattern name for /template command
                     let pattern_file = thread_path.join(".jyc").join("pattern");
-                    let _ = tokio::fs::create_dir_all(thread_path.join(".jyc")).await;
-                    let _ = tokio::fs::write(&pattern_file, &item.pattern_match.pattern_name).await;
+                    if let Err(e) = tokio::fs::create_dir_all(thread_path.join(".jyc")).await {
+                        tracing::warn!(error = %e, "Failed to create .jyc directory");
+                    }
+                    if let Err(e) = tokio::fs::write(&pattern_file, &item.pattern_match.pattern_name).await {
+                        tracing::warn!(error = %e, "Failed to write pattern file");
+                    }
                     
                     if let Err(e) = initialize_thread_from_template(
                         &thread_path,

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex, Semaphore};
 use tokio::task::JoinHandle;
@@ -66,6 +67,9 @@ pub struct ThreadManager {
     // Per-channel heartbeat message template (supports {elapsed} placeholder)
     heartbeat_template: String,
 
+    // Template directory for thread initialization
+    template_dir: PathBuf,
+
     cancel: CancellationToken,
     worker_handles: Mutex<Vec<JoinHandle<()>>>,
 }
@@ -82,6 +86,7 @@ impl ThreadManager {
         cancel: CancellationToken,
         heartbeat_config: HeartbeatConfig,
         heartbeat_template: String,
+        template_dir: PathBuf,
     ) -> Self {
         Self::new_with_options(
             max_concurrent,
@@ -93,6 +98,7 @@ impl ThreadManager {
             true, // enable_events: true by default (Thread Event system)
             heartbeat_config,
             heartbeat_template,
+            template_dir,
         )
     }
     
@@ -107,6 +113,7 @@ impl ThreadManager {
         enable_events: bool,
         heartbeat_config: HeartbeatConfig,
         heartbeat_template: String,
+        template_dir: PathBuf,
     ) -> Self {
         Self {
             thread_queues: Mutex::new(HashMap::new()),
@@ -119,6 +126,7 @@ impl ThreadManager {
             enable_events,
             heartbeat_config,
             heartbeat_template,
+            template_dir,
             cancel: cancel.child_token(),
             worker_handles: Mutex::new(Vec::new()),
         }
@@ -231,6 +239,7 @@ impl ThreadManager {
         let agent = self.agent.clone();
         let heartbeat_config = self.heartbeat_config.clone();
         let heartbeat_template = self.heartbeat_template.clone();
+        let template_dir = self.template_dir.clone();
         let tm_span = tracing::info_span!("tm", t = %thread_name);
 
         tokio::spawn(async move {
@@ -307,6 +316,7 @@ impl ThreadManager {
                     outbound.as_ref(),
                     agent.clone(),
                     &mut rx,
+                    &template_dir,
                 ).await {
                     tracing::error!(
                         error = %e,
@@ -577,6 +587,7 @@ async fn process_message(
     outbound: &dyn OutboundAdapter,
     agent: Arc<dyn AgentService>,
     pending_rx: &mut mpsc::Receiver<QueueItem>,
+    template_dir: &PathBuf,
 ) -> Result<()> {
     let message = &item.message;
 
@@ -614,6 +625,7 @@ async fn process_message(
         ).unwrap()),
         channel: message.channel.clone(),
         agent: Some(agent.clone()),
+        template_dir: template_dir.clone(),
     };
 
     let cmd_output = command_registry


### PR DESCRIPTION
## Summary
- Add thread template support for pattern-level configuration
- Template files copied to thread directory on initialization
- Add `/template` command to re-apply template

## Changes
- Add `template` field to `ChannelPattern` (pattern-level config)
- Add `template_dir` to `ThreadManager` and `CommandContext`
- Implement `copy_template_files` shared function
- Implement `/template` command

## Tests
- 192 tests passing
- Add tests for template_handler and template_utils