### PR TITLE
fix: developer agent完成后未添加ready-to-review标签

### DIFF
--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -93,7 +93,7 @@ Read the triggering comment at the bottom of the incoming message.
         fi
         git add -A && git commit -m "feat: step N - <title>" && git push
         ```
-     - **Push after each step — do NOT batch**
+      - **Push after each step — do NOT batch**
    - If specific task: do what the comment asks
      - Run `{check_command}` to verify
 
@@ -113,30 +113,28 @@ Read the triggering comment at the bottom of the incoming message.
    - `docs: <what>` for documentation tasks
    - Other semantic commit types as appropriate
 
-4. **Reply on the PR**:
+4. **Hand off to reviewer if needed**:
+   Only hand off after completing the FULL implementation plan from a planner-created PR.
+   Skip handoff after fixing reviewer feedback, adding comments, refactoring, or any task from a non-planner comment.
+   ```bash
+   # Add ready-to-review label to trigger reviewer agent
+   gh pr edit <number> --add-label ready-to-review
+   gh pr ready <number>
+   ```
+
+5. **Reply on the PR**:
    ```bash
    gh pr comment <number> --body "[Developer] Done: <summary of what was done>"
    ```
 
-   5. **Wait for the next trigger** (new issues matching pattern rules or labeled for review)
+   6. **Wait for the next trigger** (new issues matching pattern rules or labeled for review)
 
-## Hand-off Rules
+## Hand-off Rules (Reference)
 
-When to hand off to Reviewer:
-- ONLY after completing the FULL implementation plan from a planner-created PR
-- Add the `ready-to-review` label — the reviewer pattern is auto-triggered by the label alone
-- Mark PR ready: `gh pr ready <number>`
-- Add label: `gh pr edit <number> --add-label ready-to-review`
-
-When NOT to hand off:
-- After fixing reviewer feedback (reviewer already knows — they will re-review)
-- After adding comments, refactoring, or any task requested by a non-planner comment
-- In these cases, just reply "[Developer] Done: ..." and wait
-
-When to hand off again after fixing reviewer feedback:
-- If the reviewer explicitly asks you to re-submit for review
-- Add `ready-to-review` label again: `gh pr edit <number> --add-label ready-to-review`
-- Otherwise, just reply "[Developer] Done: ..." — the reviewer will re-review when ready
+See Step 4 above for the handoff workflow. Key points:
+- **Hand off** after completing the FULL implementation plan from a planner-created PR
+- **Do NOT hand off** after fixing reviewer feedback, adding comments, refactoring, or non-planner tasks
+- To re-submit for review: `gh pr edit <number> --add-label ready-to-review`
 
 ## Rules
 - **#1 RULE: Do what the triggering comment says.** This overrides everything else.

--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -117,7 +117,8 @@ Read the triggering comment at the bottom of the incoming message.
    Only hand off after completing the FULL implementation plan from a planner-created PR.
    Skip handoff after fixing reviewer feedback, adding comments, refactoring, or any task from a non-planner comment.
    ```bash
-   # Add ready-to-review label to trigger reviewer agent
+   # Ensure label exists, then add to PR to trigger reviewer agent
+   gh label create ready-to-review --color "0E8A16" --description "PR ready for code review" 2>/dev/null || true
    gh pr edit <number> --add-label ready-to-review
    gh pr ready <number>
    ```
@@ -134,7 +135,7 @@ Read the triggering comment at the bottom of the incoming message.
 See Step 4 above for the handoff workflow. Key points:
 - **Hand off** after completing the FULL implementation plan from a planner-created PR
 - **Do NOT hand off** after fixing reviewer feedback, adding comments, refactoring, or non-planner tasks
-- To re-submit for review: `gh pr edit <number> --add-label ready-to-review`
+- To re-submit for review: `gh label create ready-to-review --color "0E8A16" --description "PR ready for code review" 2>/dev/null || true && gh pr edit <number> --add-label ready-to-review`
 
 ## Rules
 - **#1 RULE: Do what the triggering comment says.** This overrides everything else.

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -177,6 +177,7 @@ echo "PR assignees: $PR_ASSIGNEES (expected: $ASSIGNEES)"
 echo "PR labels: $PR_LABELS (expected: $LABELS)"
 
 # Trigger the developer agent by adding the developer label
+gh label create ready-for-dev --color "0E8A16" --description "PR ready for development" 2>/dev/null || true
 gh pr edit <pr_number> --add-label "ready-for-dev"
 ```
 
@@ -199,7 +200,7 @@ gh pr edit <pr_number> --add-label "ready-for-dev"
 - ONLY use the `bash` tool and `jyc_reply` tool — NO other tools
 - ALWAYS `cd repo` before running any command
 - ALWAYS include `Fixes #<issue_number>` in PR body
-- ALWAYS add the `ready-for-dev` label after creating the PR — this auto-triggers the Developer agent via pattern matching
+- ALWAYS add the `ready-for-dev` label after creating the PR — this auto-triggers the Developer agent via pattern matching (label is created with fallback if missing)
 - Reply in the same language as the user
 - Your PR must contain ZERO code changes — only the spec in the PR body
 - Your implementation plan must break the work into small, ordered steps — each with a clear verification method


### PR DESCRIPTION
## Spec

修改 Developer Agent 模板 (`templates/github-developer/AGENTS.md`)，将 `ready-to-review` 标签的添加步骤从独立的 "Hand-off Rules" 部分合并到主工作流中，防止 AI 模型在顺序执行工作流时遗漏 handoff 步骤。

Fixes #78

## Implementation Plan

### Step 1: 重构 Developer Agent 工作流，将 handoff 步骤内联
**What:** 修改 `templates/github-developer/AGENTS.md`，在 Workflow 步骤 3（实现代码）和步骤 4（回复 PR）之间插入明确的步骤 3b：判断是否需要 handoff to reviewer，并在需要时执行 `gh pr edit <number> --add-label ready-to-review`。同时精简 "Hand-off Rules" 部分，避免信息重复导致混淆。

**Why:** 当前 handoff 指令在独立于主工作流的 "Hand-off Rules" 部分，AI 模型按步骤顺序执行工作流时容易遗漏。将 handoff 判断内联到主工作流步骤中，确保模型在完成实现后一定会检查是否需要触发 review。

**Verify:** 审查修改后的 `templates/github-developer/AGENTS.md`，确认：
1. Workflow 步骤中包含明确的 handoff 判断和执行命令
2. "Hand-off Rules" 部分不再与主工作流重复
3. 整体流程逻辑与 GITHUB_CHANNEL.md 中的设计一致

### Step 2: 同步更新 GITHUB_CHANNEL.md 中的 Developer Workflow 描述
**What:** 检查 `GITHUB_CHANNEL.md` 中 "Agent B (Developer)" 的 Workflow 描述，确保步骤 7（handoff to reviewer）的描述与修改后的 Developer Agent 模板一致。

**Why:** GITHUB_CHANNEL.md 是架构文档，需要与实际模板保持一致，避免未来开发者参考文档时产生混淆。

**Verify:** 对比 `GITHUB_CHANNEL.md` 中 Developer Workflow 与 `templates/github-developer/AGENTS.md` 的描述，确认一致。

## Design Decisions
- 选择方案 A（修改模板）而非方案 B（程序化兜底），因为模板修改更简单直接，且不会产生误触发
- handoff 步骤内联到主工作流而非仅靠独立部分提醒，因为 AI 模型按步骤顺序执行更可靠
- 保留 "Hand-off Rules" 部分作为参考，但精简避免重复