### PR TITLE
chore: bump version to 0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to JYC will be documented in this file.
 
 ## [Unreleased]
 
+## [0.1.10] - 2026-04-20
+
 ### Added
 
 **GitHub Label-Based Routing** — Auto-label matching for GitHub channel patterns
@@ -15,27 +17,86 @@ All notable changes to JYC will be documented in this file.
 - When labels are added to an existing issue/PR, the change is detected by comparing against cached labels
 - This allows users to add a label (e.g., `jyc:plan`) to an existing issue and have it routed to the planner
 
-### Changed
+**@j:<role> Mention-Driven Routing** — Refactored hand-off mechanism
+- Patterns match on `@j:<role>` mentions in comments (e.g., `@j:developer`, `@j:reviewer`, `@j:planner`)
+- Replaces earlier `[Role]` prefix filter approach
+- Agent templates updated to use `@j:<role>` for hand-offs
 
-**GitHub Self-Loop Prevention** — Replaces global `[Role]` prefix filter
-- Previously: ALL comments prefixed with `[Planner]`, `[Developer]`, or `[Reviewer]` were globally filtered (invisible to all patterns)
-- Now: each pattern only skips comments from its **own** role. `[Developer]` comments are visible to the reviewer pattern, and vice versa
-- Enables cross-agent feedback visibility (reviewer feedback triggers developer)
+**Persistent Comment Tracking** — Re-process edited comments
+- Track comment ID + `updated_at` to detect edits
+- Edited comments are re-processed through the routing pipeline
+- Backward-compatible with old `processed-comments.txt` format
 
-**GitHub Agent Templates** — Updated hand-off workflow with routing labels
-- Planner: adds `--label "jyc:develop"` when creating PRs
-- Developer: adds `jyc:review` label when handing off to reviewer
-- Reviewer: adds `jyc:develop` label when requesting changes from developer
+**SQLite Storage for Invoice Processing** — Persistent invoice database
+- SQLite database for invoice records
+- Enables duplicate checking and query capabilities
+- Schema: invoice_number, receipt_date, amount, seller, buyer, status, etc.
 
-**Developer-Reviewer Handoff** — Improved workflow for requesting changes
-- Reviewer template now explicitly triggers `@jyc:developer` when submitting review with request-changes
-- Ensures developer is notified when feedback needs to be addressed
+**GitHub Enterprise Support** — Configurable API endpoint
+- `api_url` config option for GitHub Enterprise instances
+- Default: `https://api.github.com` for public GitHub
+
+**Assignee Matching** — Route issues/PRs by assignee
+- `assignees` field on `ChannelPattern` for GitHub channel
+- Match issues/PRs where any of the specified users are assigned
+
+**Close Event Detection** — Improved event handling
+- Fetch all open issues instead of `list_closed_since` for detecting close events
+- Compare cached state to detect actual closes
 
 **Bare Metal Deployment** — Deploy jyc on Ubuntu/Debian servers without Docker
 - `deploy-bare-metal.sh` script for automated deployment
 - `dotfiles/zsh/` - zsh configuration and environment template
 - `dotfiles/opencode/opencode.jsonc` - OpenCode configuration
 - `docs/bare-metal-deploy.md` - Deployment guide
+
+**nohup Fallback** — Run on servers without systemd
+- Detect systemd user session availability
+- Fall back to `nohup` + redirect for process supervision
+
+### Fixed
+
+**Worker Semaphore Permit Release** — Fix resource leak on thread close
+- Workers now properly release semaphore permits when closing threads
+- Prevents thread pool exhaustion
+
+**GitHub Self-Loop Prevention** — Replaces global `[Role]` prefix filter
+- Previously: ALL comments prefixed with `[Planner]`, `[Developer]`, or `[Reviewer]` were globally filtered (invisible to all patterns)
+- Now: each pattern only skips comments from its **own** role. `[Developer]` comments are visible to the reviewer pattern, and vice versa
+- Enables cross-agent feedback visibility (reviewer feedback triggers developer)
+
+**Developer-Reviewer Handoff** — Improved workflow for requesting changes
+- Reviewer template now explicitly triggers `@jyc:developer` when submitting review with request-changes
+- Ensures developer is notified when feedback needs to be addressed
+
+**Invoice Processing Fixes**
+- Add duplicate invoice check before adding to Excel
+- Fix EXCEL.md with template copy step, clarify MONTH variable usage
+- Template lookup logic fixes, zero amount handling, template cleanup
+
+**Template Generalization** — Multi-language support
+- Templates generalized for multi-language workflows
+- Repository name included in trigger messages
+
+**Model Override in Templates** — Per-template model configuration
+- Support `model-override` in templates while ignoring `.jyc` elsewhere
+- Updated GitHub developer template with model override support
+
+### Changed
+
+**GitHub Agent Templates** — Updated hand-off workflow with routing labels
+- Planner: adds `--label "jyc:develop"` when creating PRs
+- Developer: adds `jyc:review` label when handing off to reviewer
+- Reviewer: adds `jyc:develop` label when requesting changes from developer
+
+**Invoice Summary Export** — Generate summary xlsx
+- Summary xlsx with correct naming (`summary_YYYY-MM.xlsx`)
+- Template-based generation with proper file handling
+
+**Docker Simplification** — Removed s6-overlay
+- Removed s6-overlay from Docker setup
+- Simplified entrypoint/CMD in Dockerfile
+- Removed jyc-deploy-docker skill (no longer self-bootstrapping)
 
 ## [0.1.9] - 2026-04-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "jyc"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jyc"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 description = "Channel-agnostic AI agent"
 


### PR DESCRIPTION
## Spec

Bump the project version from 0.1.9 to 0.1.10, updating the version in Cargo.toml and finalizing the CHANGELOG.md with all changes since the last release.

Fixes #51

## Implementation Plan

### Step 1: Update version in Cargo.toml
**What:** Change `version = "0.1.9"` to `version = "0.1.10"` in `Cargo.toml:3`
**Why:** This is the canonical version source for the Rust project
**Verify:** `grep 'version = "0.1.10"' Cargo.toml` returns a match

### Step 2: Run cargo check to update Cargo.lock
**What:** Run `cargo check` to propagate the version change into `Cargo.lock`
**Why:** Cargo.lock must reflect the updated package version from Cargo.toml
**Verify:** `grep 'name = "jyc"' -A1 Cargo.lock | grep '0.1.10'` returns a match

### Step 3: Update CHANGELOG.md
**What:** 
1. Compare the existing `[Unreleased]` section against `git log v0.1.9..HEAD --oneline` to find any missing changes
2. Add any missing entries (commits not yet documented in the Unreleased section) to the appropriate categories (Added/Fixed/Changed)
3. Replace `## [Unreleased]` header with `## [0.1.10] - 2026-04-20`
4. Add a new empty `## [Unreleased]` section above it

**Why:** The Unreleased section may not cover all changes since 0.1.9. The developer must cross-reference git logs to ensure completeness. Key areas to verify from the git log:
- GitHub label-based routing & self-loop prevention (already in Unreleased)
- `@j:<role>` mention-driven routing refactor (may be missing)
- Persistent comment tracking & edited comment re-processing (may be missing)
- SQLite storage for invoice processing (may be missing)
- GitHub Enterprise support with configurable api_url (may be missing)
- Assignee matching for GitHub issue/PR routing (may be missing)
- Close event detection improvements (may be missing)
- Worker semaphore permit release fix (may be missing)
- nohup fallback for non-systemd servers (may be missing)
- Multiple invoice processing fixes and skill improvements
- Template generalization for multi-language support
- Model override support in templates

**Verify:** `head -60 CHANGELOG.md` shows `[0.1.10] - 2026-04-20` and a new `[Unreleased]` section; all significant commits from `git log v0.1.9..HEAD` are represented

### Step 4: Run tests to verify
**What:** Run `cargo test` and `cargo check` to ensure nothing is broken
**Why:** Version bump should not break the build
**Verify:** Both commands exit with code 0

## Design Decisions
- PATCH bump (0.1.9 → 0.1.10) per project convention — the release includes multiple features and fixes but no breaking changes
- Developer must cross-reference git logs with existing Unreleased section to ensure the CHANGELOG is complete — the Unreleased section may not cover all changes
- Date: 2026-04-20 (today)