### PR TITLE
feat: 支持 GitHub Enterprise

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -244,6 +244,7 @@ interval_hours = 3
 # repo = "myrepo"
 # token = "${GITHUB_TOKEN}"           # PAT scopes: repo, read:user
 # poll_interval_secs = 60
+# # api_url = "https://api.github.com"  # Default. For GitHub Enterprise, use: https://github.example.com/api/v3
 #
 # # Pattern: Issues → Planner agent
 # [[channels.my_repo.patterns]]

--- a/src/channels/github/client.rs
+++ b/src/channels/github/client.rs
@@ -15,6 +15,7 @@ pub struct GithubClient {
     client: reqwest::Client,
     owner: String,
     repo: String,
+    api_url: String,
 }
 
 /// GitHub user (minimal fields).
@@ -109,19 +110,23 @@ impl GithubClient {
             .build()
             .context("Failed to create HTTP client")?;
 
+        // Remove trailing slash from api_url if present
+        let api_url = config.api_url.trim_end_matches('/').to_string();
+
         Ok(Self {
             client,
             owner: config.owner.clone(),
             repo: config.repo.clone(),
+            api_url,
         })
     }
 
     /// Get the authenticated user (bot identity).
     pub async fn get_authenticated_user(&self) -> Result<GithubUser> {
-        let url = "https://api.github.com/user";
+        let url = format!("{}/user", self.api_url);
         let resp = self
             .client
-            .get(url)
+            .get(&url)
             .send()
             .await
             .context("Failed to fetch authenticated user")?;
@@ -151,8 +156,8 @@ impl GithubClient {
 
         for page in 1..=max_pages {
             let url = format!(
-                "https://api.github.com/repos/{}/{}/issues?state=open&sort=updated&direction=desc&per_page=100&page={}",
-                self.owner, self.repo, page
+                "{}/repos/{}/{}/issues?state=open&sort=updated&direction=desc&per_page=100&page={}",
+                self.api_url, self.owner, self.repo, page
             );
 
             let resp = self
@@ -190,8 +195,8 @@ impl GithubClient {
     /// Returns comments across all issues/PRs in the repo.
     pub async fn list_comments_since(&self, since: &str) -> Result<Vec<GithubComment>> {
         let url = format!(
-            "https://api.github.com/repos/{}/{}/issues/comments?since={}&sort=updated&direction=asc&per_page=100",
-            self.owner, self.repo, since
+            "{}/repos/{}/{}/issues/comments?since={}&sort=updated&direction=asc&per_page=100",
+            self.api_url, self.owner, self.repo, since
         );
 
         let resp = self
@@ -215,8 +220,8 @@ impl GithubClient {
     /// List recently closed issues/PRs (for close event detection).
     pub async fn list_closed_since(&self, since: &str) -> Result<Vec<GithubIssue>> {
         let url = format!(
-            "https://api.github.com/repos/{}/{}/issues?state=closed&since={}&sort=updated&direction=asc&per_page=100",
-            self.owner, self.repo, since
+            "{}/repos/{}/{}/issues?state=closed&since={}&sort=updated&direction=asc&per_page=100",
+            self.api_url, self.owner, self.repo, since
         );
 
         let resp = self
@@ -243,8 +248,8 @@ impl GithubClient {
     /// Returns the comment ID.
     pub async fn create_comment(&self, number: u64, body: &str) -> Result<u64> {
         let url = format!(
-            "https://api.github.com/repos/{}/{}/issues/{}/comments",
-            self.owner, self.repo, number
+            "{}/repos/{}/{}/issues/{}/comments",
+            self.api_url, self.owner, self.repo, number
         );
 
         let resp = self

--- a/src/channels/github/config.rs
+++ b/src/channels/github/config.rs
@@ -1,5 +1,15 @@
 use serde::{Deserialize, Serialize};
 
+const DEFAULT_API_URL: &str = "https://api.github.com";
+
+fn default_api_url() -> String {
+    DEFAULT_API_URL.to_string()
+}
+
+fn default_poll_interval() -> u64 {
+    60
+}
+
 /// GitHub-specific configuration for a channel.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GithubConfig {
@@ -12,6 +22,11 @@ pub struct GithubConfig {
     /// GitHub Personal Access Token (scopes: repo, read:user)
     pub token: String,
 
+    /// GitHub API base URL (default: https://api.github.com)
+    /// For GitHub Enterprise, use: https://github.example.com/api/v3
+    #[serde(default = "default_api_url")]
+    pub api_url: String,
+
     /// Polling interval in seconds (default: 60)
     #[serde(default = "default_poll_interval")]
     pub poll_interval_secs: u64,
@@ -23,13 +38,10 @@ impl Default for GithubConfig {
             owner: String::new(),
             repo: String::new(),
             token: String::new(),
+            api_url: default_api_url(),
             poll_interval_secs: default_poll_interval(),
         }
     }
-}
-
-fn default_poll_interval() -> u64 {
-    60
 }
 
 #[cfg(test)]
@@ -40,6 +52,7 @@ mod tests {
     fn test_default_config() {
         let config = GithubConfig::default();
         assert_eq!(config.poll_interval_secs, 60);
+        assert_eq!(config.api_url, "https://api.github.com");
         assert!(config.owner.is_empty());
     }
 
@@ -57,6 +70,7 @@ mod tests {
         assert_eq!(config.repo, "jyc");
         assert_eq!(config.token, "ghp_test123");
         assert_eq!(config.poll_interval_secs, 120);
+        assert_eq!(config.api_url, "https://api.github.com");
     }
 
     #[test]
@@ -69,5 +83,21 @@ mod tests {
 
         let config: GithubConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.poll_interval_secs, 60);
+        assert_eq!(config.api_url, "https://api.github.com");
+    }
+
+    #[test]
+    fn test_config_deserialize_enterprise_url() {
+        let toml_str = r#"
+            owner = "myorg"
+            repo = "myrepo"
+            token = "ghp_test123"
+            api_url = "https://github.example.com/api/v3"
+        "#;
+
+        let config: GithubConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.owner, "myorg");
+        assert_eq!(config.repo, "myrepo");
+        assert_eq!(config.api_url, "https://github.example.com/api/v3");
     }
 }

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -1358,6 +1358,7 @@ mod tests {
             owner: "kingye".to_string(),
             repo: "jyc".to_string(),
             token: "test".to_string(),
+            api_url: "https://api.github.com".to_string(),
             poll_interval_secs: 60,
         };
         let adapter = GithubInboundAdapter::new(&config, "test_github".to_string());
@@ -1403,6 +1404,7 @@ mod tests {
             owner: "kingye".to_string(),
             repo: "jyc".to_string(),
             token: "test".to_string(),
+            api_url: "https://api.github.com".to_string(),
             poll_interval_secs: 60,
         };
         let adapter = GithubInboundAdapter::new(&config, "test_github".to_string());
@@ -1431,6 +1433,7 @@ mod tests {
             owner: "kingye".to_string(),
             repo: "jyc".to_string(),
             token: "test".to_string(),
+            api_url: "https://api.github.com".to_string(),
             poll_interval_secs: 60,
         };
         let adapter = GithubInboundAdapter::new(&config, "test_github".to_string());


### PR DESCRIPTION
## Spec

为 GitHub channel 添加 GitHub Enterprise 支持，允许配置自定义 API 端点。

## Requirements

1. 在 `GithubConfig` 中添加可选的 `api_url` 配置项
2. 修改 `GithubClient` 使用配置的 `api_url`，默认为 `https://api.github.com`
3. 更新配置文件示例 `config.example.toml` 添加 `api_url` 说明
4. 保持向后兼容：不配置时使用默认的 `api.github.com`

## Implementation Notes

- `api_url` 应为可选字段，不配置时使用默认值
- 需要处理 URL 末尾的斜杠（如果有）
- 所有 API 调用使用同一个基础 URL

Fixes #40

@jyc:developer