### PR TITLE
feat: copy repo skills to thread directory in GitHub templates

### DIFF
--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -26,6 +26,7 @@ then `cd repo` before running any command:
 if [ ! -d "repo" ]; then
     gh repo clone <repository_from_trigger> repo
 fi
+cp -rn repo/.opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
 cd repo
 ```
 

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -27,6 +27,7 @@ then `cd repo` before running any command:
 if [ ! -d "repo" ]; then
     gh repo clone <repository_from_trigger> repo
 fi
+cp -rn repo/.opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
 cd repo
 ```
 

--- a/templates/github-reviewer/AGENTS.md
+++ b/templates/github-reviewer/AGENTS.md
@@ -20,6 +20,7 @@ then `cd repo` before running any command:
 if [ ! -d "repo" ]; then
     gh repo clone <repository_from_trigger> repo
 fi
+cp -rn repo/.opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
 cd repo
 ```
 


### PR DESCRIPTION
## Spec

In the GitHub workflow, when an agent clones a repo into `repo/` within the thread directory, any skills defined in `repo/.opencode/skills/` are not discovered by OpenCode because its working directory is the thread directory, not the repo subdirectory. This PR adds a `cp -rn` step in the Repository Setup section of `templates/github-developer/AGENTS.md`, `templates/github-planner/AGENTS.md`, and `templates/github-reviewer/AGENTS.md` to copy repo skills to the thread's `.opencode/skills/` so they can be discovered and loaded natively by OpenCode.

Fixes #49

## Implementation Plan

### Step 1: Update `templates/github-developer/AGENTS.md`
**What:** Add a skill copy step in the Repository Setup section, after `gh repo clone` and before `cd repo`. The step copies `repo/.opencode/skills/*` to `../.opencode/skills/` (relative to repo, i.e. the thread directory) using `cp -rn` to avoid overwriting existing files.
**Why:** Developer agent needs access to repo-specific skills (e.g., `incremental-dev`, `dev-workflow`) to follow proper coding conventions.
**Verify:** Read the updated AGENTS.md and confirm the skill copy step appears after the clone step.

### Step 2: Update `templates/github-planner/AGENTS.md`
**What:** Add the same skill copy step in the Repository Setup section.
**Why:** Planner agent may need repo-specific skills (e.g., `plan-solution`, `dev-workflow`) for proper planning.
**Verify:** Read the updated AGENTS.md and confirm the skill copy step appears after the clone step.

### Step 3: Update `templates/github-reviewer/AGENTS.md`
**What:** Add the same skill copy step in the Repository Setup section.
**Why:** Reviewer agent may need repo-specific skills (e.g., `pr-review`) for proper review workflow.
**Verify:** Read the updated AGENTS.md and confirm the skill copy step appears after the clone step.

## Design Decisions
- **`cp -rn` (no-clobber)**: Avoids overwriting skills that may already exist in the thread's `.opencode/skills/` from the template or previous runs.
- **Implementation in AGENTS.md, not Rust code**: Repo cloning is done by the agent (via AGENTS.md instructions), not by JYC core. The skill copy belongs at the same level.
- **No symlink**: Symlinks break when the repo is re-cloned. Copy is more reliable.
- **Path consistency**: Skills that use relative paths like `.opencode/skills/<name>/scripts/` continue to work correctly because the directory structure is preserved at the thread level.