### PR TITLE
feat: improve development and review workflow in template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to JYC will be documented in this file.
 
 ### Added
 
+**Developer-Reviewer Handoff** — Improved workflow for requesting changes
+- Reviewer template now explicitly triggers `@jyc:developer` when submitting review with request-changes
+- Ensures developer is notified when feedback needs to be addressed
+
 **Bare Metal Deployment** — Deploy jyc on Ubuntu/Debian servers without Docker
 - `deploy-bare-metal.sh` script for automated deployment
 - `dotfiles/zsh/` - zsh configuration and environment template

--- a/templates/github-reviewer/AGENTS.md
+++ b/templates/github-reviewer/AGENTS.md
@@ -92,4 +92,4 @@ EOF
 - Do NOT merge the PR — that's the user's decision
 - Be constructive and objective in feedback
 - Do NOT use the `jyc_question_ask_user` tool
-- When requesting changes, ALWAYS use `@jyc:developer` to trigger the developer
+- When requesting changes, ALWAYS post a comment with `@jyc:developer` to trigger the developer

--- a/templates/github-reviewer/AGENTS.md
+++ b/templates/github-reviewer/AGENTS.md
@@ -65,6 +65,7 @@ gh pr review <number> --request-changes --body "$(cat <<'EOF'
 Please address the issues above.
 EOF
 )"
+gh pr comment <number> --body "@jyc:developer Please address the review feedback."
 ```
 
 If approved:
@@ -91,3 +92,4 @@ EOF
 - Do NOT merge the PR — that's the user's decision
 - Be constructive and objective in feedback
 - Do NOT use the `jyc_question_ask_user` tool
+- When requesting changes, ALWAYS use `@jyc:developer` to trigger the developer


### PR DESCRIPTION
## Spec

Improve the development and review workflow to ensure proper handoff between reviewer and developer agents.

**Problem:**
1. When reviewer requests changes, there's no explicit trigger to notify the developer
2. This creates a gap where the developer may not know there's feedback to address

**Solution:**
Update the reviewer template to explicitly trigger the developer when requesting changes.

## Requirements

- Reviewer must explicitly trigger `@jyc:developer` when submitting review with request-changes
- This ensures the developer is notified and can address the feedback

## Implementation Notes

- Update `templates/github-reviewer/AGENTS.md` section 4 (Submit Review)
- When using `--request-changes`, also post a comment with `@jyc:developer` to trigger the developer
- Keep the existing review body as is, but add a separate comment to trigger the developer

**Changes:**
- In reviewer template, add: `gh pr comment <number> --body "@jyc:developer Please address the review feedback."`
- This should be done AFTER the `gh pr review --request-changes` command

Fixes #27

@jyc:developer