### PR TITLE
fix: 重构github-developer模板，使developer持续响应修改指令

### DIFF
--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -7,6 +7,7 @@
 - **NEVER merge the PR — that's the user's decision**
 - **You MUST push code to the EXISTING PR branch, not create a new one**
 - **You MUST commit and push after EACH plan step — NEVER implement all steps then commit once**
+- **NEVER assume your work is "done" — you are a persistent, always-responsive agent. Every `@j:developer` trigger is a new, independent task.**
 
 You are a developer agent for GitHub PRs.
 
@@ -20,10 +21,6 @@ Examples:
 - `[Planner] @j:developer Please implement according to the plan above` → implement the full plan
 - `[Reviewer] @j:developer fix error handling` → fix error handling
 - `@j:developer` (bare mention) → read PR comments for context
-
-**NEVER assume your work is "done".** Even if the code is already committed,
-the triggering comment may ask for improvements, comments, refactoring, or fixes.
-Do what the comment says.
 
 ## Repository Setup
 Clone the repository from the trigger message to `repo/` if not already present,
@@ -75,36 +72,52 @@ gh pr view <number> --comments
 
 Read the triggering comment at the bottom of the incoming message.
 
-**If the comment asks for a specific task** (add comments, fix something, refactor, etc.):
-1. Do that specific task
-2. Run `{check_command}` to verify
-3. Commit and push:
-   ```bash
-   git add -A && git commit -m "fix: <what was done>" && git push
-   ```
-4. Reply on the PR:
-   ```bash
-   gh pr comment <number> --body "[Developer] Done: <summary of what was changed>"
-   ```
-5. **STOP. Do NOT request review. Do NOT post @j:reviewer.**
+1. **Analyze the task**: Determine what the comment asks for
+   - If it's implementing the full implementation plan → treat as planner task
+   - Otherwise → treat as specific task (fix, add comments, refactor, etc.)
 
-**If the comment asks to implement the full plan** (typically from planner):
-1. Read the Implementation Plan from the PR body
-2. For each step in the plan:
-   - Implement the step
-   - Run `{check_command}` and `{test_command}`
-   - Commit: `git add -A && git commit -m "feat: step N - <title>" && git push`
-   - **Push after each step — do NOT batch**
-3. After all steps: run full `{test_command}` and `{build_command}`
-4. Mark PR ready: `gh pr ready <number>`
-5. Hand off to reviewer:
-   ```bash
-   gh pr comment <number> --body "[Developer] @j:reviewer Implementation complete. Ready for review.
+2. **Execute the task**:
+   - If implementing full plan: iterate through each step
+     - Implement the step
+     - Run `{check_command}` and `{test_command}` to verify
+     - Commit: `git add -A && git commit -m "feat: step N - <title>" && git push`
+     - **Push after each step — do NOT batch**
+   - If specific task: do what the comment asks
+     - Run `{check_command}` to verify
 
-   Commits:
-   $(git log main..HEAD --oneline)
-   "
+3. **Commit and push**:
+   ```bash
+   git add -A && git commit -m "<type>: <what>" && git push
    ```
+   Where `<type>` is:
+   - `feat: step N - <title>` for implementation plan steps
+   - `fix: <what was fixed>` for reviewer feedback fixes
+   - `refactor: <what>` for refactoring tasks
+   - `docs: <what>` for documentation tasks
+   - Other semantic commit types as appropriate
+
+4. **Reply on the PR**:
+   ```bash
+   gh pr comment <number> --body "[Developer] Done: <summary of what was done>"
+   ```
+
+5. **Wait for the next `@j:developer` trigger**
+
+## Hand-off Rules
+
+When to trigger `@j:reviewer`:
+- ONLY after completing the FULL implementation plan from a planner-created PR
+- Post: `gh pr comment <number> --body "[Developer] @j:reviewer Implementation complete. Ready for review."`
+- Then mark PR ready: `gh pr ready <number>`
+
+When NOT to trigger `@j:reviewer`:
+- After fixing reviewer feedback (reviewer already knows — they will re-review)
+- After adding comments, refactoring, or any task requested by a non-planner comment
+- In these cases, just reply "[Developer] Done: ..." and wait
+
+When to trigger `@j:reviewer` after fixing reviewer feedback:
+- If the reviewer explicitly asks you to re-trigger review (e.g., "@j:developer fix X and then re-submit for review")
+- Otherwise, just reply "[Developer] Done: ..." — the reviewer will re-review when ready
 
 ## Rules
 - **#1 RULE: Do what the triggering comment says.** This overrides everything else.
@@ -113,9 +126,9 @@ Read the triggering comment at the bottom of the incoming message.
 - ALWAYS run `{check_command}` before each commit
 - ALWAYS commit and push after EACH plan step
 - ALWAYS prefix PR comments with `[Developer]`
-- NEVER request review (`@j:reviewer`) unless you just completed the full implementation plan
 - NEVER implement multiple plan steps before committing
-- NEVER assume work is done — the triggering comment tells you what to do
+- You are ALWAYS responsive — every `@j:developer` trigger is an independent task, regardless of what you did before
+- After completing any task, reply with "[Developer] Done: ..." and wait for the next trigger
 - When using the reply tool, put your COMPLETE response in the message
 - Do NOT create new PRs or branches
 - Do NOT merge the PR


### PR DESCRIPTION
## Spec

重构 `templates/github-developer/AGENTS.md`，修复 developer 在完成初始实现后不再响应后续修改指令的 bug。当前模板的工作流结构暗示 developer 的工作是"一次性"的（Path 1 有 STOP，Path 2 handoff 后无后续），导致 reviewer 用 `@j:developer` 要求修改时 developer 可能认为自己已完成。修复后，developer 将作为持久响应的 agent，每次 `@j:developer` 触发都独立执行任务。

Fixes #59

## Implementation Plan

### Step 1: 重写顶部 CRITICAL RESTRICTIONS 区域
**What:** 修改 `templates/github-developer/AGENTS.md` 的 CRITICAL RESTRICTIONS 部分，新增一条：**NEVER assume your work is "done" — you are a persistent, always-responsive agent. Every `@j:developer` trigger is a new, independent task.** 并将原有的 "NEVER assume work is done" 从 Rules 移到此顶部区域，与 CRITICAL RESTRICTIONS 合并。
**Why:** 当前顶部 CRITICAL RESTRICTIONS 只关注不创建 PR、不合并等限制，没有强调 developer 是持久 agent 的核心语义。将此置于顶部可确保 AI 在处理任何逻辑前先建立正确的心智模型。
**Verify:** 检查 CRITICAL RESTRICTIONS 列表包含新规则，且 Rules 中不再重复。

### Step 2: 重构 Workflow Section 3 — 合并两条路径为统一流程
**What:** 将当前 Workflow Section 3 中的两条分支路径：
- "If the comment asks for a specific task" (Path 1)
- "If the comment asks to implement the full plan" (Path 2)

合并为统一的流程：
1. 读取触发评论（triggering comment at the bottom of incoming message）
2. 执行评论所要求的任务
3. 运行 `{check_command}` 验证
4. 提交并推送：`git add -A && git commit -m "<type>: <what>" && git push`
5. 回复 PR：`gh pr comment <number> --body "[Developer] Done: <summary>"`
6. 等待下一个 `@j:developer` 触发

**Why:** 两条路径的分裂是 bug 的核心原因。Path 1 的 STOP 和 Path 2 的 handoff 都暗示"结束"，与 developer 应持续响应的语义矛盾。统一流程让每次触发都走相同路径，消除歧义。
**Verify:** 确认 Workflow Section 3 不再有 "If...Else" 分支，只有一个线性步骤列表。

### Step 3: 新增 "Hand-off Rules" 子部分
**What:** 在 Workflow Section 3 之后新增一个 "Hand-off Rules" 部分：
```
## Hand-off Rules

When to trigger @j:reviewer:
- ONLY after completing the FULL implementation plan from a planner-created PR
- Post: gh pr comment <number> --body "[Developer] @j:reviewer Implementation complete. Ready for review."
- Then mark PR ready: gh pr ready <number>

When NOT to trigger @j:reviewer:
- After fixing reviewer feedback (reviewer already knows — they will re-review)
- After adding comments, refactoring, or any task requested by a non-planner comment
- In these cases, just reply "[Developer] Done: ..." and wait

When to trigger @j:reviewer after fixing reviewer feedback:
- If the reviewer explicitly asks you to re-trigger review (e.g., "@j:developer fix X and then re-submit for review")
- Otherwise, just reply "[Developer] Done: ..." — the reviewer will re-review when ready
```
**Why:** 当前模板没有 hand-off 规则，developer 在 reviewer 反馈后不知道是否应该再次触发 reviewer。明确的规则消除歧义。
**Verify:** 确认 Hand-off Rules 部分存在且覆盖三种场景。

### Step 4: 更新 Rules 部分 — 移除矛盾规则，添加一致规则
**What:** 修改 Rules 部分：
- 移除 "NEVER assume work is done — the triggering comment tells you what to do"（已移至 CRITICAL RESTRICTIONS）
- 移除 "NEVER request review (@j:reviewer) unless you just completed the full implementation plan"（已移至 Hand-off Rules）
- 新增："You are ALWAYS responsive — every @j:developer trigger is an independent task, regardless of what you did before"
- 新增："After completing any task, reply with [Developer] Done: ... and wait for the next trigger"
- 保留其他不冲突的规则
**Why:** Rules 与 CRITICAL RESTRICTIONS 和 Hand-off Rules 应保持一致，不重复不矛盾。
**Verify:** 确认 Rules 列表中没有与 Hand-off Rules 矛盾的条目。

### Step 5: 更新 commit message 格式
**What:** 在统一流程中明确 commit message 格式：
- 实现计划步骤：feat: step N - <title>（保留原有格式）
- 修复 reviewer 反馈：fix: <what was fixed>
- 其他任务：<type>: <what was done> 其中 type 根据 semantic commit 规范选择
**Why:** 当前只有计划步骤的 commit 格式，其他场景缺少指导。
**Verify:** 确认 commit message 格式覆盖所有场景。

## Design Decisions
- **不修改 Rust 代码**：路由逻辑（inbound.rs）和线程管理（thread_manager.rs）已正确支持 developer 持续响应，bug 纯粹在模板指令层面
- **统一流程优于分支路径**：每次触发走相同流程，消除"我该走哪条路径"的歧义
- **Hand-off Rules 独立成节**：比嵌入 Workflow 更清晰，便于 developer 快速查阅
- **"Done" 而非 "STOP"**：语义从"结束"变为"完成当前任务，等待下一个"，与持久 agent 语义一致