### PR TITLE
fix: close event not received for GitHub issues/PRs

### DIFF
--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -706,12 +706,57 @@ impl GithubInboundAdapter {
             }
         }
 
-        // 3. Fetch recently closed issues/PRs → trigger thread close
+        // 3. Detect closed issues/PRs by comparing with previous cache.
+        // Strategy: if an issue was in the previous cache but not in current open list,
+        // it was closed since the last poll.
+        //
+        // Build set of current open issue numbers for comparison
+        let current_open_numbers: HashSet<u64> = issues.iter().map(|i| i.number).collect();
+
+        // Find issues that were in cache but not in current open list
+        let cached_numbers: Vec<u64> = issue_cache.keys().cloned().collect();
+        for cached_number in cached_numbers {
+            if !current_open_numbers.contains(&cached_number) {
+                // Get cached info before removing
+                if let Some((_title, github_type, _labels, _assignees)) = issue_cache.get(&cached_number) {
+                    let event_uid = format!("{}-{}-closed", github_type, cached_number);
+
+                    if !processed_events.contains(&event_uid) {
+                        tracing::info!(
+                            channel = %self.channel_name,
+                            event = "closed",
+                            number = cached_number,
+                            github_type = github_type,
+                            "GitHub close event detected (via cache comparison) → closing threads"
+                        );
+
+                        if let Some(ref on_close) = options.on_thread_close {
+                            match github_type.as_str() {
+                                "pull_request" => {
+                                    let _ = (on_close)(format!("pr-{}", cached_number));
+                                    let _ = (on_close)(format!("review-pr-{}", cached_number));
+                                }
+                                _ => {
+                                    let _ = (on_close)(format!("issue-{}", cached_number));
+                                }
+                            }
+                        }
+
+                        processed_events.insert(event_uid);
+                    }
+                }
+
+                issue_cache.remove(&cached_number);
+            }
+        }
+
+        // 4. Fetch recently closed issues/PRs as backup (for edge cases).
+        // This catches issues that were closed but never cached (e.g., closed before first poll).
         let closed = client.list_closed_since(&poll_start).await?;
         tracing::trace!(
             channel = %self.channel_name,
             count = closed.len(),
-            "Fetched closed issues/PRs"
+            "Fetched closed issues/PRs (backup)"
         );
 
         for item in &closed {


### PR DESCRIPTION
## Spec

修复 GitHub issue/PR close 事件未被接收的问题。

### 问题根因

在 `poll_once` 方法中，`list_closed_since` 使用 GitHub API 的 `since` 参数按**创建时间**过滤，而不是按**关闭时间**过滤。这导致只有最近创建的 closed issues 才会被返回，而不是最近关闭的 issues。

当 JYC 正常运行时，`last_poll` 不断前移，如果一个 issue 在较长时间前被关闭（例如 10 分钟前），它就永远不会被 `list_closed_since` 返回。重启后能收到的原因是因为启动时 `last_poll` 设为 5 分钟前，会获取最近 5 分钟创建的 closed issues。

### 解决方案

采用比较策略：在每次 poll 周期中，比较当前获取的 open issues 与上一次 poll 缓存的 open issues。任何在上一次缓存中存在但当前不在 open 列表中的 issue，都视为已被关闭。

### 实现细节

1. 修改 `poll_once` 方法的 close 检测逻辑：
   - 在处理 open issues 后，保留一个当前 open issues 的编号集合
   - 遍历上一次缓存中的所有 issue 编号
   - 对于在缓存中但不在当前 open 列表中的 issue，触发 close 事件

2. 保持现有的 `list_closed_since` 查询作为备份（用于捕获直接通过 GitHub UI 关闭但不在当前 open 列表中的情况）

## Requirements

- close 事件必须在 issue/PR 被关闭时被触发
- 重启后不应该重复触发已处理的 close 事件（使用 processed_events 去重）

## Implementation Notes

- 使用 HashSet 存储当前 open issues 的编号，便于快速查找
- 利用已有的 issue_cache 来获取上一次 poll 的 open issues 信息
- 对于从 open 列表中消失的 issue，需要从 cache 中获取其标题和类型信息

Fixes #36

@jyc:developer