### PR TITLE
feat: deploy-templates.sh 支持单个template部署和设置AI model

### DIFF
--- a/deploy-templates.sh
+++ b/deploy-templates.sh
@@ -4,29 +4,65 @@ set -e
 # Deploy templates by composing AGENTS.md + referenced skills from .opencode/skills/
 #
 # Usage:
-#   ./deploy-templates.sh <target_dir>
+#   ./deploy-templates.sh <target_dir> [template_name] [--model <model-id>]
 #
-# Example:
-#   ./deploy-templates.sh /home/jiny/projects/jyc-data/templates
-#
-# This script:
-# 1. Reads templates/ directory for AGENTS.md files
-# 2. Reads the skill mapping below
-# 3. Copies AGENTS.md + skills into target/<template_name>/
+# Examples:
+#   ./deploy-templates.sh /path/to/templates
+#   ./deploy-templates.sh /path/to/templates github-planner
+#   ./deploy-templates.sh /path/to/templates --model tencent/glm-5.1
+#   ./deploy-templates.sh /path/to/templates github-planner --model ark/minimax-m2.5
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TEMPLATES_DIR="${SCRIPT_DIR}/templates"
 SKILLS_DIR="${SCRIPT_DIR}/.opencode/skills"
 
-if [ -z "$1" ]; then
-    echo "Usage: $0 <target_dir>"
-    echo "Example: $0 /home/jiny/projects/jyc-data/templates"
+TARGET_DIR=""
+TEMPLATE_NAME=""
+MODEL_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --model)
+            MODEL_OVERRIDE="$2"
+            shift 2
+            ;;
+        -*)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+        *)
+            if [ -z "$TARGET_DIR" ]; then
+                TARGET_DIR="$1"
+            elif [ -z "$TEMPLATE_NAME" ]; then
+                TEMPLATE_NAME="$1"
+            else
+                echo "Unexpected argument: $1" >&2
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [ -z "$TARGET_DIR" ]; then
+    echo "Usage: $0 <target_dir> [template_name] [--model <model-id>]"
+    echo ""
+    echo "Examples:"
+    echo "  $0 /path/to/templates"
+    echo "  $0 /path/to/templates github-planner"
+    echo "  $0 /path/to/templates --model tencent/glm-5.1"
+    echo "  $0 /path/to/templates github-planner --model ark/minimax-m2.5"
     exit 1
 fi
 
-TARGET_DIR="$1"
+if [ -n "$TEMPLATE_NAME" ]; then
+    template_path="${TEMPLATES_DIR}/${TEMPLATE_NAME}"
+    if [ ! -d "$template_path" ]; then
+        echo "Error: template '${TEMPLATE_NAME}' not found at ${template_path}" >&2
+        exit 1
+    fi
+fi
 
-# Return the skills for a given template name
 get_skills() {
     case "$1" in
         invoice-processing)   echo "invoice-processing" ;;
@@ -43,32 +79,38 @@ echo "=== Template Deployment ==="
 echo "Source templates: ${TEMPLATES_DIR}"
 echo "Source skills:    ${SKILLS_DIR}"
 echo "Target:           ${TARGET_DIR}"
+if [ -n "$TEMPLATE_NAME" ]; then
+    echo "Template filter: ${TEMPLATE_NAME}"
+fi
+if [ -n "$MODEL_OVERRIDE" ]; then
+    echo "Model override:  ${MODEL_OVERRIDE}"
+fi
 echo ""
 
-# Deploy each template
 for template_dir in "${TEMPLATES_DIR}"/*/; do
     template_name=$(basename "$template_dir")
+
+    if [ -n "$TEMPLATE_NAME" ] && [ "$template_name" != "$TEMPLATE_NAME" ]; then
+        continue
+    fi
+
     target="${TARGET_DIR}/${template_name}"
 
     echo "--- ${template_name} ---"
 
-    # Create target directory
     mkdir -p "${target}"
 
-    # Copy AGENTS.md
     if [ -f "${template_dir}/AGENTS.md" ]; then
         cp "${template_dir}/AGENTS.md" "${target}/AGENTS.md"
         echo "  AGENTS.md copied"
     fi
 
-    # Copy .jyc directory (model-override, etc.)
     if [ -d "${template_dir}/.jyc" ]; then
         rm -rf "${target}/.jyc"
         cp -r "${template_dir}/.jyc" "${target}/.jyc"
         echo "  .jyc copied"
     fi
 
-    # Copy skills
     skills=$(get_skills "$template_name")
     if [ -n "$skills" ]; then
         mkdir -p "${target}/.opencode/skills"
@@ -84,6 +126,12 @@ for template_dir in "${TEMPLATES_DIR}"/*/; do
         done
     else
         echo "  (no skills)"
+    fi
+
+    if [ -n "$MODEL_OVERRIDE" ]; then
+        mkdir -p "${target}/.jyc"
+        echo -n "${MODEL_OVERRIDE}" > "${target}/.jyc/model-override"
+        echo "  model-override: ${MODEL_OVERRIDE}"
     fi
 done
 


### PR DESCRIPTION
## Spec

扩展 `deploy-templates.sh`，支持：1) 部署单个指定 template；2) 部署时通过 `--model` 参数设置 AI model，写入 `.jyc/model-override`。

Fixes #53

## Implementation Plan

### Step 1: 添加参数解析逻辑
**What:** 在 `deploy-templates.sh` 中添加参数解析，支持：
- 可选的第二个位置参数 `TEMPLATE_NAME`（只部署指定 template）
- `--model <model-id>` 选项（设置 AI model override）
- 用法说明更新

解析逻辑：
```bash
TEMPLATE_NAME=""
MODEL_OVERRIDE=""

while [[ $# -gt 0 ]]; do
  case "$1" in
    --model)
      MODEL_OVERRIDE="$2"
      shift 2
      ;;
    -*)
      echo "Unknown option: $1"; exit 1
      ;;
    *)
      if [ -z "$TARGET_DIR" ]; then
        TARGET_DIR="$1"
      elif [ -z "$TEMPLATE_NAME" ]; then
        TEMPLATE_NAME="$1"
      else
        echo "Unexpected argument: $1"; exit 1
      fi
      shift
      ;;
  esac
done
```

**Why:** 当前脚本只接受一个位置参数 `<target_dir>`，需要扩展支持可选的 template 名称和 `--model` 选项。
**Verify:** 运行 `./deploy-templates.sh` 不带参数应显示更新后的 usage；`./deploy-templates.sh /tmp/test --model foo` 应设置 MODEL_OVERRIDE 变量。

### Step 2: 根据 TEMPLATE_NAME 过滤部署目标
**What:** 在遍历 template 目录的 `for` 循环中，如果 `TEMPLATE_NAME` 非空，只处理匹配的 template：

```bash
for template_dir in "${TEMPLATES_DIR}"/*/; do
    template_name=$(basename "$template_dir")
    
    # Filter by template name if specified
    if [ -n "$TEMPLATE_NAME" ] && [ "$template_name" != "$TEMPLATE_NAME" ]; then
        continue
    fi
    # ... existing deployment logic
done
```

同时，如果指定了 `TEMPLATE_NAME` 但对应目录不存在，输出错误并退出。

**Why:** 当前脚本总是部署所有 template，用户无法只部署一个。
**Verify:** `./deploy-templates.sh /tmp/test github-planner` 只应部署 `github-planner` template；`./deploy-templates.sh /tmp/test nonexistent` 应报错退出。

### Step 3: 部署后写入 model-override
**What:** 在每个 template 部署完成后（复制 AGENTS.md、.jyc、skills 之后），如果 `MODEL_OVERRIDE` 非空，写入 `.jyc/model-override`：

```bash
# Apply model override if specified
if [ -n "$MODEL_OVERRIDE" ]; then
    mkdir -p "${target}/.jyc"
    echo -n "${MODEL_OVERRIDE}" > "${target}/.jyc/model-override"
    echo "  model-override: ${MODEL_OVERRIDE}"
fi
```

注意使用 `echo -n` 避免 model ID 末尾多出换行符（与现有 `.jyc/model-override` 文件格式一致，当前文件无末尾换行）。

**Why:** 这是 issue #53 的核心需求——部署时可以指定 AI model，覆盖 template 自带的默认 model。
**Verify:** `./deploy-templates.sh /tmp/test --model tencent/glm-5.1` 后检查 `/tmp/test/github-planner/.jyc/model-override` 内容应为 `tencent/glm-5.1`（无末尾换行）。

### Step 4: 更新 usage 说明和帮助文本
**What:** 更新脚本顶部的 usage 注释和错误提示：

```
Usage:
  ./deploy-templates.sh <target_dir> [template_name] [--model <model-id>]

Examples:
  ./deploy-templates.sh /path/to/templates
  ./deploy-templates.sh /path/to/templates github-planner
  ./deploy-templates.sh /path/to/templates --model tencent/glm-5.1
  ./deploy-templates.sh /path/to/templates github-planner --model ark/minimax-m2.5
```

**Why:** 用户需要知道新的参数用法。
**Verify:** `./deploy-templates.sh` 不带参数应显示新的 usage 文本。

### Step 5: 验证端到端场景
**What:** 手动测试以下场景：
1. `./deploy-templates.sh /tmp/test` — 部署所有 template，不修改 model（与现有行为一致）
2. `./deploy-templates.sh /tmp/test github-planner` — 只部署 github-planner
3. `./deploy-templates.sh /tmp/test --model tencent/glm-5.1` — 所有 template 使用指定 model
4. `./deploy-templates.sh /tmp/test github-developer --model ark/minimax-m2.5` — 只部署一个，并设置 model
5. 确认 model-override 文件无末尾换行符

**Why:** 确保所有新功能和现有功能正常工作。
**Verify:** 所有场景输出正确，文件内容符合预期。

## Design Decisions
- `--model` 写入时覆盖 template 自带的 model-override（部署参数优先于 template 默认值）
- model-override 文件不包含末尾换行符（与现有 `/model` 命令写入格式一致，`echo -n` 保证）
- 不指定 `--model` 时保持 template 自带的 model-override 不变
- 参数顺序：`<target_dir> [template_name] [--model <model-id>]`，`--model` 放在最后方便解析