### PR TITLE
fix: 移除模板中的model-override

### DIFF
--- a/templates/github-developer/.jyc/model-override
+++ b/templates/github-developer/.jyc/model-override
@@ -1,1 +1,0 @@
-ark/deepseek-v3.2

--- a/templates/github-planner/.jyc/model-override
+++ b/templates/github-planner/.jyc/model-override
@@ -1,1 +1,0 @@
-tencent/glm-5.1

--- a/templates/github-reviewer/.jyc/model-override
+++ b/templates/github-reviewer/.jyc/model-override
@@ -1,1 +1,0 @@
-ark/minimax-m2.5


### PR DESCRIPTION
## Spec

移除 templates 目录下三个 GitHub 模板中的 `.jyc/model-override` 文件。这些文件在部署时将模型硬编码到线程目录中，应改为通过 `config.toml` 的 `agent.opencode.model` 统一配置。

Fixes #67

## Implementation Plan

### Step 1: 删除 github-planner 的 model-override
**What:** 删除 `templates/github-planner/.jyc/` 目录（仅含 `model-override` 文件）
**Why:** 移除 planner 模板的硬编码模型配置 `tencent/glm-5.1`
**Verify:** `ls templates/github-planner/` 不再包含 `.jyc` 目录

### Step 2: 删除 github-developer 的 model-override
**What:** 删除 `templates/github-developer/.jyc/` 目录（仅含 `model-override` 文件）
**Why:** 移除 developer 模板的硬编码模型配置 `ark/deepseek-v3.2`
**Verify:** `ls templates/github-developer/` 不再包含 `.jyc` 目录

### Step 3: 删除 github-reviewer 的 model-override
**What:** 删除 `templates/github-reviewer/.jyc/` 目录（仅含 `model-override` 文件）
**Why:** 移除 reviewer 模板的硬编码模型配置 `ark/minimax-m2.5`
**Verify:** `ls templates/github-reviewer/` 不再包含 `.jyc` 目录

### Step 4: 验证无其他模板遗留
**What:** 运行 `find templates -name "model-override"` 确认无残留文件
**Why:** 确保清理完整
**Verify:** 命令无输出

### Step 5: 构建验证
**What:** 运行 `cargo check` 确认代码无编译错误
**Why:** 模板文件不参与编译，但需确认无其他代码引用这些模板路径
**Verify:** 编译通过，无错误

## Design Decisions
- 不修改 `deploy-templates.sh`，保留 `--model` 参数作为部署时动态配置方式
- 运行时 `/model` 命令功能不变，用户仍可在线程中动态切换模型
- 移除后模型将通过 `config.toml` 的 `agent.opencode.model` fallback 获取（`session.rs:235-237`）