### PR TITLE
feat: use label ready-to-review to trigger reviewer

### DIFF
--- a/GITHUB_CHANNEL.md
+++ b/GITHUB_CHANNEL.md
@@ -176,7 +176,7 @@ Each pattern has a `trigger_mode` field controlling when it matches:
 
 **Recommended configuration:**
 - Planner/Developer patterns: `trigger_mode = "pattern"` (auto-trigger on new issues/PRs)
-- Reviewer pattern: `trigger_mode = "both"` (require both label + explicit @j:reviewer)
+- Reviewer pattern: `trigger_mode = "pattern"` (auto-trigger when PR has `ready-to-review` label)
 
 ### Auto-Label from Role
 
@@ -348,7 +348,7 @@ gh pr edit 43 --add-label "jyc:develop"
 4. Clone repo, checkout PR branch
 5. Implement code (incremental-dev approach)
 6. Commit, push
-7. Hand over to reviewer (auto-trigger via pattern rules, no @j:reviewer needed)
+7. Hand over to reviewer (add `ready-to-review` label to trigger reviewer)
 8. When review feedback received:
    - Read reviews: `gh pr view {N} --comments`
    - Fix issues, commit, push
@@ -358,15 +358,16 @@ gh pr edit 43 --add-label "jyc:develop"
 
 **Thread**: `review-pr-{N}`
 **Role**: Review PR code quality, approve or request changes.
-**Trigger**: `trigger_mode = "both"` (requires both label + @j:reviewer mention)
+**Trigger**: `trigger_mode = "pattern"` (auto-triggered when PR has `ready-to-review` label)
 
 **Workflow**:
-1. Triggered when PR has review label AND `@j:reviewer` mention
+1. Triggered automatically when PR has `ready-to-review` label
 2. Read PR: `gh pr view {N}`
 3. Read diff: `gh pr diff {N}`
 4. Review code
 5. Submit review: `gh pr review {N} --approve` or `--request-changes`
-6. If changes requested: hand over to developer (auto-trigger via pattern)
+6. Remove `ready-to-review` label: `gh pr edit {N} --remove-label ready-to-review`
+7. If changes requested: hand over to developer (auto-trigger via pattern)
 
 ## Close & Cleanup
 
@@ -454,7 +455,7 @@ Every poll_interval_secs:
 3. Fetch recently closed issues/PRs (for close events)
    GET /repos/{o}/{r}/issues?state=closed&since={last_poll}&sort=updated
 
-4. For each open PR with 'ready-for-review' label: fetch reviews
+4. For each open PR with 'ready-to-review' label: fetch reviews
    GET /repos/{o}/{r}/pulls/{n}/reviews?since={last_poll}
 ```
 
@@ -517,7 +518,7 @@ User1                    Agent A (Planner)        Agent B (Developer)      Agent
   │                                │                      ├─ gh issue view 42     │
   │                                │                      ├─ Implement code       │
   │                                │                      ├─ git commit + push    │
-  │                                │                      ├─ comment: @j:reviewer │
+   │                                │                      ├─ add-label "ready-to-review" │
   │                                │                      │                       │
   │                                │                      │  [poll: @j:rev] ─────►│
   │                                │                      │                       ├─ gh pr view 43
@@ -531,7 +532,7 @@ User1                    Agent A (Planner)        Agent B (Developer)      Agent
   │                                │                      ├─ gh pr view 43 --comments
   │                                │                      ├─ Fix code             │
   │                                │                      ├─ git push             │
-  │                                │                      ├─ comment: @j:reviewer │
+   │                                │                      ├─ add-label "ready-to-review" │
   │                                │                      │                       │
   │                                │                      │  [poll: @j:rev] ─────►│
   │                                │                      │                       ├─ gh pr diff 43

--- a/config.example.toml
+++ b/config.example.toml
@@ -264,17 +264,17 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # github_type = ["pull_request"]
 # labels = ["ready-for-dev"]
 #
-# # Pattern: PRs with 'ready-for-review' label → Reviewer agent (require mention)
+# # Pattern: PRs with 'ready-to-review' label → Reviewer agent (auto-trigger)
 # [[channels.my_repo.patterns]]
 # name = "reviewer"
 # enabled = true
 # role = "Reviewer"
 # template = "github-reviewer"
-# trigger_mode = "both"               # Requires both label + @j:reviewer mention
+# trigger_mode = "pattern"            # Auto-trigger when PR matches rules
 #
 # [channels.my_repo.patterns.rules]
 # github_type = ["pull_request"]
-# labels = ["ready-for-review"]
+# labels = ["ready-to-review"]
 #
 # # Pattern: PRs assigned to specific team members → Route to those assignees
 # # Assignee matching: OR logic (matches if ANY assignee is in the list)
@@ -287,7 +287,7 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # github_type = ["pull_request"]
 # assignees = ["alice", "bob"]
 #
-# # Pattern: PRs with 'needs-review' label AND assigned to 'alice' → Senior reviewer
+# # Pattern: PRs with 'ready-to-review' label AND assigned to 'alice' → Senior reviewer
 # # This demonstrates AND logic: BOTH labels and assignees must match
 # [[channels.my_repo.patterns]]
 # name = "senior_reviewer"
@@ -297,5 +297,5 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 #
 # [channels.my_repo.patterns.rules]
 # github_type = ["pull_request"]
-# labels = ["needs-review"]
+# labels = ["ready-to-review"]
 # assignees = ["alice"]

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -1460,9 +1460,9 @@ mod tests {
 
     #[test]
     fn test_all_rules_and_logic() {
-        // Pattern requires: pull_request AND label "needs-review" AND assignee "alice"
+        // Pattern requires: pull_request AND label "ready-to-review" AND assignee "alice"
         // Message has all three — should match
-        let mut msg = make_message_with_rules("pull_request", 43, &["needs-review"], &["alice"]);
+        let mut msg = make_message_with_rules("pull_request", 43, &["ready-to-review"], &["alice"]);
         msg.metadata.insert("handover_role".to_string(), serde_json::json!("reviewer"));
         let patterns = vec![ChannelPattern {
             name: "reviewer".to_string(),
@@ -1470,7 +1470,7 @@ mod tests {
             role: Some("Reviewer".to_string()),
             rules: crate::channels::types::PatternRules {
                 github_type: Some(vec!["pull_request".to_string()]),
-                labels: Some(vec!["needs-review".to_string()]),
+                labels: Some(vec!["ready-to-review".to_string()]),
                 assignees: Some(vec!["alice".to_string()]),
                 ..Default::default()
             },
@@ -1482,9 +1482,9 @@ mod tests {
 
     #[test]
     fn test_and_logic_partial_fail() {
-        // Pattern requires: pull_request AND label "needs-review" AND assignee "alice"
+        // Pattern requires: pull_request AND label "ready-to-review" AND assignee "alice"
         // Message has correct type and label but wrong assignee — should NOT match
-        let mut msg = make_message_with_rules("pull_request", 43, &["needs-review"], &["bob"]);
+        let mut msg = make_message_with_rules("pull_request", 43, &["ready-to-review"], &["bob"]);
         msg.metadata.insert("handover_role".to_string(), serde_json::json!("reviewer"));
         let patterns = vec![ChannelPattern {
             name: "reviewer".to_string(),
@@ -1492,7 +1492,7 @@ mod tests {
             role: Some("Reviewer".to_string()),
             rules: crate::channels::types::PatternRules {
                 github_type: Some(vec!["pull_request".to_string()]),
-                labels: Some(vec!["needs-review".to_string()]),
+                labels: Some(vec!["ready-to-review".to_string()]),
                 assignees: Some(vec!["alice".to_string()]),
                 ..Default::default()
             },

--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -124,9 +124,9 @@ Read the triggering comment at the bottom of the incoming message.
 
 When to hand off to Reviewer:
 - ONLY after completing the FULL implementation plan from a planner-created PR
-- Add the reviewer trigger label (e.g., `ready-for-review`) — the reviewer pattern uses `trigger_mode = "both"` so it requires BOTH the label AND `@j:reviewer` mention
+- Add the `ready-to-review` label — the reviewer pattern uses `trigger_mode = "pattern"` and is auto-triggered by the label alone
 - Mark PR ready: `gh pr ready <number>`
-- Post a comment with `@j:reviewer` to trigger the reviewer (required with "both" mode)
+- Add label: `gh pr edit <number> --add-label ready-to-review`
 
 When NOT to hand off:
 - After fixing reviewer feedback (reviewer already knows — they will re-review)
@@ -135,6 +135,7 @@ When NOT to hand off:
 
 When to hand off again after fixing reviewer feedback:
 - If the reviewer explicitly asks you to re-submit for review
+- Add `ready-to-review` label again: `gh pr edit <number> --add-label ready-to-review`
 - Otherwise, just reply "[Developer] Done: ..." — the reviewer will re-review when ready
 
 ## Rules

--- a/templates/github-reviewer/AGENTS.md
+++ b/templates/github-reviewer/AGENTS.md
@@ -6,7 +6,7 @@ quality, correctness, and design, then approve or request changes.
 **⚠️ NEVER use the `jyc_question_ask_user` tool. Use the reply tool ONLY.**
 
 ## How You Receive Work
-You are triggered when someone posts a comment containing `@j:reviewer` on a PR.
+You are triggered automatically when a PR has the `ready-to-review` label.
 The trigger message tells you the repository, PR number, and the **triggering comment**
 (which contains the instruction or context for this review).
 ```
@@ -97,6 +97,7 @@ Please address the issues above.
 EOF
 )"
 gh pr comment <number> --body "[Reviewer] @j:developer Please address the review feedback."
+gh pr edit <number> --remove-label ready-to-review
 ```
 
 If approved:
@@ -112,6 +113,7 @@ Code looks good. Approved.
 - <any minor notes>
 EOF
 )"
+gh pr edit <number> --remove-label ready-to-review
 ```
 
 ## Rules
@@ -120,10 +122,11 @@ EOF
 - Use `gh` CLI for ALL GitHub operations
 - ALWAYS read the full diff before reviewing
 - ALWAYS provide specific, actionable feedback
-- When requesting changes, post a comment with `@j:developer` to trigger the developer — this is the ONLY way to hand over
+- When requesting changes, add the `ready-for-dev` label to trigger the developer — `gh pr edit <number> --add-label ready-for-dev`
 - When using the reply tool, put your COMPLETE response in the message — do NOT generate text after calling the reply tool (it will be lost)
 - Do NOT modify code yourself — only review and comment
 - Do NOT merge the PR — that's the user's decision
 - Do NOT run `cargo build` or `npm run build` — use `cargo check` or `npm run lint` for lightweight verification. Full builds are the developer's responsibility, not the reviewer's.
+- ALWAYS remove the `ready-to-review` label after completing your review: `gh pr edit <number> --remove-label ready-to-review`
 - Do NOT use the `jyc_question_ask_user` tool
 - Be constructive and objective in feedback


### PR DESCRIPTION
## Spec

Change reviewer trigger from `trigger_mode = "both"` (label + @j:reviewer mention) to `trigger_mode = "pattern"` (label only). The label name changes from `ready-for-review` to `ready-to-review`. Reviewer removes the label after completing review; developer re-adds it when requesting another review.

Fixes #74

## Implementation Plan

### Step 1: Update `config.example.toml`
**What:** Change reviewer pattern's `trigger_mode` from `"both"` to `"pattern"`, change label from `ready-for-review` to `ready-to-review`. Also update `senior_reviewer` pattern's label from `needs-review` to `ready-to-review`.
**Why:** This is the primary config change that enables label-only reviewer triggering.
**Verify:** `grep -n "ready-to-review\|trigger_mode" config.example.toml` shows correct values.

### Step 2: Update `GITHUB_CHANNEL.md`
**What:** Update all references to reviewer trigger mode from `"both"` to `"pattern"`, remove `@j:reviewer` mention requirements from reviewer workflow descriptions, change label name from `ready-for-review` / `needs-review` to `ready-to-review`. Key sections:
- Line ~179: Reviewer pattern trigger_mode recommendation table
- Line ~255-258: Pattern 3 config example
- Line ~361-364: Agent C Reviewer workflow — remove "AND @j:reviewer mention" requirement, add "reviewer removes ready-to-review label after review"
- Any other references to `@j:reviewer` mention as a trigger requirement
**Why:** Documentation must reflect the new trigger mechanism.
**Verify:** `grep -n "both.*reviewer\|@j:reviewer\|ready-for-review" GITHUB_CHANNEL.md` returns no results (or only historical context).

### Step 3: Update `templates/github-developer/AGENTS.md`
**What:** Simplify hand-off rules (line ~127): remove requirement for `@j:reviewer` mention, change to only adding `ready-to-review` label. Update the `trigger_mode = "both"` reference. Add instruction that when developer needs re-review after fixing feedback, they should add `ready-to-review` label again.
**Why:** Developer needs to know the correct hand-off procedure.
**Verify:** `grep -n "ready-to-review\|@j:reviewer\|both" templates/github-developer/AGENTS.md` shows only `ready-to-review` label instructions, no `@j:reviewer` mention requirement.

### Step 4: Update `templates/github-reviewer/AGENTS.md`
**What:** Change trigger description from "triggered when someone posts a comment containing @j:reviewer" to "triggered automatically when PR has `ready-to-review` label". Add step at end of workflow: after submitting review, remove `ready-to-review` label (`gh pr edit <number> --remove-label ready-to-review`).
**Why:** Reviewer must know how they are triggered and must clean up the label after review.
**Verify:** `grep -n "ready-to-review\|@j:reviewer\|remove-label" templates/github-reviewer/AGENTS.md` shows correct label-based trigger and label removal step.

### Step 5: Update `.opencode/skills/pr-review/SKILL.md`
**What:** Check if this skill references `@j:reviewer` or `trigger_mode = "both"`. If so, update to reflect pattern-only triggering with `ready-to-review` label.
**Why:** Skill documentation must be consistent.
**Verify:** `grep -n "ready-to-review\|@j:reviewer\|both" .opencode/skills/pr-review/SKILL.md` shows correct references.

### Step 6: Update test code in `src/channels/github/inbound.rs`
**What:** Update test label names from `needs-review` to `ready-to-review` in test functions (lines ~1463, 1465, 1473, 1485, 1487, 1495). These are in `test_rules_match_labels_and_assignees` and related tests.
**Why:** Test labels should match the new convention.
**Verify:** `cargo test` passes; `grep -n "needs-review" src/channels/github/inbound.rs` returns no results.

### Step 7: Run full test suite
**What:** Run `cargo test` to verify all changes compile and tests pass.
**Why:** Ensure no regressions from the changes.
**Verify:** `cargo test` exits with code 0.

## Design Decisions
- Label name: `ready-to-review` (per issue #74 requirement)
- Reviewer removes label after completing review (clean state)
- Developer re-adds `ready-to-review` label when requesting re-review
- `trigger_mode` changes from `"both"` to `"pattern"` for reviewer — no `@j:reviewer` mention needed
- Test code label names updated for consistency