### PR TITLE
feat: 修改 GitHub 流程中 planner、developer、reviewer 的触发机制

### DIFF
--- a/GITHUB_CHANNEL.md
+++ b/GITHUB_CHANNEL.md
@@ -13,7 +13,7 @@ repositories through issue discussion, PR development, and code review.
    - **Both mode**: Requires both pattern rules match AND `@j:<role>` mention.
    - Configure via `trigger_mode` field in pattern config (default: `mention` for backward compatibility)
    - Processed comment IDs persisted to `<channel>/.github/processed-comments.txt`
-   - Seen issues persisted to `<channel>/.github/seen-issues.txt` to prevent re-trigger after restart
+   - Seen issues persisted to `<channel>/.github/seen-issues.txt` to prevent re-trigger after restart (tracked by number:labels:updated_at)
 3. **One Token, Role Prefix + Self-Loop Prevention** — Single GitHub PAT. Agents
    prefix comments with `[Planner]`, `[Developer]`, `[Reviewer]`. Each pattern
    only skips comments from its **own** role (self-loop prevention), but allows
@@ -213,7 +213,7 @@ All comments are routed (not just those with mentions) to enable Pattern mode ma
 Self-loop prevention still applies: an agent's own comments (identified by `[Role]` prefix) don't re-trigger that same agent.
 
 Processed comment IDs are persisted to `<channel>/.github/processed-comments.txt`.
-Seen issues are persisted to `<channel>/.github/seen-issues.txt` to prevent re-triggering after restart.
+Seen issues are persisted to `<channel>/.github/seen-issues.txt` to prevent re-triggering after restart. Issues are tracked by `{number}:{labels}:{updated_at}` — note that if labels change without updating the issue's `updated_at`, re-triggering may not occur.
 
 ### Configuration Example
 

--- a/GITHUB_CHANNEL.md
+++ b/GITHUB_CHANNEL.md
@@ -7,12 +7,13 @@ repositories through issue discussion, PR development, and code review.
 
 1. **Channel = Lightweight Trigger + Router** — Channel only polls events and
    routes them. Agents use `gh` CLI to read/write actual content.
-2. **Mention-Based Routing** — Routing is driven by `@j:<role>` mentions in comments:
-   - A comment containing `@j:planner` triggers the Planner agent
-   - A comment containing `@j:developer` triggers the Developer agent
-   - A comment containing `@j:reviewer` triggers the Reviewer agent
-   - Comments without `@j:<role>` are ignored (no routing)
-   - Processed comment IDs are persisted to `<channel>/.github/processed-comments.txt`
+2. **Flexible Trigger Modes** — Routing can be triggered by:
+   - **Pattern mode** (default for Planner/Developer): Pattern rules alone trigger (labels, github_type, assignees). No `@j:<role>` mention required.
+   - **Mention mode**: Requires `@j:<role>` mention in comment. Pattern rules are optional.
+   - **Both mode**: Requires both pattern rules match AND `@j:<role>` mention.
+   - Configure via `trigger_mode` field in pattern config (default: `mention` for backward compatibility)
+   - Processed comment IDs persisted to `<channel>/.github/processed-comments.txt`
+   - Seen issues persisted to `<channel>/.github/seen-issues.txt` to prevent re-trigger after restart
 3. **One Token, Role Prefix + Self-Loop Prevention** — Single GitHub PAT. Agents
    prefix comments with `[Planner]`, `[Developer]`, `[Reviewer]`. Each pattern
    only skips comments from its **own** role (self-loop prevention), but allows
@@ -159,8 +160,23 @@ pub struct PatternRules {
     // GitHub-specific
     pub github_type: Option<Vec<String>>,    // ["issue"] or ["pull_request"]
     pub labels: Option<Vec<String>>,          // ["bug", "custom-label"]
+    pub assignees: Option<Vec<String>>,       // ["alice", "bob"]
 }
 ```
+
+### Trigger Mode
+
+Each pattern has a `trigger_mode` field controlling when it matches:
+
+| Mode | Description |
+|------|-------------|
+| `pattern` | Only pattern rules (github_type, labels, assignees) need to match. No `@j:<role>` mention required. |
+| `mention` | Only `@j:<role>` mention triggers. Pattern rules are optional. (default for backward compatibility) |
+| `both` | Both pattern rules match AND `@j:<role>` mention required. |
+
+**Recommended configuration:**
+- Planner/Developer patterns: `trigger_mode = "pattern"` (auto-trigger on new issues/PRs)
+- Reviewer pattern: `trigger_mode = "both"` (require both label + explicit @j:reviewer)
 
 ### Auto-Label from Role
 
@@ -187,11 +203,17 @@ on the issue/PR.
 
 ### Routing
 
-Routing is mention-driven. Only comments containing `@j:<role>` trigger agents.
-Comments without mentions are ignored. Processed comment IDs are persisted to
-`<channel>/.github/processed-comments.txt` to survive restarts.
+Routing behavior depends on the pattern's `trigger_mode`:
 
-Matching logic: `handover_role` from `@j:<role>` mention + self-loop check
+- **Pattern mode**: Messages matching github_type/labels/assignees rules trigger immediately. No `@j:<role>` mention needed.
+- **Mention mode**: Requires `@j:<role>` mention in comment. Pattern rules are optional filters.
+- **Both mode**: Requires both pattern rules match AND `@j:<role>` mention.
+
+All comments are routed (not just those with mentions) to enable Pattern mode matching.
+Self-loop prevention still applies: an agent's own comments (identified by `[Role]` prefix) don't re-trigger that same agent.
+
+Processed comment IDs are persisted to `<channel>/.github/processed-comments.txt`.
+Seen issues are persisted to `<channel>/.github/seen-issues.txt` to prevent re-triggering after restart.
 
 ### Configuration Example
 
@@ -300,48 +322,51 @@ gh pr edit 43 --add-label "jyc:develop"
 
 **Thread**: `issue-{N}`
 **Role**: Discuss requirements with user, create PR with spec when ready.
+**Trigger**: `trigger_mode = "pattern"` (auto-triggered on new issues via labels)
 
 **Workflow**:
-1. Triggered by `@j:planner` in an issue comment
+1. Triggered automatically when issue matches pattern rules (e.g., label `planning`)
 2. Read issue: `gh issue view {N}`
 3. Read comments: `gh issue view {N} --comments`
 4. Discuss with user (reply via jyc_reply → posts issue comment)
 5. When requirements clear:
    - Create branch: `git checkout -b feat/issue-{N}`
    - Create PR: `gh pr create --body "..."`
-   - Post comment: `@j:developer` to trigger developer
+   - Hand over to developer via pattern matching (no @j:developer needed)
 6. Continue monitoring issue for user feedback
 
 ### Agent B: Developer (github-developer)
 
 **Thread**: `pr-{N}`
 **Role**: Implement code based on PR spec, address review feedback.
+**Trigger**: `trigger_mode = "pattern"` (auto-triggered on new PRs via labels)
 
 **Workflow**:
-1. Triggered by `@j:developer` in a PR comment
+1. Triggered automatically when PR matches pattern rules (e.g., label `jyc:develop`)
 2. Read PR spec: `gh pr view {N}`
 3. Read linked issue: `gh issue view {linked_issue}`
 4. Clone repo, checkout PR branch
 5. Implement code (incremental-dev approach)
 6. Commit, push
-7. Hand over: post comment with `@j:reviewer`
-8. When review feedback received (triggered by `@j:developer` from reviewer):
+7. Hand over to reviewer (auto-trigger via pattern rules, no @j:reviewer needed)
+8. When review feedback received:
    - Read reviews: `gh pr view {N} --comments`
    - Fix issues, commit, push
-   - Hand over: post comment with `@j:reviewer`
+   - Hand over to reviewer again
 
 ### Agent C: Reviewer (github-reviewer)
 
 **Thread**: `review-pr-{N}`
 **Role**: Review PR code quality, approve or request changes.
+**Trigger**: `trigger_mode = "both"` (requires both label + @j:reviewer mention)
 
 **Workflow**:
-1. Triggered by `@j:reviewer` in a PR comment
+1. Triggered when PR has review label AND `@j:reviewer` mention
 2. Read PR: `gh pr view {N}`
 3. Read diff: `gh pr diff {N}`
 4. Review code
 5. Submit review: `gh pr review {N} --approve` or `--request-changes`
-6. If changes requested: post comment with `@j:developer`
+6. If changes requested: hand over to developer (auto-trigger via pattern)
 
 ## Close & Cleanup
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -240,34 +240,37 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # poll_interval_secs = 60
 # # api_url = "https://api.github.com"  # Default. For GitHub Enterprise, use: https://github.example.com/api/v3
 #
-# # Pattern: Issues → Planner agent
+# # Pattern: Issues → Planner agent (auto-trigger via pattern matching)
 # [[channels.my_repo.patterns]]
 # name = "planner"
 # enabled = true
 # role = "Planner"
 # template = "github-planner"
+# trigger_mode = "pattern"            # Auto-trigger when issue matches rules
 #
 # [channels.my_repo.patterns.rules]
 # github_type = ["issue"]
 #
-# # Pattern: PRs with 'ready-for-dev' label → Developer agent
+# # Pattern: PRs with 'ready-for-dev' label → Developer agent (auto-trigger)
 # [[channels.my_repo.patterns]]
 # name = "developer"
 # enabled = true
 # role = "Developer"
 # template = "github-developer"
 # live_injection = false
+# trigger_mode = "pattern"            # Auto-trigger when PR matches rules
 #
 # [channels.my_repo.patterns.rules]
 # github_type = ["pull_request"]
 # labels = ["ready-for-dev"]
 #
-# # Pattern: PRs with 'ready-for-review' label → Reviewer agent
+# # Pattern: PRs with 'ready-for-review' label → Reviewer agent (require mention)
 # [[channels.my_repo.patterns]]
 # name = "reviewer"
 # enabled = true
 # role = "Reviewer"
 # template = "github-reviewer"
+# trigger_mode = "both"               # Requires both label + @j:reviewer mention
 #
 # [channels.my_repo.patterns.rules]
 # github_type = ["pull_request"]

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -607,20 +607,11 @@ impl GithubInboundAdapter {
 
             let body_trimmed = comment.body.trim();
 
-            // Extract @j:<role> mention — only route if present
+            // Extract @j:<role> mention
             let handover_role = mention_re
                 .captures(body_trimmed)
                 .and_then(|caps| caps.get(1))
                 .map(|m| m.as_str().to_lowercase());
-
-            let handover_role = match handover_role {
-                Some(role) => role,
-                None => {
-                    // No @j:<role> mention — skip routing, but mark as processed
-                    self.track_comment(&comment_key, processed_comments).await;
-                    continue;
-                }
-            };
 
             // Extract [Role] prefix for self-loop prevention
             let comment_role = extract_comment_role(body_trimmed);
@@ -635,18 +626,7 @@ impl GithubInboundAdapter {
 
             let event_uid = format!("comment-{}", comment.id);
 
-            tracing::info!(
-                channel = %self.channel_name,
-                event = "mention",
-                comment_id = comment.id,
-                issue_number = issue_number,
-                target_role = %handover_role,
-                user = %comment.user.login,
-                body_preview = %truncate_str(&comment.body, 80),
-                "Comment with @j:{} detected → routing", handover_role,
-            );
-
-            // Build trigger message with handover_role metadata
+            // Build trigger message
             let mut message = self.build_trigger_message(
                 "issue_comment",
                 issue_number,
@@ -675,10 +655,33 @@ impl GithubInboundAdapter {
                 None => message.content.text = Some(comment_section),
             }
 
-            message.metadata.insert(
-                "handover_role".to_string(),
-                serde_json::Value::String(handover_role),
-            );
+            // Add handover_role only if @j:<role> mention exists
+            // Pattern mode patterns can match without handover_role
+            if let Some(ref role) = handover_role {
+                message.metadata.insert(
+                    "handover_role".to_string(),
+                    serde_json::Value::String(role.clone()),
+                );
+
+                tracing::info!(
+                    channel = %self.channel_name,
+                    event = "mention",
+                    comment_id = comment.id,
+                    issue_number = issue_number,
+                    target_role = %role,
+                    user = %comment.user.login,
+                    body_preview = %truncate_str(&comment.body, 80),
+                    "Comment with @j:{} detected → routing", role,
+                );
+            } else {
+                tracing::debug!(
+                    channel = %self.channel_name,
+                    comment_id = comment.id,
+                    issue_number = issue_number,
+                    user = %comment.user.login,
+                    "Comment without @j:<role> mention → routing for Pattern mode"
+                );
+            }
 
             if let Some(ref role) = comment_role {
                 message.metadata.insert(

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -7,7 +7,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::channels::types::{
     ChannelMatcher, ChannelPattern, InboundAdapter, InboundAdapterOptions, InboundMessage,
-    MessageContent, PatternMatch, PatternRules,
+    MessageContent, PatternMatch, PatternRules, TriggerMode,
 };
 use crate::utils::helpers::truncate_str;
 use super::client::GithubClient;
@@ -57,32 +57,86 @@ impl ChannelMatcher for GithubMatcher {
         message: &InboundMessage,
         patterns: &[ChannelPattern],
     ) -> Option<PatternMatch> {
-        // Routing is mention-driven: only comments containing @j:<role> trigger agents.
-        // The handover_role metadata is set by poll_once() when @j:<role> is detected.
-        // No mention = no routing.
-        let handover_role = message.metadata.get("handover_role").and_then(|v| v.as_str())?;
+        let handover_role = message.metadata.get("handover_role").and_then(|v| v.as_str());
 
         for pattern in patterns {
             if !pattern.enabled {
                 continue;
             }
-            if let Some(ref role) = pattern.role {
-                if role.eq_ignore_ascii_case(handover_role) {
-                    // Self-loop prevention: skip if comment is from this pattern's own role.
-                    // A [Developer] comment with @j:developer should NOT re-trigger developer.
+
+            let Some(ref pattern_role) = pattern.role else {
+                continue;
+            };
+
+            match pattern.trigger_mode {
+                TriggerMode::Pattern => {
+                    if !self.rules_match(&pattern.rules, message) {
+                        tracing::debug!(
+                            pattern = %pattern.name,
+                            "Pattern mode: rules did not match, skipping"
+                        );
+                        continue;
+                    }
+
                     if let Some(comment_role) = message.metadata.get("comment_role").and_then(|v| v.as_str()) {
-                        if role.eq_ignore_ascii_case(comment_role) {
+                        if pattern_role.eq_ignore_ascii_case(comment_role) {
                             continue;
                         }
                     }
 
-                    // Rule filtering: all present rules must match (AND logic).
-                    // Each individual rule uses OR logic (any value in the list suffices).
+                    return Some(PatternMatch {
+                        pattern_name: pattern.name.clone(),
+                        channel: "github".to_string(),
+                        matches: HashMap::new(),
+                    });
+                }
+                TriggerMode::Mention => {
+                    let Some(role) = handover_role else {
+                        continue;
+                    };
+                    if !pattern_role.eq_ignore_ascii_case(role) {
+                        continue;
+                    }
+
+                    if let Some(comment_role) = message.metadata.get("comment_role").and_then(|v| v.as_str()) {
+                        if pattern_role.eq_ignore_ascii_case(comment_role) {
+                            continue;
+                        }
+                    }
+
                     if !self.rules_match(&pattern.rules, message) {
                         tracing::debug!(
                             pattern = %pattern.name,
                             role = %role,
-                            "Pattern rules did not match, skipping"
+                            "Mention mode: pattern rules did not match, skipping"
+                        );
+                        continue;
+                    }
+
+                    return Some(PatternMatch {
+                        pattern_name: pattern.name.clone(),
+                        channel: "github".to_string(),
+                        matches: HashMap::new(),
+                    });
+                }
+                TriggerMode::Both => {
+                    let Some(role) = handover_role else {
+                        continue;
+                    };
+                    if !pattern_role.eq_ignore_ascii_case(role) {
+                        continue;
+                    }
+
+                    if let Some(comment_role) = message.metadata.get("comment_role").and_then(|v| v.as_str()) {
+                        if pattern_role.eq_ignore_ascii_case(comment_role) {
+                            continue;
+                        }
+                    }
+
+                    if !self.rules_match(&pattern.rules, message) {
+                        tracing::debug!(
+                            pattern = %pattern.name,
+                            "Both mode: pattern rules did not match, skipping"
                         );
                         continue;
                     }

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -338,6 +338,100 @@ impl GithubInboundAdapter {
         }
     }
 
+    /// Load seen issues from persistent storage.
+    /// File format: one line per issue (`{number}:{labels}:{updated_at}`).
+    async fn load_seen_issues(&self) -> HashSet<String> {
+        let file = self.state_dir.join("seen-issues.txt");
+        if !file.exists() {
+            return HashSet::new();
+        }
+        match tokio::fs::read_to_string(&file).await {
+            Ok(content) => {
+                let set: HashSet<String> = content
+                    .lines()
+                    .map(|line| line.trim().to_string())
+                    .filter(|line| !line.is_empty())
+                    .collect();
+                tracing::debug!(
+                    channel = %self.channel_name,
+                    count = set.len(),
+                    "Loaded seen issues"
+                );
+                set
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "Failed to load seen issues, starting fresh"
+                );
+                HashSet::new()
+            }
+        }
+    }
+
+    /// Track a seen issue (append to file).
+    /// Key format: `{number}:{labels}:{updated_at}`
+    async fn track_seen_issue(&self, key: &str, seen: &mut HashSet<String>) {
+        if seen.insert(key.to_string()) {
+            let file = self.state_dir.join("seen-issues.txt");
+            use tokio::io::AsyncWriteExt;
+            if let Ok(mut f) = tokio::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&file)
+                .await
+            {
+                let _ = f.write_all(format!("{key}\n").as_bytes()).await;
+            }
+
+            if seen.len() > 5000 {
+                self.compact_seen_issues(seen).await;
+            }
+        }
+    }
+
+    /// Compact seen issues file by keeping only the latest entries.
+    async fn compact_seen_issues(&self, seen: &mut HashSet<String>) {
+        if seen.len() <= 2000 {
+            return;
+        }
+
+        let mut entries: Vec<(u64, String)> = seen
+            .iter()
+            .map(|key| {
+                let number = key.split(':').next()
+                    .and_then(|s| s.parse::<u64>().ok())
+                    .unwrap_or(0);
+                (number, key.clone())
+            })
+            .collect();
+        entries.sort_unstable_by_key(|(number, _)| *number);
+        let keep_from = entries.len() - 2000;
+        let keep: HashSet<String> = entries[keep_from..]
+            .iter()
+            .map(|(_, key)| key.clone())
+            .collect();
+
+        let before = seen.len();
+        *seen = keep;
+
+        let file = self.state_dir.join("seen-issues.txt");
+        let content: String = seen
+            .iter()
+            .map(|key| format!("{key}\n"))
+            .collect();
+        if let Err(e) = tokio::fs::write(&file, content).await {
+            tracing::warn!(error = %e, "Failed to compact seen issues file");
+        } else {
+            tracing::info!(
+                channel = %self.channel_name,
+                before = before,
+                after = seen.len(),
+                "Compacted seen issues"
+            );
+        }
+    }
+
     /// Build a minimal InboundMessage from a GitHub event.
     /// Contains only trigger metadata — agent uses `gh` CLI for actual content.
     fn build_trigger_message(
@@ -479,6 +573,9 @@ impl InboundAdapter for GithubInboundAdapter {
         // Track processed event IDs for non-comment deduplication (close events)
         let mut processed_events: HashSet<String> = HashSet::new();
 
+        // Load seen issues for deduplication (prevent re-triggering after restart)
+        let mut seen_issues: HashSet<String> = self.load_seen_issues().await;
+
         // Cache issue info for comment routing (number → title, type, labels, assignees)
         let mut issue_cache: HashMap<u64, (String, String, Vec<String>, Vec<String>)> = HashMap::new();
 
@@ -522,6 +619,7 @@ impl InboundAdapter for GithubInboundAdapter {
                         &options,
                         &mut processed_comments,
                         &mut processed_events,
+                        &mut seen_issues,
                         &mut issue_cache,
                         &mut last_poll,
                     ).await {
@@ -550,6 +648,7 @@ impl GithubInboundAdapter {
         options: &InboundAdapterOptions,
         processed_comments: &mut HashSet<String>,
         processed_events: &mut HashSet<String>,
+        seen_issues: &mut HashSet<String>,
         issue_cache: &mut HashMap<u64, (String, String, Vec<String>, Vec<String>)>, // number → (title, type, labels, assignees)
         last_poll: &mut String,
     ) -> Result<()> {
@@ -580,6 +679,14 @@ impl GithubInboundAdapter {
                 issue.number,
                 (issue.title.clone(), github_type.to_string(), labels, assignees),
             );
+
+            // Track seen issues for dedup (prevent re-triggering after restart)
+            let labels_sorted: String = issue.labels.iter()
+                .map(|l| l.name.clone())
+                .collect::<Vec<_>>()
+                .join(",");
+            let seen_key = format!("{}:{}:{}", issue.number, labels_sorted, issue.updated_at);
+            self.track_seen_issue(&seen_key, seen_issues).await;
         }
 
         // 2. Fetch and process comments — only route those with @j:<role> mentions.

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -104,7 +104,9 @@ impl ChannelMatcher for GithubMatcher {
                         }
                     }
 
-                    if !self.rules_match(&pattern.rules, message) {
+                    // In Mention mode, pattern rules are optional (backward compatibility)
+                    // Only check rules if any are actually defined
+                    if self.has_rules_defined(&pattern.rules) && !self.rules_match(&pattern.rules, message) {
                         tracing::debug!(
                             pattern = %pattern.name,
                             role = %role,
@@ -159,6 +161,13 @@ impl ChannelMatcher for GithubMatcher {
 }
 
 impl GithubMatcher {
+    /// Check if any pattern rules are defined (non-empty).
+    fn has_rules_defined(&self, rules: &PatternRules) -> bool {
+        rules.github_type.is_some()
+            || rules.labels.is_some()
+            || rules.assignees.is_some()
+    }
+
     /// Check whether the GitHub-specific rules (github_type, labels, assignees) all match.
     ///
     /// All present rules use AND logic (all must pass).

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -891,6 +891,7 @@ mod tests {
                 name: "planner".to_string(),
                 enabled: true,
                 role: Some("Planner".to_string()),
+                trigger_mode: TriggerMode::Pattern,
                 rules: crate::channels::types::PatternRules {
                     github_type: Some(vec!["issue".to_string()]),
                     ..Default::default()
@@ -901,6 +902,7 @@ mod tests {
                 name: "developer".to_string(),
                 enabled: true,
                 role: Some("Developer".to_string()),
+                trigger_mode: TriggerMode::Pattern,
                 rules: crate::channels::types::PatternRules {
                     github_type: Some(vec!["pull_request".to_string()]),
                     ..Default::default()
@@ -911,6 +913,45 @@ mod tests {
                 name: "reviewer".to_string(),
                 enabled: true,
                 role: Some("Reviewer".to_string()),
+                trigger_mode: TriggerMode::Both,
+                rules: crate::channels::types::PatternRules {
+                    github_type: Some(vec!["pull_request".to_string()]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ]
+    }
+
+    fn make_patterns_mention_mode() -> Vec<ChannelPattern> {
+        vec![
+            ChannelPattern {
+                name: "planner".to_string(),
+                enabled: true,
+                role: Some("Planner".to_string()),
+                trigger_mode: TriggerMode::Mention,
+                rules: crate::channels::types::PatternRules {
+                    github_type: Some(vec!["issue".to_string()]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ChannelPattern {
+                name: "developer".to_string(),
+                enabled: true,
+                role: Some("Developer".to_string()),
+                trigger_mode: TriggerMode::Mention,
+                rules: crate::channels::types::PatternRules {
+                    github_type: Some(vec!["pull_request".to_string()]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ChannelPattern {
+                name: "reviewer".to_string(),
+                enabled: true,
+                role: Some("Reviewer".to_string()),
+                trigger_mode: TriggerMode::Mention,
                 rules: crate::channels::types::PatternRules {
                     github_type: Some(vec!["pull_request".to_string()]),
                     ..Default::default()
@@ -964,9 +1005,8 @@ mod tests {
 
     #[test]
     fn test_no_mention_no_match() {
-        // Comment without @j:<role> → no routing
         let msg = make_message("issue", 42);
-        let patterns = make_patterns();
+        let patterns = make_patterns_mention_mode();
         let result = GithubMatcher.match_message(&msg, &patterns);
         assert!(result.is_none());
     }
@@ -975,7 +1015,7 @@ mod tests {
     fn test_mention_planner_matches() {
         let mut msg = make_message("issue", 42);
         msg.metadata.insert("handover_role".to_string(), serde_json::json!("planner"));
-        let patterns = make_patterns();
+        let patterns = make_patterns_mention_mode();
         let result = GithubMatcher.match_message(&msg, &patterns);
         assert!(result.is_some());
         assert_eq!(result.unwrap().pattern_name, "planner");
@@ -985,7 +1025,7 @@ mod tests {
     fn test_mention_developer_matches() {
         let mut msg = make_message("pull_request", 43);
         msg.metadata.insert("handover_role".to_string(), serde_json::json!("developer"));
-        let patterns = make_patterns();
+        let patterns = make_patterns_mention_mode();
         let result = GithubMatcher.match_message(&msg, &patterns);
         assert!(result.is_some());
         assert_eq!(result.unwrap().pattern_name, "developer");
@@ -995,7 +1035,7 @@ mod tests {
     fn test_mention_reviewer_matches() {
         let mut msg = make_message("pull_request", 43);
         msg.metadata.insert("handover_role".to_string(), serde_json::json!("reviewer"));
-        let patterns = make_patterns();
+        let patterns = make_patterns_mention_mode();
         let result = GithubMatcher.match_message(&msg, &patterns);
         assert!(result.is_some());
         assert_eq!(result.unwrap().pattern_name, "reviewer");
@@ -1005,7 +1045,7 @@ mod tests {
     fn test_mention_case_insensitive() {
         let mut msg = make_message("pull_request", 43);
         msg.metadata.insert("handover_role".to_string(), serde_json::json!("Reviewer"));
-        let patterns = make_patterns();
+        let patterns = make_patterns_mention_mode();
         let result = GithubMatcher.match_message(&msg, &patterns);
         assert!(result.is_some());
         assert_eq!(result.unwrap().pattern_name, "reviewer");
@@ -1015,7 +1055,7 @@ mod tests {
     fn test_mention_unknown_role_no_match() {
         let mut msg = make_message("issue", 42);
         msg.metadata.insert("handover_role".to_string(), serde_json::json!("unknown"));
-        let patterns = make_patterns();
+        let patterns = make_patterns_mention_mode();
         let result = GithubMatcher.match_message(&msg, &patterns);
         assert!(result.is_none());
     }
@@ -1042,33 +1082,30 @@ mod tests {
 
     #[test]
     fn test_self_loop_developer_mention_own_role() {
-        // [Developer] posts "@j:developer" — should NOT re-trigger developer
         let mut msg = make_message("pull_request", 43);
         msg.metadata.insert("handover_role".to_string(), serde_json::json!("developer"));
         msg.metadata.insert("comment_role".to_string(), serde_json::json!("Developer"));
-        let patterns = make_patterns();
+        let patterns = make_patterns_mention_mode();
         let result = GithubMatcher.match_message(&msg, &patterns);
         assert!(result.is_none());
     }
 
     #[test]
     fn test_self_loop_reviewer_mention_own_role() {
-        // [Reviewer] posts "@j:reviewer" — should NOT re-trigger reviewer
         let mut msg = make_message("pull_request", 43);
         msg.metadata.insert("handover_role".to_string(), serde_json::json!("reviewer"));
         msg.metadata.insert("comment_role".to_string(), serde_json::json!("Reviewer"));
-        let patterns = make_patterns();
+        let patterns = make_patterns_mention_mode();
         let result = GithubMatcher.match_message(&msg, &patterns);
         assert!(result.is_none());
     }
 
     #[test]
     fn test_cross_role_reviewer_to_developer() {
-        // [Reviewer] posts "@j:developer" — should trigger developer
         let mut msg = make_message("pull_request", 43);
         msg.metadata.insert("handover_role".to_string(), serde_json::json!("developer"));
         msg.metadata.insert("comment_role".to_string(), serde_json::json!("Reviewer"));
-        let patterns = make_patterns();
+        let patterns = make_patterns_mention_mode();
         let result = GithubMatcher.match_message(&msg, &patterns);
         assert!(result.is_some());
         assert_eq!(result.unwrap().pattern_name, "developer");
@@ -1076,11 +1113,10 @@ mod tests {
 
     #[test]
     fn test_cross_role_developer_to_reviewer() {
-        // [Developer] posts "@j:reviewer" — should trigger reviewer
         let mut msg = make_message("pull_request", 43);
         msg.metadata.insert("handover_role".to_string(), serde_json::json!("reviewer"));
         msg.metadata.insert("comment_role".to_string(), serde_json::json!("Developer"));
-        let patterns = make_patterns();
+        let patterns = make_patterns_mention_mode();
         let result = GithubMatcher.match_message(&msg, &patterns);
         assert!(result.is_some());
         assert_eq!(result.unwrap().pattern_name, "reviewer");
@@ -1109,20 +1145,18 @@ mod tests {
 
     #[test]
     fn test_github_type_rule_blocks_wrong_type() {
-        // Developer pattern requires pull_request, but message is an issue
         let mut msg = make_message("issue", 42);
         msg.metadata.insert("handover_role".to_string(), serde_json::json!("developer"));
-        let patterns = make_patterns();
+        let patterns = make_patterns_mention_mode();
         let result = GithubMatcher.match_message(&msg, &patterns);
         assert!(result.is_none(), "developer pattern should not match issue type");
     }
 
     #[test]
     fn test_github_type_rule_allows_correct_type() {
-        // Planner pattern requires issue, message is an issue
         let mut msg = make_message("issue", 42);
         msg.metadata.insert("handover_role".to_string(), serde_json::json!("planner"));
-        let patterns = make_patterns();
+        let patterns = make_patterns_mention_mode();
         let result = GithubMatcher.match_message(&msg, &patterns);
         assert!(result.is_some());
         assert_eq!(result.unwrap().pattern_name, "planner");
@@ -1620,5 +1654,117 @@ mod tests {
         assert!(text.contains("gh pr view 43"));
         assert!(text.contains("gh pr diff 43"));
         assert!(text.contains("assignees: alice, bob"));
+    }
+
+    // --- Trigger mode tests ---
+
+    #[test]
+    fn test_trigger_mode_pattern_issue_matches() {
+        let msg = make_message("issue", 42);
+        let patterns = make_patterns();
+        let result = GithubMatcher.match_message(&msg, &patterns);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().pattern_name, "planner");
+    }
+
+    #[test]
+    fn test_trigger_mode_pattern_pr_matches() {
+        let msg = make_message("pull_request", 43);
+        let patterns = make_patterns();
+        let result = GithubMatcher.match_message(&msg, &patterns);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().pattern_name, "developer");
+    }
+
+    #[test]
+    fn test_trigger_mode_pattern_self_loop_prevention() {
+        let mut msg = make_message("pull_request", 43);
+        msg.metadata.insert("comment_role".to_string(), serde_json::json!("Developer"));
+        let patterns = make_patterns();
+        let result = GithubMatcher.match_message(&msg, &patterns);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_trigger_mode_pattern_blocks_wrong_type() {
+        let msg = make_message("issue", 42);
+        let patterns = vec![ChannelPattern {
+            name: "developer".to_string(),
+            enabled: true,
+            role: Some("Developer".to_string()),
+            trigger_mode: TriggerMode::Pattern,
+            rules: crate::channels::types::PatternRules {
+                github_type: Some(vec!["pull_request".to_string()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
+        let result = GithubMatcher.match_message(&msg, &patterns);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_trigger_mode_mention_requires_handover() {
+        let msg = make_message("issue", 42);
+        let patterns = make_patterns_mention_mode();
+        let result = GithubMatcher.match_message(&msg, &patterns);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_trigger_mode_both_requires_handover_and_rules() {
+        let mut msg = make_message("pull_request", 43);
+        msg.metadata.insert("handover_role".to_string(), serde_json::json!("reviewer"));
+        let patterns = vec![ChannelPattern {
+            name: "reviewer".to_string(),
+            enabled: true,
+            role: Some("Reviewer".to_string()),
+            trigger_mode: TriggerMode::Both,
+            rules: crate::channels::types::PatternRules {
+                github_type: Some(vec!["pull_request".to_string()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
+        let result = GithubMatcher.match_message(&msg, &patterns);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().pattern_name, "reviewer");
+    }
+
+    #[test]
+    fn test_trigger_mode_both_without_handover_fails() {
+        let msg = make_message("pull_request", 43);
+        let patterns = vec![ChannelPattern {
+            name: "reviewer".to_string(),
+            enabled: true,
+            role: Some("Reviewer".to_string()),
+            trigger_mode: TriggerMode::Both,
+            rules: crate::channels::types::PatternRules {
+                github_type: Some(vec!["pull_request".to_string()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
+        let result = GithubMatcher.match_message(&msg, &patterns);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_trigger_mode_both_without_rules_fails() {
+        let mut msg = make_message("issue", 42);
+        msg.metadata.insert("handover_role".to_string(), serde_json::json!("reviewer"));
+        let patterns = vec![ChannelPattern {
+            name: "reviewer".to_string(),
+            enabled: true,
+            role: Some("Reviewer".to_string()),
+            trigger_mode: TriggerMode::Both,
+            rules: crate::channels::types::PatternRules {
+                github_type: Some(vec!["pull_request".to_string()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
+        let result = GithubMatcher.match_message(&msg, &patterns);
+        assert!(result.is_none());
     }
 }

--- a/src/channels/types.rs
+++ b/src/channels/types.rs
@@ -278,6 +278,13 @@ pub struct ChannelPattern {
     /// When false, messages queue and are processed sequentially.
     #[serde(default = "default_true")]
     pub live_injection: bool,
+    /// Trigger mode for this pattern.
+    /// - `Pattern`: Only pattern rules need to match (no mention required)
+    /// - `Mention`: Only @j:role mention triggers (pattern rules optional)
+    /// - `Both`: Both pattern rules AND @j:role mention required
+    /// Defaults to `Mention` for backward compatibility.
+    #[serde(default)]
+    pub trigger_mode: TriggerMode,
 }
 
 impl Default for ChannelPattern {
@@ -292,6 +299,7 @@ impl Default for ChannelPattern {
             thread_name: None,
             role: None,
             live_injection: true,
+            trigger_mode: TriggerMode::default(),
         }
     }
 }
@@ -337,6 +345,25 @@ pub struct PatternRules {
     /// GitHub assignees to match (OR logic: match if ANY assignee is assigned to the issue/PR)
     #[serde(default)]
     pub assignees: Option<Vec<String>>,
+}
+
+/// Trigger mode for pattern matching.
+///
+/// - `Pattern`: Only pattern rules need to match (no mention required)
+/// - `Mention`: Only @j:role mention triggers (pattern rules optional)
+/// - `Both`: Both pattern rules AND @j:role mention required
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TriggerMode {
+    Pattern,
+    Mention,
+    Both,
+}
+
+impl Default for TriggerMode {
+    fn default() -> Self {
+        Self::Mention
+    }
 }
 
 impl Default for PatternRules {

--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -124,8 +124,9 @@ Read the triggering comment at the bottom of the incoming message.
 
 When to hand off to Reviewer:
 - ONLY after completing the FULL implementation plan from a planner-created PR
-- Add the reviewer trigger label (e.g., `ready-for-review`) — this auto-triggers reviewer via pattern matching
+- Add the reviewer trigger label (e.g., `ready-for-review`) — the reviewer pattern uses `trigger_mode = "both"` so it requires BOTH the label AND `@j:reviewer` mention
 - Mark PR ready: `gh pr ready <number>`
+- Post a comment with `@j:reviewer` to trigger the reviewer (required with "both" mode)
 
 When NOT to hand off:
 - After fixing reviewer feedback (reviewer already knows — they will re-review)

--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -7,7 +7,7 @@
 - **NEVER merge the PR — that's the user's decision**
 - **You MUST push code to the EXISTING PR branch, not create a new one**
 - **You MUST commit and push after EACH plan step — NEVER implement all steps then commit once**
-- **NEVER assume your work is "done" — you are a persistent, always-responsive agent. Every `@j:developer` trigger is a new, independent task.**
+- **NEVER assume your work is "done" — you are a persistent, always-responsive agent. Every trigger is a new, independent task.**
 - **NEVER commit or push on the main branch — you MUST be on the PR branch first**
 
 You are a developer agent for GitHub PRs.
@@ -16,12 +16,8 @@ You are a developer agent for GitHub PRs.
 comment is at the bottom of the incoming message after "Triggering comment by".
 That comment IS your task. Do what it says — nothing more, nothing less.
 
-Examples:
-- `@j:developer add code comments` → add code comments to the changed files
-- `@j:developer 请在dockerfile被修改的地方添加注释` → add comments in the Dockerfile
-- `[Planner] @j:developer Please implement according to the plan above` → implement the full plan
-- `[Reviewer] @j:developer fix error handling` → fix error handling
-- `@j:developer` (bare mention) → read PR comments for context
+You are triggered automatically when a PR matches the pattern rules (e.g., label `ready-for-dev`).
+The pattern has `trigger_mode = "pattern"` so no `@j:developer` mention is required.
 
 ## Repository Setup
 Clone the repository from the trigger message to `repo/` if not already present,
@@ -122,22 +118,22 @@ Read the triggering comment at the bottom of the incoming message.
    gh pr comment <number> --body "[Developer] Done: <summary of what was done>"
    ```
 
-5. **Wait for the next `@j:developer` trigger**
+   5. **Wait for the next trigger** (new issues matching pattern rules or labeled for review)
 
 ## Hand-off Rules
 
-When to trigger `@j:reviewer`:
+When to hand off to Reviewer:
 - ONLY after completing the FULL implementation plan from a planner-created PR
-- Post: `gh pr comment <number> --body "[Developer] @j:reviewer Implementation complete. Ready for review."`
-- Then mark PR ready: `gh pr ready <number>`
+- Add the reviewer trigger label (e.g., `ready-for-review`) — this auto-triggers reviewer via pattern matching
+- Mark PR ready: `gh pr ready <number>`
 
-When NOT to trigger `@j:reviewer`:
+When NOT to hand off:
 - After fixing reviewer feedback (reviewer already knows — they will re-review)
 - After adding comments, refactoring, or any task requested by a non-planner comment
 - In these cases, just reply "[Developer] Done: ..." and wait
 
-When to trigger `@j:reviewer` after fixing reviewer feedback:
-- If the reviewer explicitly asks you to re-trigger review (e.g., "@j:developer fix X and then re-submit for review")
+When to hand off again after fixing reviewer feedback:
+- If the reviewer explicitly asks you to re-submit for review
 - Otherwise, just reply "[Developer] Done: ..." — the reviewer will re-review when ready
 
 ## Rules
@@ -148,7 +144,7 @@ When to trigger `@j:reviewer` after fixing reviewer feedback:
 - ALWAYS commit and push after EACH plan step
 - ALWAYS prefix PR comments with `[Developer]`
 - NEVER implement multiple plan steps before committing
-- You are ALWAYS responsive — every `@j:developer` trigger is an independent task, regardless of what you did before
+- You are ALWAYS responsive — every trigger is an independent task, regardless of what you did before
 - After completing any task, reply with "[Developer] Done: ..." and wait for the next trigger
 - When using the reply tool, put your COMPLETE response in the message
 - Do NOT create new PRs or branches

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -14,7 +14,8 @@ You are a planner/designer agent for GitHub issues. Your role is to discuss
 requirements with the user and create a PR when the plan is clear.
 
 ## How You Receive Work
-You are triggered when someone posts a comment containing `@j:planner` on an issue.
+You are triggered automatically when an issue matches the pattern rules (e.g., label `planning`).
+The pattern has `trigger_mode = "pattern"` so no `@j:planner` mention is required.
 The trigger message tells you the repository and issue number, for example:
 ```
 repository: kingye/jyc
@@ -181,7 +182,7 @@ gh pr comment <pr_number> --body "[Planner] @j:developer Please implement accord
 
 **CRITICAL:** The PR must be EMPTY (no code changes) and created as a **draft**. The developer agent will implement the code.
 **CRITICAL:** You MUST copy ALL assignees and labels from the issue to the PR using `gh pr edit --add-assignee` and `gh pr edit --add-label` AFTER creating the PR. This ensures correct routing to developer/reviewer agents. DO NOT rely on `gh pr create --assignee/--label` flags alone.
-**CRITICAL:** You MUST post a separate comment with `@j:developer` after creating the PR — this is what triggers the developer.
+**CRITICAL:** After creating the PR, add the label configured for the developer (e.g., `ready-for-dev`) — this auto-triggers the developer via pattern matching (no @j:developer mention needed).
 **CRITICAL:** Include `Fixes #<issue_number>` in the PR body to link the PR to the issue.
 **CRITICAL:** The implementation plan must have concrete, testable steps — NOT vague bullet points.
 
@@ -198,7 +199,7 @@ gh pr comment <pr_number> --body "[Planner] @j:developer Please implement accord
 - ONLY use the `bash` tool and `jyc_reply` tool — NO other tools
 - ALWAYS `cd repo` before running any command
 - ALWAYS include `Fixes #<issue_number>` in PR body
-- ALWAYS post a `@j:developer` comment after creating the PR — this is what triggers the Developer agent
+- ALWAYS add the developer trigger label (e.g., `ready-for-dev`) after creating the PR — this auto-triggers the Developer agent via pattern matching
 - Reply in the same language as the user
 - Your PR must contain ZERO code changes — only the spec in the PR body
 - Your implementation plan must break the work into small, ordered steps — each with a clear verification method


### PR DESCRIPTION
## Spec

修改 GitHub channel 的触发机制：planner 和 developer 只需 pattern rules 匹配即可触发（不需要 `@j:planner`/`@j:developer`），reviewer 需要 pattern rules 匹配且 `@j:reviewer` mention。通过新增 `TriggerMode` 枚举（`Pattern`/`Mention`/`Both`）实现灵活的触发模式配置，默认 `Mention` 保持向后兼容。

Fixes #69

## Implementation Plan

### Step 1: 新增 `TriggerMode` 枚举和 `ChannelPattern.trigger_mode` 字段
**What:** 在 `src/channels/types.rs` 中：1) `PatternRules` 之后新增 `TriggerMode` 枚举（`Pattern`/`Mention`/`Both`，`serde rename_all = "lowercase"`）；2) `ChannelPattern` 添加 `trigger_mode: TriggerMode` 字段，默认 `Mention`；3) 更新 `Default for ChannelPattern`
**Why:** 整个变更的基础数据结构
**Verify:** `cargo check` 通过

### Step 2: 修改 `GithubMatcher::match_message()` 支持 `trigger_mode`
**What:** 重写 `src/channels/github/inbound.rs` 第55-100行的 `match_message()` 方法。`Pattern` 模式仅检查 `rules_match` + self-loop prevention，不需要 `handover_role`；`Mention` 模式保持当前逻辑；`Both` 模式需要 `handover_role` + `rules_match`
**Why:** 核心路由逻辑变更，使 planner/developer 不再需要 mention
**Verify:** `cargo check` 通过

### Step 3: 更新现有单元测试 + 新增 trigger_mode 测试
**What:** 修改 `src/channels/github/inbound.rs` tests 模块：1) `make_patterns()` 添加 `trigger_mode`（planner=Pattern, developer=Pattern, reviewer=Both）；2) 更新 `test_no_mention_no_match` 等受影响测试；3) 新增约7个测试覆盖三种模式
**Why:** 确保新逻辑正确
**Verify:** `cargo test -- github::inbound::tests` 全部通过

### Step 4: 修改 `poll_once()` 支持 Pattern 模式的事件路由
**What:** 在 `src/channels/github/inbound.rs` `poll_once()` 中：1) 在 fetch open issues 后新增步骤，对比上一轮 seen-issues 生成 `opened`/`labeled` 事件；2) 修改 comments 处理：无 `@j:<role>` 的评论也构建消息路由（不设 `handover_role`），让 Pattern 模式的 pattern 可以匹配
**Why:** `trigger_mode = Pattern` 需要事件源
**Verify:** `cargo test` 通过 + 手动测试

### Step 5: 持久化 seen-issues 状态
**What:** 在 `src/channels/github/inbound.rs` 中添加 `load_seen_issues()`/`track_seen_issue()`/`compact_seen_issues()` 方法，格式 `{number}:{labels}:{updated_at}`，持久化到 `.github/seen-issues.txt`，在 `start()` 中加载
**Why:** 防止重启后重复触发已有 issue/PR
**Verify:** 重启 JYC 后不重复触发

### Step 6: 更新 GITHUB_CHANNEL.md 设计文档
**What:** 更新 `GITHUB_CHANNEL.md`：Design Principles 第2条改为 Flexible Trigger Modes；Pattern Matching 章节增加 trigger_mode；Routing 章节更新；Agent Roles 章节更新触发条件；Workflow 时序图去掉 @j:planner/@j:developer 手动触发
**Why:** 文档与代码行为一致
**Verify:** 人工审阅

### Step 7: 更新 config.example.toml 配置示例
**What:** 在 `config.example.toml` GitHub channel 配置中为 planner/developer/reviewer pattern 添加 `trigger_mode` 字段示例
**Why:** 用户参考配置
**Verify:** `cargo test` 通过

### Step 8: 更新 Agent Templates
**What:** 更新 `templates/github-planner/AGENTS.md` 和 `templates/github-developer/AGENTS.md` 的触发方式说明。Planner hand-off 不再需要 `@j:developer` comment
**Why:** Agent 行为说明与实际一致
**Verify:** 人工审阅

### Step 9: 集成测试 + cargo test 全量验证
**What:** `cargo test` 全量通过，`cargo check` 无 warning，手动集成测试（创建 issue → planner 自动触发、创建 PR → developer 自动触发、@j:reviewer → reviewer 触发等）
**Why:** 最终验证
**Verify:** 全部通过

## Design Decisions
- `TriggerMode` 默认值 `Mention` 保持向后兼容，现有配置无需修改
- `Pattern` 模式仍执行 self-loop prevention（agent 自评论不触发自己）
- `Pattern` 模式对所有非 bot 评论也会触发，确保用户讨论能到达 planner
- seen-issues 持久化避免重启后重复触发