### PR TITLE
fix: 发票skill按summary.xlsx模板生成总结xlsx并修正文件命名

### DIFF
--- a/.opencode/skills/invoice-processing/EXCEL.md
+++ b/.opencode/skills/invoice-processing/EXCEL.md
@@ -220,81 +220,19 @@ Do NOT overwrite or modify this row during summary generation.
 
 1. Determine the target month (from user message or default to current month)
 2. Verify the database `invoices.db` exists
-3. Copy `summary.xlsx` template into the monthly folder (if not already there):
-   ```bash
-   MONTH="2026-04"
-   if [ ! -f "invoice_${MONTH}/summary.xlsx" ]; then
-     cp summary.xlsx "invoice_${MONTH}/summary.xlsx"
-   fi
-   ```
-4. Read all invoices from SQLite using `get_invoices_by_month()`
-5. Categorize each invoice by its 服务项目名称 (service/item name):
+3. Read all invoices from SQLite using `get_invoices_by_month()`
+4. Categorize each invoice by its 服务项目名称 (service/item name):
    - 餐饮/餐费/食品/外卖 → Food & Meals (row 12)
    - 洗衣/干洗 → Laundry (row 10)
    - 房租/租金/租赁 → Rental fee (row 14)
    - 机票/航空 → Airticket (row 16)
    - Other categories → use available rows (17-37)
-6. Fill the summary:
-
-```bash
-python3 << 'PYEOF'
-import sys
-import os
-
-sys.path.insert(0, '.opencode/skills/invoice-processing/scripts')
-from db import get_invoices_by_month
-from openpyxl import load_workbook
-
-MONTH = "2026-04"
-
-# Read invoice data from SQLite
-invoices = get_invoices_by_month(MONTH)
-
-# Read summary template
-sum_wb = load_workbook(f'invoice_{MONTH}/summary.xlsx')
-sum_ws = sum_wb.active
-
-# Update month
-sum_ws['B6'] = 'April of 2026'  # Adjust month name
-
-# Category mapping: row number → category keywords
-# NOTE: Row 14 (Rental fee) is a FIXED value — do NOT include it here
-categories = {
-    10: ['洗衣', '干洗', 'laundry'],
-    12: ['餐饮', '餐费', '食品', '外卖', 'food', 'meal'],
-    16: ['机票', '航空', 'airticket', 'flight'],
-}
-
-# Process invoices from SQLite
-for inv in invoices:
-    service = str(inv.get('service_name') or '').lower()
-    date = inv.get('issue_date')
-    amount = inv.get('total_amount')
-
-    if not amount:
-        continue
-
-    # Find matching category
-    target_row = None
-    for cat_row, keywords in categories.items():
-        if any(kw in service for kw in keywords):
-            target_row = cat_row
-            break
-
-    if target_row:
-        # Append amount to existing value
-        existing = sum_ws.cell(row=target_row, column=3).value or 0
-        if isinstance(existing, str):
-            existing = 0
-        sum_ws.cell(row=target_row, column=3, value=existing + float(amount))
-        # Set date if empty
-        if not sum_ws.cell(row=target_row, column=2).value:
-            sum_ws.cell(row=target_row, column=2, value=date)
-
-sum_wb.save(f'invoice_{MONTH}/summary.xlsx')
-print('Summary updated')
-PYEOF
-```
+6. Generate the summary using the script:
+   ```bash
+   MONTH="2026-04"
+   python3 .opencode/skills/invoice-processing/scripts/generate_summary_excel.py "$MONTH"
+   ```
+   This creates `invoice_summary_<month>.xlsx` in the current directory.
 
 7. Reply with a summary of categorized amounts
 
@@ -309,17 +247,22 @@ When the user asks to download or export all invoices for a month:
 
 1. Determine the target month (from user message or default to current month)
 2. Verify the folder exists
-3. If the user explicitly requests `invoices.xlsx`, generate it from SQLite:
+3. Generate the invoice list Excel:
    ```bash
    MONTH="2026-04"
    python3 .opencode/skills/invoice-processing/scripts/generate_excel.py "$MONTH"
    ```
-4. If summary has not been generated yet, run Step 7 first to create it
-5. Zip the entire monthly folder (includes invoices.xlsx if generated, summary.xlsx, and all invoice files):
+   This creates `invoice_list_<month>.xlsx` in the current directory.
+4. Generate the monthly summary Excel:
+   ```bash
+   python3 .opencode/skills/invoice-processing/scripts/generate_summary_excel.py "$MONTH"
+   ```
+   This creates `invoice_summary_<month>.xlsx` in the current directory.
+5. Zip the monthly folder along with both xlsx files:
    ```bash
    MONTH="2026-04"
    cd <thread_dir>
-   zip -r "invoice_${MONTH}.zip" "invoice_${MONTH}/"
+   zip -r "invoice_${MONTH}.zip" "invoice_${MONTH}/" "invoice_list_${MONTH}.xlsx" "invoice_summary_${MONTH}.xlsx"
    ```
 6. Send the zip file as an attachment in the reply
 

--- a/.opencode/skills/invoice-processing/SKILL.md
+++ b/.opencode/skills/invoice-processing/SKILL.md
@@ -144,12 +144,12 @@ Thread directory structure:
   summary.xlsx            ← Summary template (placed by user)
   invoices.db             ← SQLite database (primary storage for all months)
   invoice_YYYY-MM/        ← Monthly folder (e.g., invoice_2026-04)
-    invoices.xlsx          ← Generated on-demand (when user requests Excel export)
     errors.jsonl           ← Failed invoice log (append-only, one JSON per line)
-    summary.xlsx           ← Summary for this month (copied + filled when requested)
     INV-2026-0042.pdf      ← Downloaded invoices (named by invoice number)
     INV-2026-0043.jpg
     ...
+  invoice_list_YYYY-MM.xlsx  ← Generated on-demand (when user requests export)
+  invoice_summary_YYYY-MM.xlsx ← Generated on-demand (when user requests summary)
 ```
 
 Check if the current month's folder and database exist:

--- a/.opencode/skills/invoice-processing/scripts/generate_excel.py
+++ b/.opencode/skills/invoice-processing/scripts/generate_excel.py
@@ -23,9 +23,9 @@ def generate_excel(month: str, output_path: str = None) -> str:
         )
 
     if not output_path:
-        output_path = f"invoice_{month}/invoices.xlsx"
+        output_path = f"invoice_list_{month}.xlsx"
 
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    os.makedirs(os.path.dirname(output_path) or '.', exist_ok=True)
     shutil.copy(template_path, output_path)
 
     wb = load_workbook(output_path)
@@ -62,4 +62,4 @@ if __name__ == "__main__":
         sys.exit(1)
 
     output = generate_excel(month)
-    print(f"Generated: {output}")
+    print(f"Generated: {output} (invoice list)")

--- a/.opencode/skills/invoice-processing/scripts/generate_summary_excel.py
+++ b/.opencode/skills/invoice-processing/scripts/generate_summary_excel.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Generate invoice_summary_<month>.xlsx from SQLite database."""
+import os
+import shutil
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from openpyxl import load_workbook
+from db import get_invoices_by_month
+
+TEMPLATE_PATH = os.environ.get('INVOICE_SUMMARY_TEMPLATE_PATH', 
+    os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'summary.xlsx'))
+
+MONTH_MAP = {
+    '01': 'January', '02': 'February', '03': 'March', '04': 'April',
+    '05': 'May', '06': 'June', '07': 'July', '08': 'August',
+    '09': 'September', '10': 'October', '11': 'November', '12': 'December'
+}
+
+CATEGORY_KEYWORDS = {
+    10: ['洗衣', '干洗', 'laundry'],
+    12: ['餐饮', '餐费', '食品', '外卖', 'food', 'meal'],
+    16: ['机票', '航空', 'airticket', 'flight'],
+}
+
+
+def month_to_str(month: str) -> str:
+    """Convert YYYY-MM to 'Month of YYYY' format."""
+    try:
+        year, mon = month.split('-')
+        return f"{MONTH_MAP.get(mon, mon)} of {year}"
+    except:
+        return month
+
+
+def generate_summary_excel(month: str, output_path: str = None) -> str:
+    template_path = TEMPLATE_PATH
+    if not os.path.isabs(template_path):
+        template_path = os.path.join(os.getcwd(), template_path)
+
+    if not os.path.exists(template_path):
+        raise FileNotFoundError(
+            f"Summary template not found: {template_path}. "
+            "Please ensure summary.xlsx exists."
+        )
+
+    if not output_path:
+        output_path = f"invoice_summary_{month}.xlsx"
+
+    os.makedirs(os.path.dirname(output_path) or '.', exist_ok=True)
+    shutil.copy(template_path, output_path)
+
+    wb = load_workbook(output_path)
+    ws = wb.active
+
+    ws['B6'] = month_to_str(month)
+
+    invoices = get_invoices_by_month(month)
+
+    row_totals = {row: 0.0 for row in CATEGORY_KEYWORDS}
+
+    for inv in invoices:
+        service = str(inv.get('service_name') or '').lower()
+        date = inv.get('issue_date')
+        amount = inv.get('total_amount')
+
+        if not amount:
+            continue
+
+        target_row = None
+        for cat_row, keywords in CATEGORY_KEYWORDS.items():
+            if any(kw.lower() in service for kw in keywords):
+                target_row = cat_row
+                break
+
+        if target_row:
+            row_totals[target_row] += float(amount)
+            if not ws.cell(row=target_row, column=2).value:
+                ws.cell(row=target_row, column=2, value=date)
+
+    for row, total in row_totals.items():
+        ws.cell(row=row, column=3, value=total)
+
+    wb.save(output_path)
+    wb.close()
+    return output_path
+
+
+if __name__ == "__main__":
+    month = sys.argv[1] if len(sys.argv) > 1 else None
+    if not month:
+        print("Usage: python generate_summary_excel.py <month>")
+        sys.exit(1)
+
+    output = generate_summary_excel(month)
+    print(f"Generated: {output} (monthly summary)")

--- a/.opencode/skills/invoice-processing/scripts/migrate_excel_to_db.py
+++ b/.opencode/skills/invoice-processing/scripts/migrate_excel_to_db.py
@@ -84,15 +84,15 @@ def main():
     init_db()
     print("=== Invoice Migration Tool ===\n")
 
-    excel_files = glob.glob("invoice_*/invoices.xlsx")
+    excel_files = glob.glob("invoice_list_*.xlsx")
     if not excel_files:
-        print("No invoices.xlsx files found.")
+        print("No invoice_list_*.xlsx files found.")
         return
 
     total = {'success': 0, 'skipped': 0, 'failed': 0}
 
     for excel_path in sorted(excel_files):
-        month = excel_path.split('/')[0].replace('invoice_', '')
+        month = excel_path.replace('invoice_list_', '').replace('.xlsx', '')
         print(f"\nProcessing {excel_path} (month: {month})...")
 
         result = migrate_excel_to_db(excel_path, month)


### PR DESCRIPTION
## Spec

修复发票skill的总结生成功能：按照summary.xlsx模板生成invoice_summary_<month>.xlsx，将发票清单文件名改为invoice_list_<month>.xlsx，移除月度目录中不必要的xlsx文件存储。

Fixes #45

## Implementation Plan

### Step 1: 修改 `generate_excel.py` — 输出文件名改为 `invoice_list_<month>.xlsx`
**What:** 修改 `.opencode/skills/invoice-processing/scripts/generate_excel.py`：
- `generate_excel()` 默认输出路径从 `invoice_<month>/invoices.xlsx` 改为 `invoice_list_<month>.xlsx`（在thread目录根级别）
- 更新 `main` 中的打印信息
**Why:** 发票清单应使用新命名规范，且不应存储在月度子目录中
**Verify:** 运行 `python3 .opencode/skills/invoice-processing/scripts/generate_excel.py 2026-04`，确认生成的文件名为 `invoice_list_2026-04.xlsx` 且位于当前目录

### Step 2: 新增 `generate_summary_excel.py` 脚本
**What:** 创建 `.opencode/skills/invoice-processing/scripts/generate_summary_excel.py`：
- 参照 `generate_excel.py` 的模式，定义 `generate_summary_excel(month, output_path=None)` 函数
- 从 `.opencode/skills/invoice-processing/summary.xlsx` 复制模板
- 调用 `get_invoices_by_month(month)` 获取当月发票
- 按 `service_name` 分类到 summary.xlsx 模板对应行：
  - 洗衣/干洗 → Row 10 (Laundry), 填 B10=日期, C10=累加金额
  - 餐饮/餐费/食品/外卖 → Row 12 (Food & Meals), 填 B12=日期, C12=累加金额
  - 机票/航空 → Row 16 (Airticket), 填 B16=日期, C16=累加金额
  - **Row 14 (Rental fee, 固定值30000) 不修改**
  - 其他分类 → 使用 Row 17-37 可用行
- 更新 B6 月份（格式如 "April of 2026"，需做月份数字到英文名映射）
- 默认输出路径：`invoice_summary_<month>.xlsx`
- 支持 `INVOICE_SUMMARY_TEMPLATE_PATH` 环境变量覆盖模板路径
**Why:** 当前总结逻辑硬编码在EXCEL.md内联Python中，没有可复用脚本，且未按summary.xlsx模板结构生成
**Verify:** 插入测试数据到SQLite后运行脚本，检查生成的xlsx结构与summary.xlsx模板一致，Row 14保持30000不变，Row 38 SUM公式正确

### Step 3: 更新 `EXCEL.md` Step 7 — 改用脚本生成总结
**What:** 修改 `.opencode/skills/invoice-processing/EXCEL.md` 的 Step 7 (约第196-302行)：
- 删除内联Python代码块（第239-296行）
- 改为调用 `python3 .opencode/skills/invoice-processing/scripts/generate_summary_excel.py "$MONTH"`
- 输出文件名更新为 `invoice_summary_<month>.xlsx`
- 删除 "Copy summary.xlsx template into monthly folder" 步骤
- 保留分类映射说明和 Row 14 不可修改的警告
- 更新 Step 7 回复格式中的文件名引用
**Why:** 与 `generate_excel.py` 保持一致的脚本调用模式，避免内联代码
**Verify:** 阅读更新后的Step 7，确认步骤清晰、无内联Python代码、文件名正确

### Step 4: 更新 `EXCEL.md` Step 8 — 导出逻辑
**What:** 修改 `.opencode/skills/invoice-processing/EXCEL.md` 的 Step 8 (约第306-339行)：
- 步骤3：改为总是生成 `invoice_list_<month>.xlsx`（调用 `generate_excel.py`）
- 步骤4：总是生成 `invoice_summary_<month>.xlsx`（调用 `generate_summary_excel.py`）
- 步骤5：打包zip包含月度目录 + 两个xlsx：
  ```bash
  zip -r "invoice_${MONTH}.zip" "invoice_${MONTH}/" "invoice_list_${MONTH}.xlsx" "invoice_summary_${MONTH}.xlsx"
  ```
- 删除 "If the user explicitly requests invoices.xlsx" 条件判断，总是生成两个文件
**Why:** 两个xlsx在thread根目录不在月度目录内，zip需包含两者
**Verify:** 阅读更新后的Step 8，确认打包逻辑和文件名正确

### Step 5: 更新 `SKILL.md` — 目录结构和描述
**What:** 修改 `.opencode/skills/invoice-processing/SKILL.md`：
- 更新目录结构描述（约第141-153行），移除 `invoices.xlsx` 和 `summary.xlsx` 在月度目录下的条目
- 更新为：
  ```
  <thread_dir>/
    template.xlsx              ← 发票记录模板（从skill复制）
    summary.xlsx               ← 总结模板（用户放置）
    invoices.db                ← SQLite数据库（主存储）
    invoice_YYYY-MM/           ← 月度文件夹
      errors.jsonl             ← 失败记录
      INV-2026-0042.pdf        ← 下载的发票文件
  ```
- 在 Step 1 说明中更新：月度目录只存放发票文件和错误日志，xlsx只在用户请求导出时生成
**Why:** 目录结构描述与实际行为不符
**Verify:** 阅读更新后的SKILL.md，确认目录结构描述准确

### Step 6: 更新 `migrate_excel_to_db.py` — 适配新文件名
**What:** 修改 `.opencode/skills/invoice-processing/scripts/migrate_excel_to_db.py` 第87行：
- `glob.glob("invoice_*/invoices.xlsx")` → `glob.glob("invoice_list_*.xlsx")`
- 更新第95行的month提取逻辑以适配新文件名格式：`excel_path.replace('invoice_list_', '').replace('.xlsx', '')`
**Why:** 文件名变更，迁移脚本需适配
**Verify:** 检查代码中不再有引用旧 `invoices.xlsx` 文件名的地方

## Design Decisions
- 两个xlsx文件放在thread根目录而非月度目录内，因为它们是按需生成的导出产物而非持久存储
- `generate_summary_excel.py` 遵循 `generate_excel.py` 的模式（复制模板 → 填充 → 保存），保持代码一致性
- summary.xlsx模板从skill目录（`.opencode/skills/invoice-processing/summary.xlsx`）读取，因为skill自带模板；用户也可通过环境变量覆盖
- 导出时总是生成两个xlsx文件，不再需要用户显式请求

@jyc:developer