### PR TITLE
feat: 优化Dockerfile加速构建（dummy main缓存依赖）

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,9 +44,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
-COPY src/ src/
-COPY config.example.toml ./
 
+RUN mkdir src && echo 'fn main() {}' > src/main.rs \
+    && cargo build --release
+
+RUN rm -rf src target/release/deps/jyc* target/release/jyc* target/release/.fingerprint/jyc*
+
+COPY src/ src/
 RUN cargo build --release
 
 # ── Stage 3: Production image ────────────────────────────────────────


### PR DESCRIPTION
## Spec

优化 `docker/Dockerfile` 的 builder 阶段，使用 dummy main 技巧将依赖编译与应用编译分离，使源码变动时不再重新编译所有依赖，构建时间从数分钟降至十几秒。

Fixes #57

## Implementation Plan

### Step 1: 重构 builder 阶段为两步构建
**What:** 修改 `docker/Dockerfile` 的 `FROM rust:bookworm AS builder` 阶段，将原来的单步构建拆分为：
1. 先 `COPY Cargo.toml Cargo.lock`，创建空 `src/main.rs`（`mkdir src && echo "fn main() {}" > src/main.rs`），执行 `cargo build --release` — 此步只编译依赖，生成 Docker layer 缓存
2. 再删除 dummy 产物（`rm -rf src`），`COPY src/ src/`，再次执行 `cargo build --release` — 此步增量编译项目代码

同时移除 builder 阶段中不必要的 `COPY config.example.toml ./`（它不是 Rust 编译输入）。

**Why:** 当前 Dockerfile 在源码变动时 `COPY src/` 层缓存失效，导致 `cargo build --release` 重新编译所有依赖。dummy main 技巧使依赖编译成为一个独立 layer，只要 `Cargo.toml`/`Cargo.lock` 不变就命中缓存。

**Verify:** 
```bash
# 构建两次，第二次只改源码，观察依赖层命中缓存
podman build -t jyc:test -f docker/Dockerfile ..
# 修改 src/main.rs 加一行注释
podman build -t jyc:test -f docker/Dockerfile ..
# 第二次构建应看到 dependency layer "CACHED"，只有源码COPY和cargo build重新执行
```

### Step 2: 清理 dummy build 产生的冗余 target 产物
**What:** 在真实源码 COPY 之前，清理 dummy build 的中间产物以避免干扰：
```dockerfile
RUN rm -rf target/release/deps/jyc* target/release/jyc* target/release/.fingerprint/jyc*
```

**Why:** dummy main 编译会产生一个空的 `jyc` 二进制和对应的 fingerprint，清理后确保真实编译是干净的增量构建，不会复用 dummy 的编译指纹。

**Verify:** 构建完成后运行 `docker run --rm jyc:test --help`，确认二进制正常工作。

## Design Decisions
- 仅采用方案 A（dummy main），不使用方案 B（BuildKit cache mount），因为项目依赖变动不频繁，layer 缓存已足够
- 移除 builder 阶段 `COPY config.example.toml` — 该文件不属于编译输入
- 使用 `rm -rf src` + 重新 COPY 的方式替换 dummy src，确保干净