### PR TITLE
fix: remove trigger_mode enum and field — always use pattern matching

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -902,25 +902,8 @@ pub struct ChannelPattern {
     pub template: Option<String>,             // Thread template name
     pub thread_name: Option<String>,          // Fixed thread name override
     pub role: Option<String>,                 // Agent role (e.g., "Planner", "Developer", "Reviewer")
-    pub trigger_mode: Option<TriggerMode>,    // Trigger mode: Pattern, Mention, or Both
     #[serde(default = "default_true")]
     pub live_injection: bool,                 // Inject into active AI session (default: true)
-}
-
-/// Controls when a pattern triggers on incoming messages.
-///
-/// - **Pattern** (default for GitHub): Only pattern rules (github_type, labels, assignees) need to match.
-///   No `@j:<role>` mention required. Used for auto-trigger on new issues/PRs.
-/// - **Mention** (default for backward compatibility): Requires `@j:<role>` mention in comment.
-///   Pattern rules are optional filters.
-/// - **Both**: Both pattern rules match AND `@j:<role>` mention required. Used for reviewer patterns
-///   that should only trigger when explicitly requested AND the PR is in review state.
-#[derive(Debug, Clone, Copy, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum TriggerMode {
-    Pattern,
-    Mention,
-    Both,
 }
 
 /// Channel-agnostic pattern matching rules.

--- a/GITHUB_CHANNEL.md
+++ b/GITHUB_CHANNEL.md
@@ -7,11 +7,8 @@ repositories through issue discussion, PR development, and code review.
 
 1. **Channel = Lightweight Trigger + Router** — Channel only polls events and
    routes them. Agents use `gh` CLI to read/write actual content.
-2. **Flexible Trigger Modes** — Routing can be triggered by:
-   - **Pattern mode** (default for Planner/Developer): Pattern rules alone trigger (labels, github_type, assignees). No `@j:<role>` mention required.
-   - **Mention mode**: Requires `@j:<role>` mention in comment. Pattern rules are optional.
-   - **Both mode**: Requires both pattern rules match AND `@j:<role>` mention.
-   - Configure via `trigger_mode` field in pattern config (default: `mention` for backward compatibility)
+2. **Pattern-Based Routing** — Routing is triggered by pattern rules (labels, github_type, assignees).
+   No `@j:<role>` mention required. All triggering is pattern-based.
    - Processed comment IDs persisted to `<channel>/.github/processed-comments.txt`
    - Seen issues persisted to `<channel>/.github/seen-issues.txt` to prevent re-trigger after restart (tracked by number:labels:updated_at)
 3. **One Token, Role Prefix + Self-Loop Prevention** — Single GitHub PAT. Agents
@@ -164,21 +161,11 @@ pub struct PatternRules {
 }
 ```
 
-### Trigger Mode
+### Routing
 
-Each pattern has a `trigger_mode` field controlling when it matches:
-
-| Mode | Description |
-|------|-------------|
-| `pattern` | Only pattern rules (github_type, labels, assignees) need to match. No `@j:<role>` mention required. |
-| `mention` | Only `@j:<role>` mention triggers. Pattern rules are optional. (default for backward compatibility) |
-| `both` | Both pattern rules match AND `@j:<role>` mention required. |
-
-**Recommended configuration:**
-- Planner/Developer patterns: `trigger_mode = "pattern"` (auto-trigger on new issues/PRs)
-- Reviewer pattern: `trigger_mode = "pattern"` (auto-trigger when PR has `ready-to-review` label)
-
-### Auto-Label from Role
+Messages matching github_type/labels/assignees rules trigger immediately.
+No `@j:<role>` mention required. Self-loop prevention still applies:
+an agent's own comments (identified by `[Role]` prefix) don't re-trigger that same agent.
 
 Each pattern with a `role` field and `github_type = ["pull_request"]` gets an
 implicit routing label derived from the role name:
@@ -200,17 +187,6 @@ on the issue/PR.
 **Match logic:**
 - `github_type` + labels: AND across fields, OR within each field
 - Self-loop check: skip if comment is from the pattern's own role
-
-### Routing
-
-Routing behavior depends on the pattern's `trigger_mode`:
-
-- **Pattern mode**: Messages matching github_type/labels/assignees rules trigger immediately. No `@j:<role>` mention needed.
-- **Mention mode**: Requires `@j:<role>` mention in comment. Pattern rules are optional filters.
-- **Both mode**: Requires both pattern rules match AND `@j:<role>` mention.
-
-All comments are routed (not just those with mentions) to enable Pattern mode matching.
-Self-loop prevention still applies: an agent's own comments (identified by `[Role]` prefix) don't re-trigger that same agent.
 
 Processed comment IDs are persisted to `<channel>/.github/processed-comments.txt`.
 Seen issues are persisted to `<channel>/.github/seen-issues.txt` to prevent re-triggering after restart. Issues are tracked by `{number}:{labels}:{updated_at}` — note that if labels change without updating the issue's `updated_at`, re-triggering may not occur.
@@ -322,7 +298,7 @@ gh pr edit 43 --add-label "jyc:develop"
 
 **Thread**: `issue-{N}`
 **Role**: Discuss requirements with user, create PR with spec when ready.
-**Trigger**: `trigger_mode = "pattern"` (auto-triggered on new issues via labels)
+**Trigger**: Auto-triggered on new issues via pattern matching (github_type, labels)
 
 **Workflow**:
 1. Triggered automatically when issue matches pattern rules (e.g., label `planning`)
@@ -339,7 +315,7 @@ gh pr edit 43 --add-label "jyc:develop"
 
 **Thread**: `pr-{N}`
 **Role**: Implement code based on PR spec, address review feedback.
-**Trigger**: `trigger_mode = "pattern"` (auto-triggered on new PRs via labels)
+**Trigger**: Auto-triggered on new PRs via pattern matching (github_type, labels)
 
 **Workflow**:
 1. Triggered automatically when PR matches pattern rules (e.g., label `jyc:develop`)
@@ -358,7 +334,7 @@ gh pr edit 43 --add-label "jyc:develop"
 
 **Thread**: `review-pr-{N}`
 **Role**: Review PR code quality, approve or request changes.
-**Trigger**: `trigger_mode = "pattern"` (auto-triggered when PR has `ready-to-review` label)
+**Trigger**: Auto-triggered when PR has `ready-to-review` label via pattern matching
 
 **Workflow**:
 1. Triggered automatically when PR has `ready-to-review` label

--- a/config.example.toml
+++ b/config.example.toml
@@ -246,7 +246,6 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # enabled = true
 # role = "Planner"
 # template = "github-planner"
-# trigger_mode = "pattern"            # Auto-trigger when issue matches rules
 #
 # [channels.my_repo.patterns.rules]
 # github_type = ["issue"]
@@ -258,7 +257,6 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # role = "Developer"
 # template = "github-developer"
 # live_injection = false
-# trigger_mode = "pattern"            # Auto-trigger when PR matches rules
 #
 # [channels.my_repo.patterns.rules]
 # github_type = ["pull_request"]
@@ -270,7 +268,6 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # enabled = true
 # role = "Reviewer"
 # template = "github-reviewer"
-# trigger_mode = "pattern"            # Auto-trigger when PR matches rules
 #
 # [channels.my_repo.patterns.rules]
 # github_type = ["pull_request"]

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -7,7 +7,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::channels::types::{
     ChannelMatcher, ChannelPattern, InboundAdapter, InboundAdapterOptions, InboundMessage,
-    MessageContent, PatternMatch, PatternRules, TriggerMode,
+    MessageContent, PatternMatch, PatternRules,
 };
 use crate::utils::helpers::truncate_str;
 use super::client::GithubClient;
@@ -57,8 +57,6 @@ impl ChannelMatcher for GithubMatcher {
         message: &InboundMessage,
         patterns: &[ChannelPattern],
     ) -> Option<PatternMatch> {
-        let handover_role = message.metadata.get("handover_role").and_then(|v| v.as_str());
-
         for pattern in patterns {
             if !pattern.enabled {
                 continue;
@@ -68,88 +66,25 @@ impl ChannelMatcher for GithubMatcher {
                 continue;
             };
 
-            match pattern.trigger_mode {
-                TriggerMode::Pattern => {
-                    if !self.rules_match(&pattern.rules, message) {
-                        tracing::debug!(
-                            pattern = %pattern.name,
-                            "Pattern mode: rules did not match, skipping"
-                        );
-                        continue;
-                    }
+            if !self.rules_match(&pattern.rules, message) {
+                tracing::debug!(
+                    pattern = %pattern.name,
+                    "Rules did not match, skipping"
+                );
+                continue;
+            }
 
-                    if let Some(comment_role) = message.metadata.get("comment_role").and_then(|v| v.as_str()) {
-                        if pattern_role.eq_ignore_ascii_case(comment_role) {
-                            continue;
-                        }
-                    }
-
-                    return Some(PatternMatch {
-                        pattern_name: pattern.name.clone(),
-                        channel: "github".to_string(),
-                        matches: HashMap::new(),
-                    });
-                }
-                TriggerMode::Mention => {
-                    let Some(role) = handover_role else {
-                        continue;
-                    };
-                    if !pattern_role.eq_ignore_ascii_case(role) {
-                        continue;
-                    }
-
-                    if let Some(comment_role) = message.metadata.get("comment_role").and_then(|v| v.as_str()) {
-                        if pattern_role.eq_ignore_ascii_case(comment_role) {
-                            continue;
-                        }
-                    }
-
-                    // In Mention mode, pattern rules are optional (backward compatibility)
-                    // Only check rules if any are actually defined
-                    if self.has_rules_defined(&pattern.rules) && !self.rules_match(&pattern.rules, message) {
-                        tracing::debug!(
-                            pattern = %pattern.name,
-                            role = %role,
-                            "Mention mode: pattern rules did not match, skipping"
-                        );
-                        continue;
-                    }
-
-                    return Some(PatternMatch {
-                        pattern_name: pattern.name.clone(),
-                        channel: "github".to_string(),
-                        matches: HashMap::new(),
-                    });
-                }
-                TriggerMode::Both => {
-                    let Some(role) = handover_role else {
-                        continue;
-                    };
-                    if !pattern_role.eq_ignore_ascii_case(role) {
-                        continue;
-                    }
-
-                    if let Some(comment_role) = message.metadata.get("comment_role").and_then(|v| v.as_str()) {
-                        if pattern_role.eq_ignore_ascii_case(comment_role) {
-                            continue;
-                        }
-                    }
-
-                    if !self.rules_match(&pattern.rules, message) {
-                        tracing::debug!(
-                            pattern = %pattern.name,
-                            "Both mode: pattern rules did not match, skipping"
-                        );
-                        continue;
-                    }
-
-                    return Some(PatternMatch {
-                        pattern_name: pattern.name.clone(),
-                        channel: "github".to_string(),
-                        matches: HashMap::new(),
-                    });
+            if let Some(comment_role) = message.metadata.get("comment_role").and_then(|v| v.as_str()) {
+                if pattern_role.eq_ignore_ascii_case(comment_role) {
+                    continue;
                 }
             }
+
+            return Some(PatternMatch {
+                pattern_name: pattern.name.clone(),
+                channel: "github".to_string(),
+                matches: HashMap::new(),
+            });
         }
 
         None
@@ -161,13 +96,6 @@ impl ChannelMatcher for GithubMatcher {
 }
 
 impl GithubMatcher {
-    /// Check if any pattern rules are defined (non-empty).
-    fn has_rules_defined(&self, rules: &PatternRules) -> bool {
-        rules.github_type.is_some()
-            || rules.labels.is_some()
-            || rules.assignees.is_some()
-    }
-
     /// Check whether the GitHub-specific rules (github_type, labels, assignees) all match.
     ///
     /// All present rules use AND logic (all must pass).
@@ -1046,7 +974,6 @@ mod tests {
                 name: "planner".to_string(),
                 enabled: true,
                 role: Some("Planner".to_string()),
-                trigger_mode: TriggerMode::Pattern,
                 rules: crate::channels::types::PatternRules {
                     github_type: Some(vec!["issue".to_string()]),
                     ..Default::default()
@@ -1057,7 +984,6 @@ mod tests {
                 name: "developer".to_string(),
                 enabled: true,
                 role: Some("Developer".to_string()),
-                trigger_mode: TriggerMode::Pattern,
                 rules: crate::channels::types::PatternRules {
                     github_type: Some(vec!["pull_request".to_string()]),
                     ..Default::default()
@@ -1068,45 +994,6 @@ mod tests {
                 name: "reviewer".to_string(),
                 enabled: true,
                 role: Some("Reviewer".to_string()),
-                trigger_mode: TriggerMode::Both,
-                rules: crate::channels::types::PatternRules {
-                    github_type: Some(vec!["pull_request".to_string()]),
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-        ]
-    }
-
-    fn make_patterns_mention_mode() -> Vec<ChannelPattern> {
-        vec![
-            ChannelPattern {
-                name: "planner".to_string(),
-                enabled: true,
-                role: Some("Planner".to_string()),
-                trigger_mode: TriggerMode::Mention,
-                rules: crate::channels::types::PatternRules {
-                    github_type: Some(vec!["issue".to_string()]),
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            ChannelPattern {
-                name: "developer".to_string(),
-                enabled: true,
-                role: Some("Developer".to_string()),
-                trigger_mode: TriggerMode::Mention,
-                rules: crate::channels::types::PatternRules {
-                    github_type: Some(vec!["pull_request".to_string()]),
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            ChannelPattern {
-                name: "reviewer".to_string(),
-                enabled: true,
-                role: Some("Reviewer".to_string()),
-                trigger_mode: TriggerMode::Mention,
                 rules: crate::channels::types::PatternRules {
                     github_type: Some(vec!["pull_request".to_string()]),
                     ..Default::default()
@@ -1156,127 +1043,6 @@ mod tests {
         assert_eq!(name, "pr-43");
     }
 
-    // --- Mention-based routing ---
-
-    #[test]
-    fn test_no_mention_no_match() {
-        let msg = make_message("issue", 42);
-        let patterns = make_patterns_mention_mode();
-        let result = GithubMatcher.match_message(&msg, &patterns);
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_mention_planner_matches() {
-        let mut msg = make_message("issue", 42);
-        msg.metadata.insert("handover_role".to_string(), serde_json::json!("planner"));
-        let patterns = make_patterns_mention_mode();
-        let result = GithubMatcher.match_message(&msg, &patterns);
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().pattern_name, "planner");
-    }
-
-    #[test]
-    fn test_mention_developer_matches() {
-        let mut msg = make_message("pull_request", 43);
-        msg.metadata.insert("handover_role".to_string(), serde_json::json!("developer"));
-        let patterns = make_patterns_mention_mode();
-        let result = GithubMatcher.match_message(&msg, &patterns);
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().pattern_name, "developer");
-    }
-
-    #[test]
-    fn test_mention_reviewer_matches() {
-        let mut msg = make_message("pull_request", 43);
-        msg.metadata.insert("handover_role".to_string(), serde_json::json!("reviewer"));
-        let patterns = make_patterns_mention_mode();
-        let result = GithubMatcher.match_message(&msg, &patterns);
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().pattern_name, "reviewer");
-    }
-
-    #[test]
-    fn test_mention_case_insensitive() {
-        let mut msg = make_message("pull_request", 43);
-        msg.metadata.insert("handover_role".to_string(), serde_json::json!("Reviewer"));
-        let patterns = make_patterns_mention_mode();
-        let result = GithubMatcher.match_message(&msg, &patterns);
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().pattern_name, "reviewer");
-    }
-
-    #[test]
-    fn test_mention_unknown_role_no_match() {
-        let mut msg = make_message("issue", 42);
-        msg.metadata.insert("handover_role".to_string(), serde_json::json!("unknown"));
-        let patterns = make_patterns_mention_mode();
-        let result = GithubMatcher.match_message(&msg, &patterns);
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_disabled_pattern_skipped() {
-        let mut msg = make_message("issue", 42);
-        msg.metadata.insert("handover_role".to_string(), serde_json::json!("planner"));
-        let patterns = vec![ChannelPattern {
-            name: "planner".to_string(),
-            enabled: false,
-            role: Some("Planner".to_string()),
-            rules: crate::channels::types::PatternRules {
-                github_type: Some(vec!["issue".to_string()]),
-                ..Default::default()
-            },
-            ..Default::default()
-        }];
-        let result = GithubMatcher.match_message(&msg, &patterns);
-        assert!(result.is_none());
-    }
-
-    // --- Self-loop prevention ---
-
-    #[test]
-    fn test_self_loop_developer_mention_own_role() {
-        let mut msg = make_message("pull_request", 43);
-        msg.metadata.insert("handover_role".to_string(), serde_json::json!("developer"));
-        msg.metadata.insert("comment_role".to_string(), serde_json::json!("Developer"));
-        let patterns = make_patterns_mention_mode();
-        let result = GithubMatcher.match_message(&msg, &patterns);
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_self_loop_reviewer_mention_own_role() {
-        let mut msg = make_message("pull_request", 43);
-        msg.metadata.insert("handover_role".to_string(), serde_json::json!("reviewer"));
-        msg.metadata.insert("comment_role".to_string(), serde_json::json!("Reviewer"));
-        let patterns = make_patterns_mention_mode();
-        let result = GithubMatcher.match_message(&msg, &patterns);
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_cross_role_reviewer_to_developer() {
-        let mut msg = make_message("pull_request", 43);
-        msg.metadata.insert("handover_role".to_string(), serde_json::json!("developer"));
-        msg.metadata.insert("comment_role".to_string(), serde_json::json!("Reviewer"));
-        let patterns = make_patterns_mention_mode();
-        let result = GithubMatcher.match_message(&msg, &patterns);
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().pattern_name, "developer");
-    }
-
-    #[test]
-    fn test_cross_role_developer_to_reviewer() {
-        let mut msg = make_message("pull_request", 43);
-        msg.metadata.insert("handover_role".to_string(), serde_json::json!("reviewer"));
-        msg.metadata.insert("comment_role".to_string(), serde_json::json!("Developer"));
-        let patterns = make_patterns_mention_mode();
-        let result = GithubMatcher.match_message(&msg, &patterns);
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().pattern_name, "reviewer");
-    }
-
     // --- Rule filtering (github_type, labels, assignees) ---
 
     /// Helper: create a message with labels and assignees metadata
@@ -1300,18 +1066,25 @@ mod tests {
 
     #[test]
     fn test_github_type_rule_blocks_wrong_type() {
-        let mut msg = make_message("issue", 42);
-        msg.metadata.insert("handover_role".to_string(), serde_json::json!("developer"));
-        let patterns = make_patterns_mention_mode();
+        let msg = make_message("issue", 42);
+        let patterns = vec![ChannelPattern {
+            name: "developer".to_string(),
+            enabled: true,
+            role: Some("Developer".to_string()),
+            rules: crate::channels::types::PatternRules {
+                github_type: Some(vec!["pull_request".to_string()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
         let result = GithubMatcher.match_message(&msg, &patterns);
         assert!(result.is_none(), "developer pattern should not match issue type");
     }
 
     #[test]
     fn test_github_type_rule_allows_correct_type() {
-        let mut msg = make_message("issue", 42);
-        msg.metadata.insert("handover_role".to_string(), serde_json::json!("planner"));
-        let patterns = make_patterns_mention_mode();
+        let msg = make_message("issue", 42);
+        let patterns = make_patterns();
         let result = GithubMatcher.match_message(&msg, &patterns);
         assert!(result.is_some());
         assert_eq!(result.unwrap().pattern_name, "planner");
@@ -1835,84 +1608,27 @@ mod tests {
     fn test_trigger_mode_pattern_self_loop_prevention() {
         let mut msg = make_message("pull_request", 43);
         msg.metadata.insert("comment_role".to_string(), serde_json::json!("Developer"));
-        let patterns = make_patterns();
+        let patterns = vec![ChannelPattern {
+            name: "developer".to_string(),
+            enabled: true,
+            role: Some("Developer".to_string()),
+            rules: crate::channels::types::PatternRules {
+                github_type: Some(vec!["pull_request".to_string()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
         let result = GithubMatcher.match_message(&msg, &patterns);
         assert!(result.is_none());
     }
 
     #[test]
-    fn test_trigger_mode_pattern_blocks_wrong_type() {
+    fn test_pattern_blocks_wrong_type() {
         let msg = make_message("issue", 42);
         let patterns = vec![ChannelPattern {
             name: "developer".to_string(),
             enabled: true,
             role: Some("Developer".to_string()),
-            trigger_mode: TriggerMode::Pattern,
-            rules: crate::channels::types::PatternRules {
-                github_type: Some(vec!["pull_request".to_string()]),
-                ..Default::default()
-            },
-            ..Default::default()
-        }];
-        let result = GithubMatcher.match_message(&msg, &patterns);
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_trigger_mode_mention_requires_handover() {
-        let msg = make_message("issue", 42);
-        let patterns = make_patterns_mention_mode();
-        let result = GithubMatcher.match_message(&msg, &patterns);
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_trigger_mode_both_requires_handover_and_rules() {
-        let mut msg = make_message("pull_request", 43);
-        msg.metadata.insert("handover_role".to_string(), serde_json::json!("reviewer"));
-        let patterns = vec![ChannelPattern {
-            name: "reviewer".to_string(),
-            enabled: true,
-            role: Some("Reviewer".to_string()),
-            trigger_mode: TriggerMode::Both,
-            rules: crate::channels::types::PatternRules {
-                github_type: Some(vec!["pull_request".to_string()]),
-                ..Default::default()
-            },
-            ..Default::default()
-        }];
-        let result = GithubMatcher.match_message(&msg, &patterns);
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().pattern_name, "reviewer");
-    }
-
-    #[test]
-    fn test_trigger_mode_both_without_handover_fails() {
-        let msg = make_message("pull_request", 43);
-        let patterns = vec![ChannelPattern {
-            name: "reviewer".to_string(),
-            enabled: true,
-            role: Some("Reviewer".to_string()),
-            trigger_mode: TriggerMode::Both,
-            rules: crate::channels::types::PatternRules {
-                github_type: Some(vec!["pull_request".to_string()]),
-                ..Default::default()
-            },
-            ..Default::default()
-        }];
-        let result = GithubMatcher.match_message(&msg, &patterns);
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn test_trigger_mode_both_without_rules_fails() {
-        let mut msg = make_message("issue", 42);
-        msg.metadata.insert("handover_role".to_string(), serde_json::json!("reviewer"));
-        let patterns = vec![ChannelPattern {
-            name: "reviewer".to_string(),
-            enabled: true,
-            role: Some("Reviewer".to_string()),
-            trigger_mode: TriggerMode::Both,
             rules: crate::channels::types::PatternRules {
                 github_type: Some(vec!["pull_request".to_string()]),
                 ..Default::default()

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -1587,7 +1587,7 @@ mod tests {
     // --- Trigger mode tests ---
 
     #[test]
-    fn test_trigger_mode_pattern_issue_matches() {
+    fn test_pattern_issue_matches() {
         let msg = make_message("issue", 42);
         let patterns = make_patterns();
         let result = GithubMatcher.match_message(&msg, &patterns);
@@ -1596,7 +1596,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trigger_mode_pattern_pr_matches() {
+    fn test_pattern_pr_matches() {
         let msg = make_message("pull_request", 43);
         let patterns = make_patterns();
         let result = GithubMatcher.match_message(&msg, &patterns);
@@ -1605,7 +1605,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trigger_mode_pattern_self_loop_prevention() {
+    fn test_pattern_self_loop_prevention() {
         let mut msg = make_message("pull_request", 43);
         msg.metadata.insert("comment_role".to_string(), serde_json::json!("Developer"));
         let patterns = vec![ChannelPattern {

--- a/src/channels/types.rs
+++ b/src/channels/types.rs
@@ -278,13 +278,6 @@ pub struct ChannelPattern {
     /// When false, messages queue and are processed sequentially.
     #[serde(default = "default_true")]
     pub live_injection: bool,
-    /// Trigger mode for this pattern.
-    /// - `Pattern`: Only pattern rules need to match (no mention required)
-    /// - `Mention`: Only @j:role mention triggers (pattern rules optional)
-    /// - `Both`: Both pattern rules AND @j:role mention required
-    /// Defaults to `Mention` for backward compatibility.
-    #[serde(default)]
-    pub trigger_mode: TriggerMode,
 }
 
 impl Default for ChannelPattern {
@@ -299,7 +292,6 @@ impl Default for ChannelPattern {
             thread_name: None,
             role: None,
             live_injection: true,
-            trigger_mode: TriggerMode::default(),
         }
     }
 }
@@ -345,25 +337,6 @@ pub struct PatternRules {
     /// GitHub assignees to match (OR logic: match if ANY assignee is assigned to the issue/PR)
     #[serde(default)]
     pub assignees: Option<Vec<String>>,
-}
-
-/// Trigger mode for pattern matching.
-///
-/// - `Pattern`: Only pattern rules need to match (no mention required)
-/// - `Mention`: Only @j:role mention triggers (pattern rules optional)
-/// - `Both`: Both pattern rules AND @j:role mention required
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum TriggerMode {
-    Pattern,
-    Mention,
-    Both,
-}
-
-impl Default for TriggerMode {
-    fn default() -> Self {
-        Self::Mention
-    }
 }
 
 impl Default for PatternRules {

--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -17,7 +17,7 @@ comment is at the bottom of the incoming message after "Triggering comment by".
 That comment IS your task. Do what it says — nothing more, nothing less.
 
 You are triggered automatically when a PR matches the pattern rules (e.g., label `ready-for-dev`).
-The pattern has `trigger_mode = "pattern"` so no `@j:developer` mention is required.
+No `@j:developer` mention is required.
 
 ## Repository Setup
 Clone the repository from the trigger message to `repo/` if not already present,
@@ -124,7 +124,7 @@ Read the triggering comment at the bottom of the incoming message.
 
 When to hand off to Reviewer:
 - ONLY after completing the FULL implementation plan from a planner-created PR
-- Add the `ready-to-review` label — the reviewer pattern uses `trigger_mode = "pattern"` and is auto-triggered by the label alone
+- Add the `ready-to-review` label — the reviewer pattern is auto-triggered by the label alone
 - Mark PR ready: `gh pr ready <number>`
 - Add label: `gh pr edit <number> --add-label ready-to-review`
 

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -15,7 +15,7 @@ requirements with the user and create a PR when the plan is clear.
 
 ## How You Receive Work
 You are triggered automatically when an issue matches the pattern rules (e.g., label `planning`).
-The pattern has `trigger_mode = "pattern"` so no `@j:planner` mention is required.
+No `@j:planner` mention is required.
 The trigger message tells you the repository and issue number, for example:
 ```
 repository: kingye/jyc


### PR DESCRIPTION
## Spec

Remove the `TriggerMode` enum (`Pattern`/`Mention`/`Both`) and `trigger_mode` field from `ChannelPattern`. Since mention-based triggering is no longer used, all patterns now exclusively use pattern matching (rules-based). This simplifies the matching logic in `GithubMatcher::match_message`, removes dead code paths, and cleans up config/docs.

Fixes #76

## Implementation Plan

### Step 1: Remove `TriggerMode` enum and `trigger_mode` field from `src/channels/types.rs`
**What:** Delete the `TriggerMode` enum (lines 357-367), its `impl Default` block, the `trigger_mode` field from `ChannelPattern` (line 287), and the `trigger_mode` initialization in `ChannelPattern::default()` (line 302). Remove the doc comments on the field (lines 282-286).
**Why:** The enum and field are no longer needed — all triggering is pattern-based.
**Verify:** `cargo check` — should fail in `inbound.rs` due to removed type (fixed in Step 2).

### Step 2: Simplify `match_message` in `src/channels/github/inbound.rs`
**What:** 
- Remove `TriggerMode` from the import (line 10).
- Replace the `match pattern.trigger_mode { Pattern => ..., Mention => ..., Both => ... }` block (lines 71-138) with a single code path that:
  1. Calls `self.rules_match(&pattern.rules, message)` — if false, skip.
  2. Checks self-loop prevention (`comment_role` check) — if same role, skip.
  3. Returns `PatternMatch`.
- Remove the `has_rules_defined` helper method (lines ~156-162).
**Why:** Only pattern mode logic remains; Mention/Both branches are dead code.
**Verify:** `cargo check` compiles successfully.

### Step 3: Update test helpers and tests in `src/channels/github/inbound.rs`
**What:**
- In `make_patterns()` (line ~1045): remove `trigger_mode: TriggerMode::Pattern` from all 3 pattern definitions. Remove `trigger_mode: TriggerMode::Both` from reviewer.
- Delete `make_patterns_mention_mode()` function entirely (lines ~1083-1113) — it's only used by Mention-mode tests.
- Update `test_trigger_mode_pattern_*` tests (lines 1817-1856): remove `trigger_mode` field from inline patterns. Rename to remove "trigger_mode_" prefix (e.g. `test_pattern_issue_matches`).
- Delete Mention/Both tests: `test_trigger_mode_mention_requires_handover`, `test_trigger_mode_both_requires_handover_and_rules`, `test_trigger_mode_both_without_handover_fails`, `test_trigger_mode_both_without_rules_fails` (lines ~1862-1925).
**Why:** Tests for removed modes are invalid; remaining tests should reflect the simplified API.
**Verify:** `cargo test` — all remaining tests pass.

### Step 4: Remove `trigger_mode` from `config.example.toml`
**What:** Delete the 3 `trigger_mode = "pattern"` lines (lines 249, 261, 273) and their inline comments.
**Why:** Config option no longer exists.
**Verify:** Grep confirms no `trigger_mode` references remain in config.

### Step 5: Update documentation — `GITHUB_CHANNEL.md`
**What:**
- Remove the "Trigger Mode" section (lines ~169-181) including the table.
- Remove `trigger_mode` references from the Routing section (lines ~206-212), simplify to describe only pattern-based routing.
- Remove `trigger_mode` references from pattern descriptions (lines ~325, 342, 361).
- Update the summary line (line 14) to remove `trigger_mode` mention.
**Why:** Docs should not reference removed features.
**Verify:** Grep confirms no `trigger_mode` references in the file.

### Step 6: Update documentation — `DESIGN.md`
**What:** Remove `trigger_mode` field from the `ChannelPattern` struct (line ~905) and the `TriggerMode` enum description block below it.
**Why:** Design doc should reflect current architecture.
**Verify:** Grep confirms no `trigger_mode` references in the file.

### Step 7: Update template AGENTS.md files
**What:**
- `templates/github-planner/AGENTS.md`: Remove line 18 mentioning `trigger_mode = "pattern"`.
- `templates/github-developer/AGENTS.md`: Remove line 20 mentioning `trigger_mode = "pattern"`, and line 127 mentioning `trigger_mode = "pattern"` for reviewer.
**Why:** Templates should not reference removed config.
**Verify:** Grep confirms no `trigger_mode` references in templates.

### Step 8: Final verification
**What:** Run `cargo test` and `cargo clippy` to ensure no warnings or errors. Grep the entire repo for any remaining `trigger_mode` or `TriggerMode` references.
**Why:** Ensure complete removal with no dangling references.
**Verify:** `cargo test` passes, `cargo clippy` clean, `grep -r "trigger_mode\|TriggerMode" --include="*.rs" --include="*.toml" --include="*.md"` returns zero results.

## Design Decisions
- The self-loop prevention (`comment_role` check) is preserved — it's not specific to trigger_mode and prevents agents from re-triggering themselves.
- The `handover_role` metadata field remains in the matching logic for potential future use, but is no longer checked in `match_message` (it was only used by Mention/Both modes).
- All patterns now implicitly behave like the old `Pattern` mode — rules must match, no mention required.