### PR TITLE
feat: add GitHub Issue channel support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "jyc"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -181,11 +181,19 @@ User sends message (any channel) → Pattern Match → Thread Queue → Worker (
 ### Components
 
 1. **Inbound Adapters** — Channel-specific message receivers (Email/IMAP, FeiShu/WebSocket, etc.)
-2. **Outbound Adapters** — Channel-specific reply senders (Email/SMTP, FeiShu/API, etc.)
-3. **Channel Registry** — Lookup adapters by channel type (uses `Arc<dyn>` trait objects). Currently `#[allow(dead_code)]` / unused — ThreadManager uses `Arc<dyn OutboundAdapter>` directly.
-4. **Message Router** — Delegates matching/naming to `ChannelMatcher` trait, dispatches to thread queues. Channel-agnostic: `route(matcher: &dyn ChannelMatcher, ...)`
+ 2. **Outbound Adapters** — Channel-specific reply senders (Email/SMTP, FeiShu/API, GitHub/API)
+ 3. **Channel Registry** — Lookup adapters by channel type (uses `Arc<dyn>` trait objects). Currently `#[allow(dead_code)]` / unused — ThreadManager uses `Arc<dyn OutboundAdapter>` directly.
+ 4. **Message Router** — Delegates matching/naming to `ChannelMatcher` trait, dispatches to thread queues. Channel-agnostic: `route(matcher: &dyn ChannelMatcher, ...)`
  5. **Thread Manager** — Per-thread mpsc queues with semaphore-bounded concurrency. Dispatches to agent services. Handles fallback send if agent returns text instead of sending via tool. Includes Thread Event system for heartbeat control.
  6. **OpenCode Service** — AI agent: server lifecycle, session management, prompt building, SSE streaming, error recovery. Returns `GenerateReplyResult` to the caller — does NOT send emails.
+
+### Supported Channels
+
+| Channel | Inbound | Outbound | Docs |
+|---------|---------|----------|------|
+| Email | IMAP polling/IDLE | SMTP | DESIGN.md |
+| Feishu | WebSocket events | Feishu API | FEISHU.md |
+| GitHub | REST API polling | Issue comments | GITHUB_CHANNEL.md |
  7. **Thread Event Bus** — Thread-isolated event bus for publishing and subscribing to processing events (SSE → ThreadEvent conversion).
  8. **Thread Event System** — Heartbeat rhythm control: monitors processing progress and sends periodic updates (default every 10 minutes, configurable via `[heartbeat]` config section) via `send_heartbeat()`.
  9. **Prompt Builder** — Builds channel-agnostic prompts from InboundMessage

--- a/GITHUB_CHANNEL.md
+++ b/GITHUB_CHANNEL.md
@@ -1,0 +1,140 @@
+# GitHub Channel
+
+GitHub Issue/PR channel for jyc — enables AI agents to work on GitHub issues, create PRs, and participate in code reviews.
+
+## Architecture
+
+```
+GitHub API (polling)
+    ↓
+poll_events()
+├── Fetch all open items (issues + PRs) from /issues?state=open
+├── Classify into issues and PRs
+│
+├── process_comments()
+│   ├── Fetch comments from /issues/comments?since=...
+│   ├── Skip bot's own comments
+│   ├── Skip comments on closed items
+│   └── Route to thread: github-<number>
+│
+├── process_issues()
+│   ├── Filter: only issues, open, not already processed
+│   └── Route to thread: github-<issue_number>
+│
+└── process_pull_requests()
+    ├── Filter: only PRs, open, not already processed
+    ├── Detect linked issue (Fixes #N, Closes #N, Resolves #N)
+    ├── If linked → route to issue thread (github-<issue_number>)
+    └── If not linked → own thread (github-<pr_number>)
+```
+
+## Configuration
+
+```toml
+[channels.jyc_repo]
+type = "github"
+
+[channels.jyc_repo.github]
+owner = "myorg"
+repo = "myrepo"
+token = "${GITHUB_TOKEN}"
+poll_interval_secs = 120
+events = ["issue_comment", "issues", "pull_request"]
+
+# Pattern: route issues with specific labels
+[[channels.jyc_repo.patterns]]
+name = "dev"
+enabled = true
+template = "jyc-dev"
+
+[channels.jyc_repo.patterns.rules]
+labels = ["bug", "enhancement", "question"]
+
+# Pattern: route PRs labeled 'review' to review agent
+[[channels.jyc_repo.patterns]]
+name = "review"
+enabled = true
+template = "jyc-review"
+
+[channels.jyc_repo.patterns.rules]
+labels = ["review"]
+```
+
+## Event Types
+
+| Event | Description | Config |
+|-------|-------------|--------|
+| `issues` | New open issues | `events = ["issues"]` |
+| `issue_comment` | Comments on open issues and PRs | `events = ["issue_comment"]` |
+| `pull_request` | New open PRs | `events = ["pull_request"]` |
+
+## Thread Naming
+
+- Issues: `github-<issue_number>` (e.g., `github-42`)
+- PRs linked to issues: routed to `github-<issue_number>` (same thread)
+- PRs not linked: `github-<pr_number>`
+
+## Issue → PR Lifecycle
+
+```
+1. User creates Issue #42 (label: bug)
+   → Thread github-42 created, dev agent assigned
+   
+2. Dev agent creates branch: fix/issue-42
+   → Agent implements fix (incremental-dev skill)
+   
+3. Dev agent creates PR #45 (body: "Fixes #42")
+   → PR linked to issue, comments routed to github-42 thread
+   
+4. User labels PR with "review"
+   → Review agent picks up PR, posts review via pr-review skill
+   
+5. Review comments appear on PR
+   → Routed to github-42 thread, dev agent fixes issues
+   
+6. User approves and merges PR
+   → Issue closed, thread becomes inactive
+```
+
+## Deduplication
+
+- **Issues**: Tracked by `issue.id` in memory. Same issue not re-processed across polls.
+- **Comments**: Tracked by `comment.id` in memory. Same comment not re-processed.
+- **Bot comments**: Detected by `[bot]` suffix in username or reply footer (`Model:/Mode:`). Skipped to prevent feedback loops.
+
+## Pattern Matching
+
+| Rule | Description |
+|------|-------------|
+| `labels` | Match issues/PRs with any of the specified labels |
+| `sender.exact` | Match by GitHub user ID |
+| `sender.regex` | Match by GitHub user ID pattern |
+
+## Data Model Mapping
+
+| GitHub Field | InboundMessage Field |
+|-------------|---------------------|
+| Issue/PR body | `content.markdown` |
+| Issue/PR title | `topic` |
+| Issue/PR number | `channel_uid`, `metadata["issue_number"]` |
+| User login | `sender` |
+| User ID | `sender_address` |
+| Labels | `metadata["labels"]` |
+| Event type | `metadata["event_type"]` |
+| HTML URL | `metadata["html_url"]` |
+| Is PR | `metadata["is_pr"]` |
+| Linked issue | `metadata["linked_issue"]` |
+
+## Outbound
+
+Replies are posted as comments on the issue/PR via `POST /repos/{owner}/{repo}/issues/{number}/comments`.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `src/channels/github/config.rs` | Channel configuration |
+| `src/channels/github/types.rs` | GitHub API types |
+| `src/channels/github/client.rs` | HTTP client for GitHub REST API |
+| `src/channels/github/inbound.rs` | Polling, pattern matching, message routing |
+| `src/channels/github/outbound.rs` | Posting comments to issues/PRs |

--- a/src/channels/email/inbound.rs
+++ b/src/channels/email/inbound.rs
@@ -398,6 +398,7 @@ mod tests {
                 mentions: None,
                 keywords: None,
                 chat_name: None,
+                labels: None,
             },
             attachments: None,
             ..Default::default()

--- a/src/channels/feishu/inbound.rs
+++ b/src/channels/feishu/inbound.rs
@@ -469,6 +469,7 @@ mod tests {
                 mentions,
                 keywords,
                 chat_name: None,
+                labels: None,
             },
             attachments: None,
             ..Default::default()

--- a/src/channels/github/client.rs
+++ b/src/channels/github/client.rs
@@ -44,6 +44,10 @@ impl GitHubClient {
             reqwest::header::AUTHORIZATION,
             format!("Bearer {}", self.config.token).parse().unwrap(),
         );
+        headers.insert(
+            reqwest::header::USER_AGENT,
+            "jyc-bot".parse().unwrap(),
+        );
         headers
     }
 
@@ -56,6 +60,8 @@ impl GitHubClient {
             url = format!("{}?since={}", url, since);
         }
 
+        tracing::debug!(url = %url, "Fetching GitHub issue comments");
+
         let response = self
             .http_client
             .get(&url)
@@ -67,7 +73,7 @@ impl GitHubClient {
         if !response.status().is_success() {
             let status = response.status();
             let text = response.text().await.unwrap_or_default();
-            anyhow::bail!("GitHub API error: {} - {}", status, text);
+            anyhow::bail!("GitHub API error ({}): {} - URL: {}", status, text, url);
         }
 
         let comments: Vec<GitHubIssueComment> = response

--- a/src/channels/github/client.rs
+++ b/src/channels/github/client.rs
@@ -1,0 +1,207 @@
+//! GitHub API client for polling and sending messages.
+
+use anyhow::{Context, Result};
+use reqwest::Client;
+use std::time::Duration;
+
+use super::config::GitHubConfig;
+use super::types::{
+    CreateIssueCommentRequest, CreateIssueCommentResponse, GitHubIssue, GitHubIssueComment,
+};
+
+pub struct GitHubClient {
+    config: GitHubConfig,
+    http_client: Client,
+}
+
+impl GitHubClient {
+    pub fn new(config: GitHubConfig) -> Self {
+        let http_client = Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .expect("Failed to create HTTP client");
+
+        Self {
+            config,
+            http_client,
+        }
+    }
+
+    fn base_url(&self) -> String {
+        format!(
+            "https://api.github.com/repos/{}/{}",
+            self.config.owner, self.config.repo
+        )
+    }
+
+    fn headers(&self) -> reqwest::header::HeaderMap {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(
+            reqwest::header::ACCEPT,
+            "application/vnd.github.v3+json".parse().unwrap(),
+        );
+        headers.insert(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {}", self.config.token).parse().unwrap(),
+        );
+        headers
+    }
+
+    pub async fn get_issue_comments(
+        &self,
+        since: Option<&str>,
+    ) -> Result<Vec<GitHubIssueComment>> {
+        let mut url = format!("{}/issues/comments", self.base_url());
+        if let Some(since) = since {
+            url = format!("{}?since={}", url, since);
+        }
+
+        let response = self
+            .http_client
+            .get(&url)
+            .headers(self.headers())
+            .send()
+            .await
+            .context("Failed to fetch issue comments")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            anyhow::bail!("GitHub API error: {} - {}", status, text);
+        }
+
+        let comments: Vec<GitHubIssueComment> = response
+            .json()
+            .await
+            .context("Failed to parse issue comments")?;
+
+        Ok(comments)
+    }
+
+    pub async fn get_issues(&self, since: Option<&str>, state: Option<&str>) -> Result<Vec<GitHubIssue>> {
+        let mut url = format!("{}/issues", self.base_url());
+        let mut params = Vec::new();
+
+        if let Some(since) = since {
+            params.push(format!("since={}", since));
+        }
+        if let Some(state) = state {
+            params.push(format!("state={}", state));
+        } else {
+            params.push("state=all".to_string());
+        }
+
+        if !params.is_empty() {
+            url = format!("{}?{}", url, params.join("&"));
+        }
+
+        let response = self
+            .http_client
+            .get(&url)
+            .headers(self.headers())
+            .send()
+            .await
+            .context("Failed to fetch issues")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            anyhow::bail!("GitHub API error: {} - {}", status, text);
+        }
+
+        let issues: Vec<GitHubIssue> = response
+            .json()
+            .await
+            .context("Failed to parse issues")?;
+
+        Ok(issues)
+    }
+
+    pub async fn create_issue_comment(
+        &self,
+        issue_number: i64,
+        body: &str,
+    ) -> Result<CreateIssueCommentResponse> {
+        let url = format!("{}/issues/{}/comments", self.base_url(), issue_number);
+
+        let request = CreateIssueCommentRequest {
+            body: body.to_string(),
+        };
+
+        let response = self
+            .http_client
+            .post(&url)
+            .headers(self.headers())
+            .json(&request)
+            .send()
+            .await
+            .context("Failed to create issue comment")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            anyhow::bail!("GitHub API error: {} - {}", status, text);
+        }
+
+        let result: CreateIssueCommentResponse = response
+            .json()
+            .await
+            .context("Failed to parse create comment response")?;
+
+        Ok(result)
+    }
+
+    pub async fn get_rate_limit_status(&self) -> Result<GitHubRateLimitResponse> {
+        let url = "https://api.github.com/rate_limit".to_string();
+
+        let response = self
+            .http_client
+            .get(&url)
+            .headers(self.headers())
+            .send()
+            .await
+            .context("Failed to fetch rate limit status")?;
+
+        let result: GitHubRateLimitResponse = response
+            .json()
+            .await
+            .context("Failed to parse rate limit response")?;
+
+        Ok(result)
+    }
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct GitHubRateLimitResponse {
+    pub resources: RateLimitResources,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct RateLimitResources {
+    pub core: RateLimit,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct RateLimit {
+    pub limit: i64,
+    pub remaining: i64,
+    pub reset: i64,
+    pub used: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_client_creation() {
+        let config = GitHubConfig {
+            owner: "testorg".to_string(),
+            repo: "testrepo".to_string(),
+            token: "test_token".to_string(),
+            ..Default::default()
+        };
+        let client = GitHubClient::new(config);
+        assert_eq!(client.base_url(), "https://api.github.com/repos/testorg/testrepo");
+    }
+}

--- a/src/channels/github/client.rs
+++ b/src/channels/github/client.rs
@@ -60,7 +60,7 @@ impl GitHubClient {
             url = format!("{}?since={}", url, since);
         }
 
-        tracing::debug!(url = %url, "Fetching GitHub issue comments");
+        tracing::trace!(url = %url, "Fetching GitHub issue comments");
 
         let response = self
             .http_client

--- a/src/channels/github/config.rs
+++ b/src/channels/github/config.rs
@@ -1,0 +1,67 @@
+//! GitHub-specific configuration for a channel.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct GitHubConfig {
+    pub owner: String,
+    pub repo: String,
+    pub token: String,
+    #[serde(default = "default_poll_interval")]
+    pub poll_interval_secs: u64,
+    #[serde(default = "default_events")]
+    pub events: Vec<String>,
+    #[serde(default)]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+impl Default for GitHubConfig {
+    fn default() -> Self {
+        Self {
+            owner: String::new(),
+            repo: String::new(),
+            token: String::new(),
+            poll_interval_secs: default_poll_interval(),
+            events: default_events(),
+            metadata: HashMap::new(),
+        }
+    }
+}
+
+fn default_poll_interval() -> u64 {
+    30
+}
+
+fn default_events() -> Vec<String> {
+    vec!["issue_comment".to_string(), "issues".to_string()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = GitHubConfig::default();
+        assert_eq!(config.poll_interval_secs, 30);
+        assert!(config.events.contains(&"issue_comment".to_string()));
+        assert!(config.events.contains(&"issues".to_string()));
+    }
+
+    #[test]
+    fn test_config_deserialize() {
+        let toml_str = r#"
+            owner = "myorg"
+            repo = "myrepo"
+            token = "ghp_xxxxx"
+            poll_interval_secs = 60
+        "#;
+
+        let config: GitHubConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.owner, "myorg");
+        assert_eq!(config.repo, "myrepo");
+        assert_eq!(config.token, "ghp_xxxxx");
+        assert_eq!(config.poll_interval_secs, 60);
+    }
+}

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -1,0 +1,455 @@
+//! GitHub inbound adapter implementation.
+//!
+//! This module handles receiving messages from GitHub via polling.
+//! It provides channel-specific pattern matching and thread name derivation.
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use crate::channels::types::{
+    ChannelMatcher, ChannelPattern, InboundAdapterOptions, InboundMessage, MessageContent,
+    PatternMatch,
+};
+
+use super::client::GitHubClient;
+use super::config::GitHubConfig;
+
+pub struct GitHubInboundAdapter {
+    config: GitHubConfig,
+    channel_name: String,
+    workspace_root: std::path::PathBuf,
+    last_poll_timestamp: std::sync::Mutex<Option<String>>,
+}
+
+impl GitHubInboundAdapter {
+    pub fn new(config: &GitHubConfig, channel_name: String) -> Self {
+        let workspace_root = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+
+        Self {
+            config: config.clone(),
+            channel_name,
+            workspace_root,
+            last_poll_timestamp: std::sync::Mutex::new(None),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn new_with_workspace(
+        config: &GitHubConfig,
+        channel_name: String,
+        workspace_root: std::path::PathBuf,
+    ) -> Self {
+        Self {
+            config: config.clone(),
+            channel_name,
+            workspace_root,
+            last_poll_timestamp: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn get_last_poll_timestamp(&self) -> Option<String> {
+        self.last_poll_timestamp.lock().unwrap().clone()
+    }
+
+    fn set_last_poll_timestamp(&self, timestamp: &str) {
+        *self.last_poll_timestamp.lock().unwrap() = Some(timestamp.to_string());
+    }
+}
+
+impl ChannelMatcher for GitHubInboundAdapter {
+    fn channel_type(&self) -> &str {
+        "github"
+    }
+
+    fn derive_thread_name(
+        &self,
+        message: &InboundMessage,
+        _patterns: &[ChannelPattern],
+        _pattern_match: Option<&PatternMatch>,
+    ) -> String {
+        let issue_number = message.metadata.get("issue_number")
+            .and_then(|v| v.as_i64())
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| message.channel_uid.clone());
+        
+        format!("github-{}", issue_number)
+    }
+
+    fn match_message(
+        &self,
+        message: &InboundMessage,
+        patterns: &[ChannelPattern],
+    ) -> Option<PatternMatch> {
+        github_match_message(message, patterns)
+    }
+
+    fn store_unmatched_messages(&self) -> bool {
+        true
+    }
+}
+
+pub fn github_match_message(
+    message: &InboundMessage,
+    patterns: &[ChannelPattern],
+) -> Option<PatternMatch> {
+    for pattern in patterns {
+        if !pattern.enabled {
+            continue;
+        }
+
+        let mut matches = true;
+        let mut match_details = HashMap::new();
+
+        if let Some(ref labels) = pattern.rules.labels {
+            let msg_labels = message.metadata.get("labels")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_lowercase()))
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+
+            let label_matches = labels.iter().any(|l| msg_labels.contains(&l.to_lowercase()));
+
+            if !label_matches {
+                matches = false;
+            } else {
+                match_details.insert(
+                    "labels".to_string(),
+                    labels.join(","),
+                );
+            }
+        }
+
+        if matches {
+            if let Some(ref sender_rule) = pattern.rules.sender {
+                let addr = message.sender_address.to_lowercase();
+
+                let sender_matches = {
+                    let mut any_rule_present = false;
+                    let mut any_rule_matched = false;
+
+                    if let Some(ref exact_addrs) = sender_rule.exact {
+                        any_rule_present = true;
+                        if exact_addrs.iter().any(|e| e.to_lowercase() == addr) {
+                            any_rule_matched = true;
+                            match_details.insert("sender.exact".to_string(), addr.clone());
+                        }
+                    }
+
+                    if let Some(ref regex_str) = sender_rule.regex {
+                        any_rule_present = true;
+                        if let Ok(re) = regex::Regex::new(regex_str) {
+                            if re.is_match(&addr) {
+                                any_rule_matched = true;
+                                match_details.insert("sender.regex".to_string(), addr.clone());
+                            }
+                        }
+                    }
+
+                    !any_rule_present || any_rule_matched
+                };
+
+                if !sender_matches {
+                    matches = false;
+                }
+            }
+        }
+
+        if matches {
+            return Some(PatternMatch {
+                pattern_name: pattern.name.clone(),
+                channel: "github".to_string(),
+                matches: match_details,
+            });
+        }
+    }
+
+    None
+}
+
+#[async_trait]
+impl crate::channels::types::InboundAdapter for GitHubInboundAdapter {
+    async fn start(
+        &self,
+        options: InboundAdapterOptions,
+        cancel: CancellationToken,
+    ) -> Result<()> {
+        let client = Arc::new(GitHubClient::new(self.config.clone()));
+        let poll_interval = Duration::from_secs(self.config.poll_interval_secs);
+
+        loop {
+            if cancel.is_cancelled() {
+                break;
+            }
+
+            tracing::info!("Polling GitHub for new events...");
+
+            let since = self.get_last_poll_timestamp();
+            let now: DateTime<Utc> = Utc::now();
+
+            if let Err(e) = self.poll_events(&client, &since, &options).await {
+                tracing::error!(error = %e, "Error polling GitHub");
+            }
+
+            self.set_last_poll_timestamp(&now.to_rfc3339());
+
+            tokio::select! {
+                _ = cancel.cancelled() => break,
+                _ = tokio::time::sleep(poll_interval) => continue,
+            }
+        }
+
+        tracing::info!("GitHub inbound adapter stopped");
+        Ok(())
+    }
+}
+
+impl GitHubInboundAdapter {
+    async fn poll_events(
+        &self,
+        client: &GitHubClient,
+        since: &Option<String>,
+        options: &InboundAdapterOptions,
+    ) -> Result<()> {
+        if self.config.events.contains(&"issue_comment".to_string()) {
+            let comments = client.get_issue_comments(since.as_deref()).await
+                .context("Failed to fetch issue comments")?;
+
+            for comment in comments {
+                let mut metadata = HashMap::new();
+                metadata.insert("repo".to_string(), serde_json::Value::String(format!("{}/{}", self.config.owner, self.config.repo)));
+                metadata.insert("action".to_string(), serde_json::Value::String("created".to_string()));
+                metadata.insert("event_type".to_string(), serde_json::Value::String("issue_comment".to_string()));
+                metadata.insert("comment_id".to_string(), serde_json::Value::Number(comment.id.into()));
+
+                if let Some(issue_num) = comment.html_url.split("/issues/").nth(1) {
+                    if let Some(num) = issue_num.split('#').next() {
+                        if let Ok(n) = num.parse::<i64>() {
+                            metadata.insert("issue_number".to_string(), serde_json::Value::Number(n.into()));
+                        }
+                    }
+                }
+
+                let message = InboundMessage {
+                    id: Uuid::new_v4().to_string(),
+                    channel: "github".to_string(),
+                    channel_uid: comment.id.to_string(),
+                    sender: comment.user.login.clone(),
+                    sender_address: comment.user.id.to_string(),
+                    recipients: vec![],
+                    topic: "".to_string(),
+                    content: MessageContent {
+                        text: Some(comment.body.clone()),
+                        html: None,
+                        markdown: Some(comment.body.clone()),
+                    },
+                    timestamp: DateTime::parse_from_rfc3339(&comment.created_at)
+                        .map(|dt| dt.with_timezone(&Utc))
+                        .unwrap_or_else(|_| Utc::now()),
+                    thread_refs: None,
+                    reply_to_id: metadata.get("issue_number").and_then(|v| v.as_i64()).map(|n| n.to_string()),
+                    external_id: Some(comment.id.to_string()),
+                    attachments: vec![],
+                    metadata,
+                    matched_pattern: None,
+                };
+
+                (options.on_message)(message)?;
+            }
+        }
+
+        if self.config.events.contains(&"issues".to_string()) {
+            let issues = client.get_issues(since.as_deref(), None).await
+                .context("Failed to fetch issues")?;
+
+            for issue in issues {
+                if issue.pull_request.is_some() {
+                    continue;
+                }
+
+                let labels: Vec<String> = issue.labels.iter().map(|l| l.name.clone()).collect();
+                let labels_json: Vec<serde_json::Value> = labels.iter().map(|l| serde_json::Value::String(l.clone())).collect();
+
+                let mut metadata = HashMap::new();
+                metadata.insert("repo".to_string(), serde_json::Value::String(format!("{}/{}", self.config.owner, self.config.repo)));
+                metadata.insert("action".to_string(), serde_json::Value::String(issue.state.clone()));
+                metadata.insert("event_type".to_string(), serde_json::Value::String("issues".to_string()));
+                metadata.insert("issue_number".to_string(), serde_json::Value::Number(issue.number.into()));
+                metadata.insert("labels".to_string(), serde_json::Value::Array(labels_json));
+                metadata.insert("html_url".to_string(), serde_json::Value::String(issue.html_url.clone()));
+
+                let body = issue.body.unwrap_or_default();
+
+                let message = InboundMessage {
+                    id: Uuid::new_v4().to_string(),
+                    channel: "github".to_string(),
+                    channel_uid: issue.number.to_string(),
+                    sender: issue.user.login.clone(),
+                    sender_address: issue.user.id.to_string(),
+                    recipients: vec![],
+                    topic: issue.title.clone(),
+                    content: MessageContent {
+                        text: Some(body.clone()),
+                        html: None,
+                        markdown: Some(body.clone()),
+                    },
+                    timestamp: DateTime::parse_from_rfc3339(&issue.created_at)
+                        .map(|dt| dt.with_timezone(&Utc))
+                        .unwrap_or_else(|_| Utc::now()),
+                    thread_refs: None,
+                    reply_to_id: Some(issue.number.to_string()),
+                    external_id: Some(issue.id.to_string()),
+                    attachments: vec![],
+                    metadata,
+                    matched_pattern: None,
+                };
+
+                (options.on_message)(message)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::channels::types::{MessageContent, PatternRules, SenderRule};
+
+    fn make_github_message(
+        sender_addr: &str,
+        body: &str,
+        issue_number: i64,
+        labels: Vec<&str>,
+    ) -> InboundMessage {
+        let labels_json: Vec<serde_json::Value> = labels
+            .iter()
+            .map(|l| serde_json::Value::String(l.to_string()))
+            .collect();
+
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "issue_number".to_string(),
+            serde_json::Value::Number(issue_number.into()),
+        );
+        metadata.insert(
+            "labels".to_string(),
+            serde_json::Value::Array(labels_json),
+        );
+
+        InboundMessage {
+            id: "test".to_string(),
+            channel: "github".to_string(),
+            channel_uid: issue_number.to_string(),
+            sender: "testuser".to_string(),
+            sender_address: sender_addr.to_string(),
+            recipients: vec![],
+            topic: "Test Issue".to_string(),
+            content: MessageContent {
+                text: Some(body.to_string()),
+                html: None,
+                markdown: Some(body.to_string()),
+            },
+            timestamp: Utc::now(),
+            thread_refs: None,
+            reply_to_id: Some(issue_number.to_string()),
+            external_id: Some("123".to_string()),
+            attachments: vec![],
+            metadata,
+            matched_pattern: None,
+        }
+    }
+
+    fn make_github_pattern(
+        name: &str,
+        labels: Option<Vec<String>>,
+        sender: Option<SenderRule>,
+    ) -> ChannelPattern {
+        ChannelPattern {
+            name: name.to_string(),
+            channel: "github".to_string(),
+            enabled: true,
+            rules: PatternRules {
+                sender,
+                labels,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_match_by_labels() {
+        let msg = make_github_message("user1", "Hello", 42, vec!["bug", "urgent"]);
+        let patterns = vec![make_github_pattern(
+            "bug_triage",
+            Some(vec!["bug".to_string()]),
+            None,
+        )];
+
+        let result = github_match_message(&msg, &patterns);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().pattern_name, "bug_triage");
+    }
+
+    #[test]
+    fn test_no_match_wrong_labels() {
+        let msg = make_github_message("user1", "Hello", 42, vec!["enhancement"]);
+        let patterns = vec![make_github_pattern(
+            "bug_triage",
+            Some(vec!["bug".to_string()]),
+            None,
+        )];
+
+        assert!(github_match_message(&msg, &patterns).is_none());
+    }
+
+    #[test]
+    fn test_match_by_sender() {
+        let msg = make_github_message("12345", "Hello", 42, vec![]);
+        let patterns = vec![make_github_pattern(
+            "vip_user",
+            None,
+            Some(SenderRule {
+                exact: Some(vec!["12345".to_string()]),
+                ..Default::default()
+            }),
+        )];
+
+        assert!(github_match_message(&msg, &patterns).is_some());
+    }
+
+    #[test]
+    fn test_derive_thread_name() {
+        let msg = make_github_message("user1", "Hello", 42, vec![]);
+        let matcher = GitHubInboundAdapter::new(&GitHubConfig::default(), "test".to_string());
+        let name = matcher.derive_thread_name(&msg, &[], None);
+        assert_eq!(name, "github-42");
+    }
+
+    #[test]
+    fn test_disabled_pattern_skipped() {
+        let msg = make_github_message("user1", "Hello", 42, vec!["bug"]);
+        let mut pattern = make_github_pattern("bug_triage", Some(vec!["bug".to_string()]), None);
+        pattern.enabled = false;
+
+        assert!(github_match_message(&msg, &[pattern]).is_none());
+    }
+
+    #[test]
+    fn test_empty_rules_matches_all() {
+        let msg = make_github_message("user1", "Hello", 42, vec![]);
+        let patterns = vec![make_github_pattern("catch_all", None, None)];
+
+        assert!(github_match_message(&msg, &patterns).is_some());
+    }
+}

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -195,11 +195,17 @@ impl crate::channels::types::InboundAdapter for GitHubInboundAdapter {
             let since = self.get_last_poll_timestamp();
             let now: DateTime<Utc> = Utc::now();
 
-            if let Err(e) = self.poll_events(&client, &since, &options).await {
-                tracing::error!(error = %e, "Error polling GitHub");
+            match self.poll_events(&client, &since, &options).await {
+                Ok(()) => {
+                    // Only advance timestamp on successful poll
+                    // Use ISO 8601 format without nanoseconds (GitHub API requirement)
+                    self.set_last_poll_timestamp(&now.format("%Y-%m-%dT%H:%M:%SZ").to_string());
+                }
+                Err(e) => {
+                    // Don't advance timestamp on failure — retry same window next cycle
+                    tracing::error!(error = %e, "Error polling GitHub");
+                }
             }
-
-            self.set_last_poll_timestamp(&now.to_rfc3339());
 
             tokio::select! {
                 _ = cancel.cancelled() => break,
@@ -219,23 +225,45 @@ impl GitHubInboundAdapter {
         since: &Option<String>,
         options: &InboundAdapterOptions,
     ) -> Result<()> {
+        // Fetch open issues once (used for both issue processing and comment filtering)
+        let open_issues = client.get_issues(since.as_deref(), Some("open")).await
+            .context("Failed to fetch open issues")?;
+        let open_issue_numbers: std::collections::HashSet<i64> = open_issues.iter()
+            .filter(|i| i.pull_request.is_none())
+            .map(|i| i.number)
+            .collect();
+
         if self.config.events.contains(&"issue_comment".to_string()) {
             let comments = client.get_issue_comments(since.as_deref()).await
                 .context("Failed to fetch issue comments")?;
 
             for comment in comments {
+                // Extract issue number from comment URL
+                let issue_number = comment.html_url
+                    .split("/issues/")
+                    .nth(1)
+                    .and_then(|s| s.split('#').next())
+                    .and_then(|s| s.parse::<i64>().ok());
+
+                // Skip comments on closed issues or PRs
+                if let Some(num) = issue_number {
+                    if !open_issue_numbers.contains(&num) {
+                        tracing::trace!(comment_id = comment.id, issue = num, "Skipping comment on closed/PR issue");
+                        continue;
+                    }
+                } else {
+                    tracing::trace!(comment_id = comment.id, url = %comment.html_url, "Skipping comment: cannot extract issue number");
+                    continue;
+                }
+
                 let mut metadata = HashMap::new();
                 metadata.insert("repo".to_string(), serde_json::Value::String(format!("{}/{}", self.config.owner, self.config.repo)));
                 metadata.insert("action".to_string(), serde_json::Value::String("created".to_string()));
                 metadata.insert("event_type".to_string(), serde_json::Value::String("issue_comment".to_string()));
                 metadata.insert("comment_id".to_string(), serde_json::Value::Number(comment.id.into()));
 
-                if let Some(issue_num) = comment.html_url.split("/issues/").nth(1) {
-                    if let Some(num) = issue_num.split('#').next() {
-                        if let Ok(n) = num.parse::<i64>() {
-                            metadata.insert("issue_number".to_string(), serde_json::Value::Number(n.into()));
-                        }
-                    }
+                if let Some(num) = issue_number {
+                    metadata.insert("issue_number".to_string(), serde_json::Value::Number(num.into()));
                 }
 
                 let message = InboundMessage {
@@ -267,11 +295,13 @@ impl GitHubInboundAdapter {
         }
 
         if self.config.events.contains(&"issues".to_string()) {
-            let issues = client.get_issues(since.as_deref(), None).await
-                .context("Failed to fetch issues")?;
-
-            for issue in issues {
+            for issue in &open_issues {
                 if issue.pull_request.is_some() {
+                    continue;
+                }
+
+                if issue.state != "open" {
+                    tracing::debug!(issue = issue.number, state = %issue.state, "Skipping non-open issue");
                     continue;
                 }
 
@@ -286,7 +316,7 @@ impl GitHubInboundAdapter {
                 metadata.insert("labels".to_string(), serde_json::Value::Array(labels_json));
                 metadata.insert("html_url".to_string(), serde_json::Value::String(issue.html_url.clone()));
 
-                let body = issue.body.unwrap_or_default();
+                let body = issue.body.clone().unwrap_or_default();
 
                 let message = InboundMessage {
                     id: Uuid::new_v4().to_string(),

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -25,6 +25,10 @@ pub struct GitHubInboundAdapter {
     channel_name: String,
     workspace_root: std::path::PathBuf,
     last_poll_timestamp: std::sync::Mutex<Option<String>>,
+    /// Track processed issue IDs to avoid re-processing unchanged issues
+    processed_issue_ids: std::sync::Mutex<std::collections::HashSet<i64>>,
+    /// Track processed comment IDs to avoid duplicates
+    processed_comment_ids: std::sync::Mutex<std::collections::HashSet<i64>>,
 }
 
 impl GitHubInboundAdapter {
@@ -36,6 +40,8 @@ impl GitHubInboundAdapter {
             channel_name,
             workspace_root,
             last_poll_timestamp: std::sync::Mutex::new(None),
+            processed_issue_ids: std::sync::Mutex::new(std::collections::HashSet::new()),
+            processed_comment_ids: std::sync::Mutex::new(std::collections::HashSet::new()),
         }
     }
 
@@ -50,6 +56,8 @@ impl GitHubInboundAdapter {
             channel_name,
             workspace_root,
             last_poll_timestamp: std::sync::Mutex::new(None),
+            processed_issue_ids: std::sync::Mutex::new(std::collections::HashSet::new()),
+            processed_comment_ids: std::sync::Mutex::new(std::collections::HashSet::new()),
         }
     }
 
@@ -237,7 +245,22 @@ impl GitHubInboundAdapter {
             let comments = client.get_issue_comments(since.as_deref()).await
                 .context("Failed to fetch issue comments")?;
 
+            let mut processed_comments = self.processed_comment_ids.lock().unwrap();
+
             for comment in comments {
+                // Skip already processed comments
+                if processed_comments.contains(&comment.id) {
+                    continue;
+                }
+
+                // Skip bot's own comments (detect by checking if body contains our reply footer)
+                // Also skip if the comment user matches the GitHub app/bot user
+                if comment.user.login.ends_with("[bot]") || comment.body.contains("Model:") && comment.body.contains("Mode:") {
+                    tracing::trace!(comment_id = comment.id, user = %comment.user.login, "Skipping bot's own comment");
+                    processed_comments.insert(comment.id);
+                    continue;
+                }
+
                 // Extract issue number from comment URL
                 let issue_number = comment.html_url
                     .split("/issues/")
@@ -249,12 +272,17 @@ impl GitHubInboundAdapter {
                 if let Some(num) = issue_number {
                     if !open_issue_numbers.contains(&num) {
                         tracing::trace!(comment_id = comment.id, issue = num, "Skipping comment on closed/PR issue");
+                        processed_comments.insert(comment.id);
                         continue;
                     }
                 } else {
                     tracing::trace!(comment_id = comment.id, url = %comment.html_url, "Skipping comment: cannot extract issue number");
+                    processed_comments.insert(comment.id);
                     continue;
                 }
+
+                // Mark as processed
+                processed_comments.insert(comment.id);
 
                 let mut metadata = HashMap::new();
                 metadata.insert("repo".to_string(), serde_json::Value::String(format!("{}/{}", self.config.owner, self.config.repo)));
@@ -268,7 +296,7 @@ impl GitHubInboundAdapter {
 
                 let message = InboundMessage {
                     id: Uuid::new_v4().to_string(),
-                    channel: "github".to_string(),
+                    channel: self.channel_name.clone(),
                     channel_uid: comment.id.to_string(),
                     sender: comment.user.login.clone(),
                     sender_address: comment.user.id.to_string(),
@@ -295,15 +323,24 @@ impl GitHubInboundAdapter {
         }
 
         if self.config.events.contains(&"issues".to_string()) {
+            let mut processed_issues = self.processed_issue_ids.lock().unwrap();
+
             for issue in &open_issues {
                 if issue.pull_request.is_some() {
                     continue;
                 }
 
                 if issue.state != "open" {
-                    tracing::debug!(issue = issue.number, state = %issue.state, "Skipping non-open issue");
                     continue;
                 }
+
+                // Skip already-processed issues (avoid re-sending unchanged issues every poll)
+                if processed_issues.contains(&issue.id) {
+                    continue;
+                }
+
+                // Mark as processed
+                processed_issues.insert(issue.id);
 
                 let labels: Vec<String> = issue.labels.iter().map(|l| l.name.clone()).collect();
                 let labels_json: Vec<serde_json::Value> = labels.iter().map(|l| serde_json::Value::String(l.clone())).collect();
@@ -320,7 +357,7 @@ impl GitHubInboundAdapter {
 
                 let message = InboundMessage {
                     id: Uuid::new_v4().to_string(),
-                    channel: "github".to_string(),
+                    channel: self.channel_name.clone(),
                     channel_uid: issue.number.to_string(),
                     sender: issue.user.login.clone(),
                     sender_address: issue.user.id.to_string(),

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -190,7 +190,7 @@ impl crate::channels::types::InboundAdapter for GitHubInboundAdapter {
                 break;
             }
 
-            tracing::info!("Polling GitHub for new events...");
+            tracing::trace!("Polling GitHub for new events...");
 
             let since = self.get_last_poll_timestamp();
             let now: DateTime<Utc> = Utc::now();

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -233,157 +233,300 @@ impl GitHubInboundAdapter {
         since: &Option<String>,
         options: &InboundAdapterOptions,
     ) -> Result<()> {
-        // Fetch open issues once (used for both issue processing and comment filtering)
-        let open_issues = client.get_issues(since.as_deref(), Some("open")).await
+        // Fetch all open items (issues + PRs) from GitHub.
+        // GitHub's /issues API returns both issues and PRs.
+        let open_items = client.get_issues(since.as_deref(), Some("open")).await
             .context("Failed to fetch open issues")?;
-        let open_issue_numbers: std::collections::HashSet<i64> = open_issues.iter()
-            .filter(|i| i.pull_request.is_none())
-            .map(|i| i.number)
-            .collect();
 
-        if self.config.events.contains(&"issue_comment".to_string()) {
-            let comments = client.get_issue_comments(since.as_deref()).await
-                .context("Failed to fetch issue comments")?;
-
-            let mut processed_comments = self.processed_comment_ids.lock().unwrap();
-
-            for comment in comments {
-                // Skip already processed comments
-                if processed_comments.contains(&comment.id) {
-                    continue;
-                }
-
-                // Skip bot's own comments (detect by checking if body contains our reply footer)
-                // Also skip if the comment user matches the GitHub app/bot user
-                if comment.user.login.ends_with("[bot]") || comment.body.contains("Model:") && comment.body.contains("Mode:") {
-                    tracing::trace!(comment_id = comment.id, user = %comment.user.login, "Skipping bot's own comment");
-                    processed_comments.insert(comment.id);
-                    continue;
-                }
-
-                // Extract issue number from comment URL
-                let issue_number = comment.html_url
-                    .split("/issues/")
-                    .nth(1)
-                    .and_then(|s| s.split('#').next())
-                    .and_then(|s| s.parse::<i64>().ok());
-
-                // Skip comments on closed issues or PRs
-                if let Some(num) = issue_number {
-                    if !open_issue_numbers.contains(&num) {
-                        tracing::trace!(comment_id = comment.id, issue = num, "Skipping comment on closed/PR issue");
-                        processed_comments.insert(comment.id);
-                        continue;
-                    }
-                } else {
-                    tracing::trace!(comment_id = comment.id, url = %comment.html_url, "Skipping comment: cannot extract issue number");
-                    processed_comments.insert(comment.id);
-                    continue;
-                }
-
-                // Mark as processed
-                processed_comments.insert(comment.id);
-
-                let mut metadata = HashMap::new();
-                metadata.insert("repo".to_string(), serde_json::Value::String(format!("{}/{}", self.config.owner, self.config.repo)));
-                metadata.insert("action".to_string(), serde_json::Value::String("created".to_string()));
-                metadata.insert("event_type".to_string(), serde_json::Value::String("issue_comment".to_string()));
-                metadata.insert("comment_id".to_string(), serde_json::Value::Number(comment.id.into()));
-
-                if let Some(num) = issue_number {
-                    metadata.insert("issue_number".to_string(), serde_json::Value::Number(num.into()));
-                }
-
-                let message = InboundMessage {
-                    id: Uuid::new_v4().to_string(),
-                    channel: self.channel_name.clone(),
-                    channel_uid: comment.id.to_string(),
-                    sender: comment.user.login.clone(),
-                    sender_address: comment.user.id.to_string(),
-                    recipients: vec![],
-                    topic: "".to_string(),
-                    content: MessageContent {
-                        text: Some(comment.body.clone()),
-                        html: None,
-                        markdown: Some(comment.body.clone()),
-                    },
-                    timestamp: DateTime::parse_from_rfc3339(&comment.created_at)
-                        .map(|dt| dt.with_timezone(&Utc))
-                        .unwrap_or_else(|_| Utc::now()),
-                    thread_refs: None,
-                    reply_to_id: metadata.get("issue_number").and_then(|v| v.as_i64()).map(|n| n.to_string()),
-                    external_id: Some(comment.id.to_string()),
-                    attachments: vec![],
-                    metadata,
-                    matched_pattern: None,
-                };
-
-                (options.on_message)(message)?;
+        // Classify open items into issues and PRs, build lookup sets
+        let mut open_issue_numbers = std::collections::HashSet::new();
+        let mut open_pr_numbers = std::collections::HashSet::new();
+        for item in &open_items {
+            if item.pull_request.is_some() {
+                open_pr_numbers.insert(item.number);
+            } else {
+                open_issue_numbers.insert(item.number);
             }
         }
 
+        // All open item numbers (for comment filtering — both issues and PRs)
+        let all_open_numbers: std::collections::HashSet<i64> = open_issue_numbers
+            .union(&open_pr_numbers)
+            .cloned()
+            .collect();
+
+        // Process comments on open issues and PRs
+        if self.config.events.contains(&"issue_comment".to_string()) {
+            self.process_comments(client, since, &all_open_numbers, options).await?;
+        }
+
+        // Process new issues
         if self.config.events.contains(&"issues".to_string()) {
-            let mut processed_issues = self.processed_issue_ids.lock().unwrap();
+            self.process_issues(&open_items, options)?;
+        }
 
-            for issue in &open_issues {
-                if issue.pull_request.is_some() {
-                    continue;
-                }
-
-                if issue.state != "open" {
-                    continue;
-                }
-
-                // Skip already-processed issues (avoid re-sending unchanged issues every poll)
-                if processed_issues.contains(&issue.id) {
-                    continue;
-                }
-
-                // Mark as processed
-                processed_issues.insert(issue.id);
-
-                let labels: Vec<String> = issue.labels.iter().map(|l| l.name.clone()).collect();
-                let labels_json: Vec<serde_json::Value> = labels.iter().map(|l| serde_json::Value::String(l.clone())).collect();
-
-                let mut metadata = HashMap::new();
-                metadata.insert("repo".to_string(), serde_json::Value::String(format!("{}/{}", self.config.owner, self.config.repo)));
-                metadata.insert("action".to_string(), serde_json::Value::String(issue.state.clone()));
-                metadata.insert("event_type".to_string(), serde_json::Value::String("issues".to_string()));
-                metadata.insert("issue_number".to_string(), serde_json::Value::Number(issue.number.into()));
-                metadata.insert("labels".to_string(), serde_json::Value::Array(labels_json));
-                metadata.insert("html_url".to_string(), serde_json::Value::String(issue.html_url.clone()));
-
-                let body = issue.body.clone().unwrap_or_default();
-
-                let message = InboundMessage {
-                    id: Uuid::new_v4().to_string(),
-                    channel: self.channel_name.clone(),
-                    channel_uid: issue.number.to_string(),
-                    sender: issue.user.login.clone(),
-                    sender_address: issue.user.id.to_string(),
-                    recipients: vec![],
-                    topic: issue.title.clone(),
-                    content: MessageContent {
-                        text: Some(body.clone()),
-                        html: None,
-                        markdown: Some(body.clone()),
-                    },
-                    timestamp: DateTime::parse_from_rfc3339(&issue.created_at)
-                        .map(|dt| dt.with_timezone(&Utc))
-                        .unwrap_or_else(|_| Utc::now()),
-                    thread_refs: None,
-                    reply_to_id: Some(issue.number.to_string()),
-                    external_id: Some(issue.id.to_string()),
-                    attachments: vec![],
-                    metadata,
-                    matched_pattern: None,
-                };
-
-                (options.on_message)(message)?;
-            }
+        // Process new PRs (routed to linked issue thread or own PR thread)
+        if self.config.events.contains(&"pull_request".to_string()) {
+            self.process_pull_requests(&open_items, options)?;
         }
 
         Ok(())
+    }
+
+    /// Process new comments on open issues and PRs.
+    ///
+    /// Comments are routed to the thread of the issue/PR they belong to.
+    /// Bot's own comments are skipped to prevent feedback loops.
+    async fn process_comments(
+        &self,
+        client: &GitHubClient,
+        since: &Option<String>,
+        open_numbers: &std::collections::HashSet<i64>,
+        options: &InboundAdapterOptions,
+    ) -> Result<()> {
+        let comments = client.get_issue_comments(since.as_deref()).await
+            .context("Failed to fetch issue comments")?;
+
+        let mut processed = self.processed_comment_ids.lock().unwrap();
+
+        for comment in comments {
+            if processed.contains(&comment.id) {
+                continue;
+            }
+
+            // Skip bot's own comments to prevent feedback loops
+            if self.is_bot_comment(&comment) {
+                tracing::trace!(comment_id = comment.id, user = %comment.user.login, "Skipping bot comment");
+                processed.insert(comment.id);
+                continue;
+            }
+
+            // Extract issue/PR number from comment URL
+            let item_number = Self::extract_item_number_from_url(&comment.html_url);
+
+            // Skip comments on closed items
+            if let Some(num) = item_number {
+                if !open_numbers.contains(&num) {
+                    tracing::trace!(comment_id = comment.id, item = num, "Skipping comment on closed item");
+                    processed.insert(comment.id);
+                    continue;
+                }
+            } else {
+                tracing::trace!(comment_id = comment.id, url = %comment.html_url, "Skipping comment: cannot extract item number");
+                processed.insert(comment.id);
+                continue;
+            }
+
+            processed.insert(comment.id);
+
+            let issue_number = item_number.unwrap();
+            let mut metadata = HashMap::new();
+            metadata.insert("repo".to_string(), serde_json::json!(format!("{}/{}", self.config.owner, self.config.repo)));
+            metadata.insert("action".to_string(), serde_json::json!("created"));
+            metadata.insert("event_type".to_string(), serde_json::json!("issue_comment"));
+            metadata.insert("comment_id".to_string(), serde_json::json!(comment.id));
+            metadata.insert("issue_number".to_string(), serde_json::json!(issue_number));
+
+            let message = InboundMessage {
+                id: Uuid::new_v4().to_string(),
+                channel: self.channel_name.clone(),
+                channel_uid: comment.id.to_string(),
+                sender: comment.user.login.clone(),
+                sender_address: comment.user.id.to_string(),
+                recipients: vec![],
+                topic: "".to_string(),
+                content: MessageContent {
+                    text: Some(comment.body.clone()),
+                    html: None,
+                    markdown: Some(comment.body.clone()),
+                },
+                timestamp: DateTime::parse_from_rfc3339(&comment.created_at)
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .unwrap_or_else(|_| Utc::now()),
+                thread_refs: None,
+                reply_to_id: Some(issue_number.to_string()),
+                external_id: Some(comment.id.to_string()),
+                attachments: vec![],
+                metadata,
+                matched_pattern: None,
+            };
+
+            (options.on_message)(message)?;
+        }
+
+        Ok(())
+    }
+
+    /// Process new issues (not PRs).
+    ///
+    /// Only open issues that haven't been processed before are sent.
+    fn process_issues(
+        &self,
+        open_items: &[super::types::GitHubIssue],
+        options: &InboundAdapterOptions,
+    ) -> Result<()> {
+        let mut processed = self.processed_issue_ids.lock().unwrap();
+
+        for issue in open_items {
+            // Skip PRs — handled by process_pull_requests
+            if issue.pull_request.is_some() {
+                continue;
+            }
+
+            if issue.state != "open" {
+                continue;
+            }
+
+            if processed.contains(&issue.id) {
+                continue;
+            }
+
+            processed.insert(issue.id);
+
+            let message = self.build_issue_message(issue, "issues");
+            (options.on_message)(message)?;
+        }
+
+        Ok(())
+    }
+
+    /// Process new PRs.
+    ///
+    /// PRs are treated similarly to issues. If a PR body references an issue
+    /// (e.g., "Fixes #42"), it could be linked to the issue's thread.
+    /// Otherwise, it gets its own thread (github-<pr_number>).
+    fn process_pull_requests(
+        &self,
+        open_items: &[super::types::GitHubIssue],
+        options: &InboundAdapterOptions,
+    ) -> Result<()> {
+        let mut processed = self.processed_issue_ids.lock().unwrap();
+
+        for item in open_items {
+            // Only PRs
+            if item.pull_request.is_none() {
+                continue;
+            }
+
+            if item.state != "open" {
+                continue;
+            }
+
+            if processed.contains(&item.id) {
+                continue;
+            }
+
+            processed.insert(item.id);
+
+            // Check if PR body references an issue (Fixes #N, Closes #N, etc.)
+            let linked_issue = item.body.as_deref()
+                .and_then(Self::extract_linked_issue_number);
+
+            let mut message = self.build_issue_message(item, "pull_request");
+
+            // If linked to an issue, route to that issue's thread
+            if let Some(issue_num) = linked_issue {
+                message.metadata.insert("linked_issue".to_string(), serde_json::json!(issue_num));
+                message.metadata.insert("issue_number".to_string(), serde_json::json!(issue_num));
+                tracing::debug!(
+                    pr = item.number,
+                    linked_issue = issue_num,
+                    "PR linked to issue, routing to issue thread"
+                );
+            }
+
+            (options.on_message)(message)?;
+        }
+
+        Ok(())
+    }
+
+    /// Build an InboundMessage from a GitHub issue/PR.
+    fn build_issue_message(&self, issue: &super::types::GitHubIssue, event_type: &str) -> InboundMessage {
+        let labels: Vec<String> = issue.labels.iter().map(|l| l.name.clone()).collect();
+        let labels_json: Vec<serde_json::Value> = labels.iter().map(|l| serde_json::json!(l)).collect();
+
+        let mut metadata = HashMap::new();
+        metadata.insert("repo".to_string(), serde_json::json!(format!("{}/{}", self.config.owner, self.config.repo)));
+        metadata.insert("action".to_string(), serde_json::json!(issue.state.clone()));
+        metadata.insert("event_type".to_string(), serde_json::json!(event_type));
+        metadata.insert("issue_number".to_string(), serde_json::json!(issue.number));
+        metadata.insert("labels".to_string(), serde_json::Value::Array(labels_json));
+        metadata.insert("html_url".to_string(), serde_json::json!(issue.html_url.clone()));
+
+        if issue.pull_request.is_some() {
+            metadata.insert("is_pr".to_string(), serde_json::json!(true));
+        }
+
+        let body = issue.body.clone().unwrap_or_default();
+
+        InboundMessage {
+            id: Uuid::new_v4().to_string(),
+            channel: self.channel_name.clone(),
+            channel_uid: issue.number.to_string(),
+            sender: issue.user.login.clone(),
+            sender_address: issue.user.id.to_string(),
+            recipients: vec![],
+            topic: issue.title.clone(),
+            content: MessageContent {
+                text: Some(body.clone()),
+                html: None,
+                markdown: Some(body),
+            },
+            timestamp: DateTime::parse_from_rfc3339(&issue.created_at)
+                .map(|dt| dt.with_timezone(&Utc))
+                .unwrap_or_else(|_| Utc::now()),
+            thread_refs: None,
+            reply_to_id: Some(issue.number.to_string()),
+            external_id: Some(issue.id.to_string()),
+            attachments: vec![],
+            metadata,
+            matched_pattern: None,
+        }
+    }
+
+    /// Check if a comment was posted by the bot itself.
+    fn is_bot_comment(&self, comment: &super::types::GitHubIssueComment) -> bool {
+        // Check for [bot] suffix (GitHub App bots)
+        if comment.user.login.ends_with("[bot]") {
+            return true;
+        }
+        // Check for reply footer pattern (jyc's reply footer)
+        if comment.body.contains("Model:") && comment.body.contains("Mode:") {
+            return true;
+        }
+        false
+    }
+
+    /// Extract issue/PR number from a GitHub URL.
+    /// Handles both /issues/N and /pull/N URLs.
+    fn extract_item_number_from_url(url: &str) -> Option<i64> {
+        // Try /issues/N#issuecomment-...
+        if let Some(num_str) = url.split("/issues/").nth(1) {
+            if let Some(num) = num_str.split('#').next() {
+                if let Ok(n) = num.parse::<i64>() {
+                    return Some(n);
+                }
+            }
+        }
+        // Try /pull/N#...
+        if let Some(num_str) = url.split("/pull/").nth(1) {
+            if let Some(num) = num_str.split('#').next() {
+                if let Ok(n) = num.parse::<i64>() {
+                    return Some(n);
+                }
+            }
+        }
+        None
+    }
+
+    /// Extract linked issue number from PR body.
+    /// Looks for patterns like "Fixes #42", "Closes #42", "Resolves #42".
+    fn extract_linked_issue_number(body: &str) -> Option<i64> {
+        let re = regex::Regex::new(r"(?i)(?:fix(?:es)?|close[sd]?|resolve[sd]?)\s+#(\d+)").ok()?;
+        re.captures(body)
+            .and_then(|caps| caps.get(1))
+            .and_then(|m| m.as_str().parse::<i64>().ok())
     }
 }
 

--- a/src/channels/github/mod.rs
+++ b/src/channels/github/mod.rs
@@ -1,0 +1,9 @@
+//! GitHub channel implementation for JYC.
+//!
+//! This module provides inbound and outbound adapters for GitHub Issues.
+
+pub mod config;
+pub mod types;
+pub mod client;
+pub mod inbound;
+pub mod outbound;

--- a/src/channels/github/outbound.rs
+++ b/src/channels/github/outbound.rs
@@ -1,0 +1,177 @@
+//! GitHub outbound adapter implementation.
+//!
+//! This module handles sending messages to GitHub via HTTP API.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+
+use crate::channels::github::client::GitHubClient;
+use crate::channels::github::config::GitHubConfig;
+use crate::channels::types::{InboundMessage, OutboundAttachment, SendResult};
+use crate::config::types::OutboundAttachmentConfig;
+use crate::core::email_parser;
+use crate::core::message_storage::MessageStorage;
+use crate::utils::attachment_validator;
+
+pub struct GitHubOutboundAdapter {
+    client: GitHubClient,
+    storage: Arc<MessageStorage>,
+    attachment_config: Option<OutboundAttachmentConfig>,
+}
+
+impl GitHubOutboundAdapter {
+    #[allow(dead_code)]
+    pub fn new(config: GitHubConfig, storage: Arc<MessageStorage>) -> Self {
+        Self::new_with_attachments(config, storage, None)
+    }
+
+    pub fn new_with_attachments(
+        config: GitHubConfig,
+        storage: Arc<MessageStorage>,
+        attachment_config: Option<OutboundAttachmentConfig>,
+    ) -> Self {
+        Self {
+            client: GitHubClient::new(config),
+            storage,
+            attachment_config,
+        }
+    }
+}
+
+#[async_trait]
+impl crate::channels::types::OutboundAdapter for GitHubOutboundAdapter {
+    fn channel_type(&self) -> &str {
+        "github"
+    }
+
+    async fn connect(&self) -> Result<()> {
+        tracing::info!("GitHub outbound adapter connected");
+        Ok(())
+    }
+
+    async fn disconnect(&self) -> Result<()> {
+        tracing::info!("GitHub outbound adapter disconnected");
+        Ok(())
+    }
+
+    fn clean_body(&self, raw_body: &str) -> String {
+        raw_body.trim().to_string()
+    }
+
+    async fn send_reply(
+        &self,
+        original: &InboundMessage,
+        reply_text: &str,
+        thread_path: &Path,
+        message_dir: &str,
+        attachments: Option<&[OutboundAttachment]>,
+    ) -> Result<SendResult> {
+        let reply_ctx = crate::mcp::context::load_reply_context(thread_path).await.ok();
+        let model = reply_ctx.as_ref().and_then(|c| c.model.as_deref());
+        let mode = reply_ctx.as_ref().and_then(|c| c.mode.as_deref());
+
+        let (input_tokens, max_tokens) = crate::services::opencode::session::read_input_tokens(thread_path).await;
+
+        let footer = email_parser::build_footer(model, mode, input_tokens, max_tokens);
+
+        let clean_reply = email_parser::strip_trailing_separators(reply_text);
+
+        let full_reply = if footer.is_empty() {
+            clean_reply
+        } else {
+            format!("{}\n\n{}", clean_reply, footer)
+        };
+
+        if let Some(attachments) = attachments {
+            if let Some(ref config) = self.attachment_config {
+                attachment_validator::validate_outbound_attachments(attachments, config)
+                    .await
+                    .context("Failed to validate outbound attachments")?;
+                tracing::debug!("Outbound attachments validated successfully for GitHub");
+            }
+        }
+
+        let issue_number = original.channel_uid.parse::<i64>()
+            .context("Failed to parse issue number from channel_uid")?;
+
+        let result = self.client.create_issue_comment(issue_number, &full_reply).await
+            .context("Failed to create GitHub issue comment")?;
+
+        tracing::info!(
+            issue_number = %issue_number,
+            comment_id = result.id,
+            "GitHub issue comment created"
+        );
+
+        self.storage
+            .store_reply(thread_path, &full_reply, message_dir)
+            .await?;
+
+        tracing::debug!(
+            message_dir = %message_dir,
+            "Reply stored"
+        );
+
+        Ok(SendResult {
+            message_id: result.id.to_string(),
+        })
+    }
+
+    async fn send_alert(
+        &self,
+        recipient: &str,
+        subject: &str,
+        body: &str,
+    ) -> Result<SendResult> {
+        let issue_number = recipient.parse::<i64>()
+            .context("Failed to parse issue number from recipient")?;
+
+        let alert_text = format!("**{}**\n\n{}", subject, body);
+
+        let result = self.client.create_issue_comment(issue_number, &alert_text).await
+            .context("Failed to create GitHub issue comment for alert")?;
+
+        tracing::info!("GitHub alert sent to issue #{}: {}", issue_number, subject);
+
+        Ok(SendResult {
+            message_id: result.id.to_string(),
+        })
+    }
+
+    async fn send_heartbeat(
+        &self,
+        original: &InboundMessage,
+        message: &str,
+    ) -> Result<SendResult> {
+        let issue_number = original.channel_uid.parse::<i64>()
+            .context("Failed to parse issue number from channel_uid")?;
+
+        let result = self.client.create_issue_comment(issue_number, message).await
+            .context("Failed to create GitHub issue comment for heartbeat")?;
+
+        tracing::debug!("GitHub heartbeat sent to issue #{}", issue_number);
+
+        Ok(SendResult {
+            message_id: result.id.to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::channels::types::OutboundAdapter;
+
+    #[test]
+    fn test_clean_body() {
+        let adapter = GitHubOutboundAdapter::new_with_attachments(
+            GitHubConfig::default(),
+            Arc::new(MessageStorage::new(&std::path::PathBuf::new())),
+            None,
+        );
+        assert_eq!(adapter.clean_body("  hello  "), "hello");
+    }
+}

--- a/src/channels/github/types.rs
+++ b/src/channels/github/types.rs
@@ -1,0 +1,125 @@
+//! GitHub-specific types for API responses and conversions.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub struct GitHubIssueComment {
+    pub id: i64,
+    pub body: String,
+    pub user: GitHubUser,
+    pub created_at: String,
+    pub updated_at: String,
+    pub html_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub struct GitHubIssue {
+    pub id: i64,
+    pub number: i64,
+    pub title: String,
+    pub body: Option<String>,
+    pub user: GitHubUser,
+    pub state: String,
+    pub labels: Vec<GitHubLabel>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub html_url: String,
+    #[serde(default)]
+    pub pull_request: Option<GitHubPullRequest>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub struct GitHubPullRequest {
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub struct GitHubUser {
+    pub login: String,
+    pub id: i64,
+    pub html_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub struct GitHubLabel {
+    pub name: String,
+    pub color: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(dead_code)]
+pub struct GitHubRepository {
+    pub id: i64,
+    pub name: String,
+    pub full_name: String,
+    pub owner: GitHubUser,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GitHubEvent {
+    pub action: String,
+    pub issue: Option<GitHubIssue>,
+    pub comment: Option<GitHubIssueComment>,
+    pub repository: Option<GitHubRepository>,
+    pub sender: Option<GitHubUser>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateIssueCommentRequest {
+    pub body: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateIssueCommentResponse {
+    pub id: i64,
+    pub html_url: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_issue_comment_deserialize() {
+        let json = r#"{
+            "id": 123,
+            "body": "Test comment",
+            "user": {"login": "testuser", "id": 456, "html_url": "https://github.com/testuser"},
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z",
+            "html_url": "https://github.com/test/repo/issues/1#comment_123"
+        }"#;
+
+        let comment: GitHubIssueComment = serde_json::from_str(json).unwrap();
+        assert_eq!(comment.id, 123);
+        assert_eq!(comment.body, "Test comment");
+        assert_eq!(comment.user.login, "testuser");
+    }
+
+    #[test]
+    fn test_issue_deserialize() {
+        let json = r#"{
+            "id": 1,
+            "number": 42,
+            "title": "Test Issue",
+            "body": "Issue body",
+            "user": {"login": "testuser", "id": 456, "html_url": "https://github.com/testuser"},
+            "state": "open",
+            "labels": [{"name": "bug", "color": "ff0000"}],
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z",
+            "html_url": "https://github.com/test/repo/issues/42"
+        }"#;
+
+        let issue: GitHubIssue = serde_json::from_str(json).unwrap();
+        assert_eq!(issue.number, 42);
+        assert_eq!(issue.title, "Test Issue");
+        assert_eq!(issue.labels.len(), 1);
+        assert_eq!(issue.labels[0].name, "bug");
+    }
+}

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -3,3 +3,4 @@ pub mod types;
 pub mod registry;
 pub mod email;
 pub mod feishu;
+pub mod github;

--- a/src/channels/types.rs
+++ b/src/channels/types.rs
@@ -298,6 +298,10 @@ pub struct PatternRules {
     /// Feishu group chat names to match (OR logic, case-insensitive)
     /// Matches against the chat name from the Feishu API (metadata["chat_name"])
     pub chat_name: Option<Vec<String>>,
+
+    // --- GitHub rules ---
+    /// GitHub issue labels to match (OR logic, case-insensitive)
+    pub labels: Option<Vec<String>>,
 }
 
 /// Rules for matching the sender of a message.

--- a/src/cli/monitor.rs
+++ b/src/cli/monitor.rs
@@ -13,6 +13,8 @@ use crate::services::static_agent::StaticAgentService;
 use crate::channels::email::outbound::EmailOutboundAdapter;
 use crate::channels::feishu::inbound::{FeishuInboundAdapter, FeishuMatcher};
 use crate::channels::feishu::outbound::FeishuOutboundAdapter;
+use crate::channels::github::inbound::GitHubInboundAdapter;
+use crate::channels::github::outbound::GitHubOutboundAdapter;
 use crate::channels::types::OutboundAdapter;
 use crate::config::types::MonitorConfig;
 use crate::config::{load_config, validation};
@@ -120,6 +122,20 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     .clone();
                 Arc::new(FeishuOutboundAdapter::new_with_attachments(
                     feishu_config,
+                    storage.clone(),
+                    outbound_attachment_config,
+                ))
+            }
+            "github" => {
+                let github_config = channel_config
+                    .github
+                    .as_ref()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("channel '{channel_name}': missing github config")
+                    })?
+                    .clone();
+                Arc::new(GitHubOutboundAdapter::new_with_attachments(
+                    github_config,
                     storage.clone(),
                     outbound_attachment_config,
                 ))
@@ -360,6 +376,56 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                         tracing::error!(
                             error = %e,
                             "Feishu inbound adapter error"
+                        );
+                    }
+
+                    // Shutdown thread manager for this channel
+                    tm.shutdown().await;
+                }.instrument(channel_span));
+
+                tasks.push(task);
+            }
+            "github" => {
+                let github_config = channel_config
+                    .github
+                    .as_ref()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("channel '{channel_name}': missing github config")
+                    })?
+                    .clone();
+
+                let patterns_for_callback = patterns.clone();
+                let router_for_callback = router.clone();
+
+                let task = tokio::spawn(async move {
+                    let github_config_cloned = github_config.clone();
+                    
+                    let adapter = GitHubInboundAdapter::new(&github_config_cloned, channel_name_owned.clone());
+
+                    use crate::channels::types::InboundAdapter;
+                    
+                    let options = crate::channels::types::InboundAdapterOptions {
+                        on_message: Box::new(move |message| {
+                            let router = router_for_callback.clone();
+                            let patterns = patterns_for_callback.clone();
+                            let github_config_for_route = github_config_cloned.clone();
+                            let channel_name_for_route = channel_name_owned.clone();
+                            
+                            tokio::spawn(async move {
+                                router.route(&GitHubInboundAdapter::new(&github_config_for_route, channel_name_for_route), message, &patterns).await;
+                            });
+                            Ok(())
+                        }),
+                        on_error: Box::new(|error| {
+                            tracing::error!(error = %error, "GitHub inbound error");
+                        }),
+                        attachment_config: inbound_attachment_config.clone(),
+                    };
+
+                    if let Err(e) = adapter.start(options, cancel_child).await {
+                        tracing::error!(
+                            error = %e,
+                            "GitHub inbound adapter error"
                         );
                     }
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -69,6 +69,9 @@ pub struct ChannelConfig {
     /// Feishu configuration (for feishu channels)
     pub feishu: Option<crate::channels::feishu::config::FeishuConfig>,
 
+    /// GitHub configuration (for GitHub channels)
+    pub github: Option<crate::channels::github::config::GitHubConfig>,
+
     /// Monitoring settings (IDLE vs poll, interval, etc.)
     pub monitor: Option<MonitorConfig>,
 


### PR DESCRIPTION
## Summary
- Add GitHub Issue channel implementation with polling for issue comments and issues
- Implement GitHubConfig, GitHubClient, GitHubInboundAdapter, GitHubOutboundAdapter
- Add labels pattern matching support for GitHub issues
- Register GitHub channel in monitor.rs

## Implementation

### Design
This PR implements the GitHub Issue channel as specified in `GITHUB_ISSUE_CHANNEL_PLAN.md`:

**Architecture:**
- **Polling Mode**: Uses GitHub REST API with configurable `poll_interval_secs` (default: 30s)
- **Events Supported**: 
  - `issue_comment`: Issue comments (new comments trigger inbound messages)
  - `issues`: Issue open/close events
- **Thread Naming**: `github-{issue_number}` (e.g., `github-42`)

### Configuration
```toml
[channels.my_repo]
type = "github"

[channels.my_repo.github]
owner = "myorg"
repo = "myrepo"
token = "${GITHUB_TOKEN}"
poll_interval_secs = 30
events = ["issue_comment", "issues"]

[[channels.my_repo.patterns]]
name = "urgent"
enabled = true

[channels.my_repo.patterns.rules]
labels = ["urgent", "bug"]
```

### Data Model Mapping
| GitHub Event | InboundMessage Field |
|--------------|---------------------|
| Issue body | `content.markdown` |
| Issue title | `topic` |
| Issue number | `channel_uid` |
| Commenter login | `sender` |
| Commenter ID | `sender_address` |
| Issue number | `reply_to_id` |
| Repository full_name | `metadata["repo"]` |
| Issue labels | `metadata["labels"]` |
| Event action | `metadata["action"]` |

## Changes
- New module `src/channels/github/`:
  - `config.rs` - GitHubConfig structure
  - `types.rs` - GitHub API types (GitHubIssue, GitHubIssueComment, etc.)
  - `client.rs` - GitHub API client with reqwest
  - `inbound.rs` - InboundAdapter with polling and pattern matching
  - `outbound.rs` - OutboundAdapter for posting comments
  - `mod.rs` - Module exports
- Updated `src/config/types.rs` - Added GitHubConfig support
- Updated `src/channels/types.rs` - Added `labels` field to PatternRules
- Updated `src/cli/monitor.rs` - Registered GitHub channel

## Testing
- All 204 tests pass
- Build succeeds with no errors