### PR TITLE
fix: developer agent在main分支提交而非PR分支

### DIFF
--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -8,6 +8,7 @@
 - **You MUST push code to the EXISTING PR branch, not create a new one**
 - **You MUST commit and push after EACH plan step — NEVER implement all steps then commit once**
 - **NEVER assume your work is "done" — you are a persistent, always-responsive agent. Every `@j:developer` trigger is a new, independent task.**
+- **NEVER commit or push on the main branch — you MUST be on the PR branch first**
 
 You are a developer agent for GitHub PRs.
 

--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -65,6 +65,13 @@ gh pr view <number> --json state,merged --jq '"state=\(.state) merged=\(.merged)
 cd repo
 gh pr checkout <number>
 git pull
+# Verify we are NOT on main
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
+  echo "FATAL: Still on main/master branch after checkout! Refusing to proceed."
+  echo "Current branch: $CURRENT_BRANCH"
+  exit 1
+fi
 gh pr view <number>
 gh pr view <number> --comments
 ```

--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -88,13 +88,26 @@ Read the triggering comment at the bottom of the incoming message.
    - If implementing full plan: iterate through each step
      - Implement the step
      - Run `{check_command}` and `{test_command}` to verify
-     - Commit: `git add -A && git commit -m "feat: step N - <title>" && git push`
+      - Commit: 
+        ```bash
+        # Guard: never commit on main
+        if [ "$(git branch --show-current)" = "main" ] || [ "$(git branch --show-current)" = "master" ]; then
+          echo "FATAL: Refusing to commit on main/master branch. Run 'gh pr checkout <number>' first."
+          exit 1
+        fi
+        git add -A && git commit -m "feat: step N - <title>" && git push
+        ```
      - **Push after each step — do NOT batch**
    - If specific task: do what the comment asks
      - Run `{check_command}` to verify
 
 3. **Commit and push**:
    ```bash
+   # Guard: never commit on main
+   if [ "$(git branch --show-current)" = "main" ] || [ "$(git branch --show-current)" = "master" ]; then
+     echo "FATAL: Refusing to commit on main/master branch. Run 'gh pr checkout <number>' first."
+     exit 1
+   fi
    git add -A && git commit -m "<type>: <what>" && git push
    ```
    Where `<type>` is:

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -8,6 +8,7 @@
 - **NEVER create, edit, or delete ANY files**
 - **NEVER run tests or builds**
 - **You are a PLANNER, not a developer. You ONLY discuss and create PRs.**
+- **NEVER commit or push on the main branch — you MUST be on the PR branch first**
 
 You are a planner/designer agent for GitHub issues. Your role is to discuss
 requirements with the user and create a PR when the plan is clear.
@@ -112,6 +113,11 @@ Use your codebase analysis to write concrete steps, not vague descriptions.
 cd repo
 git checkout main && git pull
 git checkout -b feat/issue-<number>
+# Verify branch
+if [ "$(git branch --show-current)" = "main" ]; then
+  echo "FATAL: Branch creation failed, still on main."
+  exit 1
+fi
 # Push the empty branch (NO code changes, NO file creation)
 git push -u origin feat/issue-<number>
 


### PR DESCRIPTION
## Spec

Developer agent（特别是使用弱LLM模型如 minimax-m2.5 时）有时不执行 `gh pr checkout`，直接在 main 分支上做修改和提交。需要在 developer 模板中增加分支守卫，确保所有 commit/push 都发生在 PR 分支上。

Fixes #65

## Implementation Plan

### Step 1: 在 CRITICAL RESTRICTIONS 中增加 main 分支禁令
**What:** 在 `templates/github-developer/AGENTS.md` 顶部的 `⚠️ CRITICAL RESTRICTIONS` 列表中新增一条：
```
- **NEVER commit or push on the main branch — you MUST be on the PR branch first**
```
**Why:** CRITICAL RESTRICTIONS 是所有 LLM 模型最优先遵守的规则，将其放在最显眼的位置，即使弱模型也能注意到。
**Verify:** 检查 `templates/github-developer/AGENTS.md` 的 CRITICAL RESTRICTIONS 部分包含该禁令。

### Step 2: 添加 checkout 后的分支验证（分支守卫）
**What:** 在 `templates/github-developer/AGENTS.md` 的 Workflow Step 2（Checkout and Read）中，在 `gh pr checkout <number>` 和 `git pull` 之后，增加分支验证逻辑：
```bash
# Verify we are NOT on main
CURRENT_BRANCH=$(git branch --show-current)
if [ "$CURRENT_BRANCH" = "main" ] || [ "$CURRENT_BRANCH" = "master" ]; then
  echo "FATAL: Still on main/master branch after checkout! Refusing to proceed."
  echo "Current branch: $CURRENT_BRANCH"
  exit 1
fi
```
**Why:** checkout 后立即验证，如果 `gh pr checkout` 静默失败或被跳过，能立刻发现问题并阻止后续操作。
**Verify:** 检查 `templates/github-developer/AGENTS.md` 的 Checkout and Read 步骤包含分支验证代码块。

### Step 3: 添加 commit/push 前的分支保护（推送守卫）
**What:** 在 `templates/github-developer/AGENTS.md` 的 Workflow Step 3 的 commit 命令中，在 `git add -A && git commit` 之前插入分支检查：
```bash
# Guard: never commit on main
if [ "$(git branch --show-current)" = "main" ] || [ "$(git branch --show-current)" = "master" ]; then
  echo "FATAL: Refusing to commit on main/master branch. Run 'gh pr checkout <number>' first."
  exit 1
fi
git add -A && git commit -m "..." && git push
```
**Why:** 这是最关键的防线——即使前面的验证被跳过，在 commit 和 push 之前再次检查，确保不会污染 main 分支。双重保险。
**Verify:** 检查 `templates/github-developer/AGENTS.md` 的 Step 3 中每次 commit 前都包含分支保护检查。

### Step 4: 同样为 planner 模板添加 main 分支保护
**What:** 在 `templates/github-planner/AGENTS.md` 的 CRITICAL RESTRICTIONS 中增加同样的禁令，并在创建分支后验证：
```bash
git checkout -b feat/issue-<number>
# Verify branch
if [ "$(git branch --show-current)" = "main" ]; then
  echo "FATAL: Branch creation failed, still on main."
  exit 1
fi
```
**Why:** planner 也会创建分支和推送，虽然它不写代码，但同样需要确保不在 main 上操作。保持一致性。
**Verify:** 检查 `templates/github-planner/AGENTS.md` 包含分支创建后的验证逻辑。

### Step 5: 运行 `cargo check` 和 `cargo test` 验证
**What:** 运行 `cargo check` 和 `cargo test` 确认模板修改不影响编译和测试。
**Why:** 虽然模板是 Markdown 文件不影响 Rust 编译，但需确认没有意外修改到 Rust 源码。
**Verify:** `cargo check` 无错误，`cargo test` 全部通过。

## Design Decisions
- **双重防线策略**：checkout 后验证 + commit 前验证，确保即使弱模型跳过其中一个，另一个仍能阻止在 main 上提交
- **在 CRITICAL RESTRICTIONS 中增加禁令**：这是模板最显眼的位置，LLM 模型通常会优先遵守顶部的重要限制
- **检查 master 分支**：不仅检查 `main`，也检查 `master`，因为某些仓库可能使用旧命名
- **使用 `exit 1` 而非仅警告**：强制终止流程，不给弱模型继续操作的机会