### PR TITLE
feat: add coding-principles skill and integrate with templates

### DIFF
--- a/.opencode/skills/coding-principles/SKILL.md
+++ b/.opencode/skills/coding-principles/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: coding-principles
+description: |
+  Andrej Karpathy's 4 coding principles for LLM agents: Think Before Coding, Simplicity First,
+  Surgical Changes, Goal-Driven Execution. Use when writing code, planning, or reviewing code
+  to reduce common LLM coding mistakes.
+---
+
+## Coding Principles
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+### 1. Think Before Coding
+
+Don't assume. Don't hide confusion. Surface tradeoffs.
+
+Before implementing:
+
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### 2. Simplicity First
+
+Minimum code that solves the problem. Nothing speculative.
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+- Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+
+Touch only what you must. Clean up only your own mess.
+
+When editing existing code:
+
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it — don't delete it.
+
+When your changes create orphans:
+
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+**The test:** Every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+
+Define success criteria. Loop until verified.
+
+Transform tasks into verifiable goals:
+
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+
+**Strong success criteria** let you loop independently. **Weak criteria** ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/.opencode/skills/incremental-dev/SKILL.md
+++ b/.opencode/skills/incremental-dev/SKILL.md
@@ -49,6 +49,13 @@ After detection, you have three commands for the rest of this workflow:
 - `{test_command}` — run tests
 - `{build_command}` — full production build (run only once at the end)
 
+### Coding Principles
+
+Follow the `coding-principles` skill for behavioral guidelines, especially:
+- **Principle 2 (Simplicity First)**: Write minimum code that solves the problem
+- **Principle 3 (Surgical Changes)**: Touch only what you must; every changed line should trace to user's request
+- **Principle 4 (Goal-Driven Execution)**: Define verifiable success criteria per step
+
 ### Principle
 
 Break every task into the smallest possible steps. Each step must be:

--- a/.opencode/skills/plan-solution/SKILL.md
+++ b/.opencode/skills/plan-solution/SKILL.md
@@ -18,6 +18,9 @@ When asked to plan a solution, follow this structure:
   - `.opencode/skills/` or `.claude/` — project-specific workflows
 - Read relevant source code (use `read`, `glob`, `grep` — NOT `task` tool)
 - Summarize your understanding in 2-3 sentences
+- Follow the `coding-principles` skill:
+  - **Principle 1 (Think Before Coding)**: State assumptions explicitly; if uncertain, ask
+  - **Principle 4 (Goal-Driven Execution)**: Define verifiable success criteria for each step
 
 ### 2. Create Implementation Plan
 Break the solution into the smallest possible steps. Each step must:

--- a/.opencode/skills/pr-review/SKILL.md
+++ b/.opencode/skills/pr-review/SKILL.md
@@ -76,6 +76,11 @@ cd repo && git diff main..<branch>
 - Consistent naming conventions
 - Dead code cleaned up
 
+**Coding principles** (check against `coding-principles` skill):
+- **Principle 2 (Simplicity First)**: Flag overcomplication — code beyond what was asked, unnecessary abstractions
+- **Principle 3 (Surgical Changes)**: Flag unnecessary changes — "improvements" to unrelated code, style changes
+- **Principle 4 (Goal-Driven Execution)**: Check goal traceability — every changed line should trace to user's request
+
 **Documentation:**
 - CHANGELOG.md updated for user-facing changes
 - DESIGN.md updated for architecture changes (if the project has one)

--- a/deploy-templates.sh
+++ b/deploy-templates.sh
@@ -66,11 +66,11 @@ fi
 get_skills() {
     case "$1" in
         invoice-processing)   echo "invoice-processing" ;;
-        jyc-dev)              echo "plan-solution dev-workflow incremental-dev jyc-deploy-bare" ;;
-        jyc-review)           echo "pr-review" ;;
-        github-planner)       echo "dev-workflow" ;;
-        github-developer)     echo "incremental-dev dev-workflow" ;;
-        github-reviewer)      echo "pr-review" ;;
+        jyc-dev)              echo "coding-principles plan-solution dev-workflow incremental-dev jyc-deploy-bare" ;;
+        jyc-review)           echo "coding-principles pr-review" ;;
+        github-planner)       echo "coding-principles dev-workflow" ;;
+        github-developer)     echo "coding-principles incremental-dev dev-workflow" ;;
+        github-reviewer)      echo "coding-principles pr-review" ;;
         *)                    echo "" ;;
     esac
 }

--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -133,3 +133,7 @@ When to trigger `@j:reviewer` after fixing reviewer feedback:
 - Do NOT create new PRs or branches
 - Do NOT merge the PR
 - Do NOT use the `jyc_question_ask_user` tool
+
+## Behavioral Guidelines
+
+Follow the `coding-principles` skill for behavioral guidelines when writing code.

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -187,3 +187,7 @@ gh pr comment <pr_number> --body "[Planner] @j:developer Please implement accord
 - Your PR must contain ZERO code changes — only the spec in the PR body
 - Your implementation plan must break the work into small, ordered steps — each with a clear verification method
 - NEVER write vague steps like "implement the feature" — always reference specific files, functions, and types
+
+## Behavioral Guidelines
+
+Follow the `coding-principles` skill — especially Principle 1 (Think Before Coding) and Principle 4 (Goal-Driven Execution).

--- a/templates/github-reviewer/AGENTS.md
+++ b/templates/github-reviewer/AGENTS.md
@@ -77,6 +77,7 @@ Check for:
 - **Edge cases**: Missing error handling, boundary conditions
 - **Project conventions**: Does the code follow the project's own rules (from AGENTS.md etc.)?
 - **Commit structure**: Does each commit correspond to one step from the Implementation Plan? Are commit messages clear and descriptive? Flag commits that combine unrelated changes or skip steps.
+- **Coding principles**: Check against the `coding-principles` skill — flag overcomplication (P2) and unnecessary changes (P3)
 
 ### 5. Submit Review
 If changes needed:

--- a/templates/jyc-dev/AGENTS.md
+++ b/templates/jyc-dev/AGENTS.md
@@ -8,6 +8,7 @@ You are developing the JYC project itself (self-bootstrapping).
 
 ## Environment
 This is a bare metal deployment using systemd for process supervision.
+- Use the `coding-principles` skill for behavioral guidelines
 - Use the plan-solution skill for plan solution
 - Use the dev-workflow skill for development
 - Use the `incremental-dev` skill for implementation


### PR DESCRIPTION
## Spec

Add the Andrej Karpathy 4 coding principles (Think Before Coding, Simplicity First, Surgical Changes, Goal-Driven Execution) as a shared `.opencode/skills/coding-principles/SKILL.md`, then reference it from all relevant templates and skills — avoiding copy-paste duplication. Update `deploy-templates.sh` to bundle the new skill with each template that needs it.

Fixes #61

## Implementation Plan

### Step 1: Create coding-principles skill
**What:** Create `.opencode/skills/coding-principles/SKILL.md` with YAML front matter and the full 4 principles text from issue #61
**Why:** Single source of truth for the principles — all other files reference this
**Verify:** File exists, front matter has `name: coding-principles` and valid description

### Step 2: Update deploy-templates.sh get_skills()
**What:** Add `coding-principles` to the skill list for: `jyc-dev`, `jyc-review`, `github-planner`, `github-developer`, `github-reviewer`. Do NOT add for `invoice-processing`.
**Why:** The deploy script is the binding layer between templates and skills — without this, the skill won't be deployed
**Verify:** Run `bash deploy-templates.sh /tmp/test-deploy && ls /tmp/test-deploy/*/coding-principles/SKILL.md` — expect 5 files

### Step 3: Update incremental-dev/SKILL.md
**What:** Add reference to `coding-principles` skill before the `### Principle` section, highlighting Principles 2/3/4. Remove redundant content from the Principle section that duplicates coding-principles (e.g. "each step must be independently verifiable"). Keep incremental-dev-specific content (interactive/autonomous modes, commit/push flow).
**Why:** incremental-dev overlaps with Principle 4 (Goal-Driven Execution) — reference instead of duplicate
**Verify:** No duplicated content between the two skills; incremental-dev still has its unique flow details

### Step 4: Update plan-solution/SKILL.md
**What:** Add reference to `coding-principles` skill in `### 1. Understand the Requirement`, highlighting Principle 1 (Think Before Coding) and Principle 4 (Goal-Driven Execution)
**Why:** Planning benefits most from explicit assumption-stating and verifiable success criteria
**Verify:** plan-solution references coding-principles for Principles 1 and 4

### Step 5: Update pr-review/SKILL.md
**What:** Add coding principles check in `### Step 3: Review Against Project Standards` under General code quality: check overcomplication (P2), unnecessary changes (P3), goal traceability (P4)
**Why:** Reviewers should flag violations of these principles
**Verify:** pr-review includes checks against coding-principles P2/P3/P4

### Step 6: Update templates/github-developer/AGENTS.md
**What:** Add line: `Follow the \`coding-principles\` skill for behavioral guidelines when writing code`
**Why:** Developer agents write code and need all 4 principles
**Verify:** AGENTS.md mentions coding-principles

### Step 7: Update templates/github-planner/AGENTS.md
**What:** Add line: `Follow the \`coding-principles\` skill — especially Principle 1 (Think Before Coding) and Principle 4 (Goal-Driven Execution)`
**Why:** Planner agents benefit from explicit assumptions and verifiable plans
**Verify:** AGENTS.md mentions coding-principles

### Step 8: Update templates/github-reviewer/AGENTS.md
**What:** Add in `### 4. Review the Code`: `**Coding principles**: Check against the \`coding-principles\` skill — flag overcomplication (P2) and unnecessary changes (P3)`
**Why:** Reviewers should check for principle violations
**Verify:** AGENTS.md mentions coding-principles

### Step 9: Update templates/jyc-dev/AGENTS.md
**What:** Add line: `Use the \`coding-principles\` skill for behavioral guidelines`
**Why:** JYC dev agents write code and need the principles
**Verify:** AGENTS.md mentions coding-principles

## Design Decisions
- Single source of truth: principles defined once in `coding-principles/SKILL.md`, all others reference it
- `deploy-templates.sh` is the binding layer — must be updated to deploy the skill
- `invoice-processing` and `jyc-deploy-bare` templates do NOT get coding-principles (domain-specific, not general coding)
- `dev-workflow` skill is NOT modified (it covers branching/releases, not coding behavior)
- incremental-dev has overlap with Principle 4 — reference rather than duplicate