### PR TITLE
fix: developer agent handoff与响应性问题修复

### DIFF
--- a/GITHUB_CHANNEL.md
+++ b/GITHUB_CHANNEL.md
@@ -275,21 +275,25 @@ Labels are a fixed convention hardcoded in agent templates.
 
 | Label | Purpose | Added By |
 |-------|---------|----------|
-| `jyc:plan` | Issue needs planning | User (or auto from config) |
-| `jyc:develop` | PR needs development | Planner (when creating PR) |
-| `jyc:review` | PR needs code review | Developer (when done implementing) |
+| `ready-for-dev` | PR ready for development | Planner (when creating PR) |
+| `ready-for-review` | PR ready for code review | Developer (when done implementing) |
 
 ### Label Usage by Agents
 
+**All label additions should include a creation tolerance** to handle cases where the label doesn't exist yet:
+
 ```bash
 # Planner: create PR with develop label
-gh pr create --title "feat: ..." --label "jyc:develop" --body "..."
+gh label create ready-for-dev --color "0E8A16" --description "PR ready for development" 2>/dev/null || true
+gh pr create --title "feat: ..." --label "ready-for-dev" --body "..."
 
 # Developer: add review label when done
-gh pr edit 43 --add-label "jyc:review"
+gh label create ready-for-review --color "0E8A16" --description "PR ready for code review" 2>/dev/null || true
+gh pr edit 43 --add-label "ready-for-review"
 
 # Reviewer: re-add develop label when requesting changes
-gh pr edit 43 --add-label "jyc:develop"
+gh label create ready-for-dev --color "0E8A16" --description "PR ready for development" 2>/dev/null || true
+gh pr edit 43 --add-label "ready-for-dev"
 ```
 
 ## Agent Roles & Skills
@@ -318,13 +322,13 @@ gh pr edit 43 --add-label "jyc:develop"
 **Trigger**: Auto-triggered on new PRs via pattern matching (github_type, labels)
 
 **Workflow**:
-1. Triggered automatically when PR matches pattern rules (e.g., label `jyc:develop`)
+1. Triggered automatically when PR matches pattern rules (e.g., label `ready-for-dev`)
 2. Read PR spec: `gh pr view {N}`
 3. Read linked issue: `gh issue view {linked_issue}`
 4. Clone repo, checkout PR branch
 5. Implement code (incremental-dev approach)
 6. Commit, push
-7. Hand over to reviewer (add `ready-to-review` label to trigger reviewer)
+7. Hand over to reviewer (create `ready-for-review` label + add to PR + `gh pr ready`)
 8. When review feedback received:
    - Read reviews: `gh pr view {N} --comments`
    - Fix issues, commit, push
@@ -334,15 +338,15 @@ gh pr edit 43 --add-label "jyc:develop"
 
 **Thread**: `review-pr-{N}`
 **Role**: Review PR code quality, approve or request changes.
-**Trigger**: Auto-triggered when PR has `ready-to-review` label via pattern matching
+**Trigger**: Auto-triggered when PR has `ready-for-review` label via pattern matching
 
 **Workflow**:
-1. Triggered automatically when PR has `ready-to-review` label
+1. Triggered automatically when PR has `ready-for-review` label
 2. Read PR: `gh pr view {N}`
 3. Read diff: `gh pr diff {N}`
 4. Review code
 5. Submit review: `gh pr review {N} --approve` or `--request-changes`
-6. Remove `ready-to-review` label: `gh pr edit {N} --remove-label ready-to-review`
+6. Remove `ready-for-review` label: `gh pr edit {N} --remove-label ready-for-review`
 7. If changes requested: hand over to developer (auto-trigger via pattern)
 
 ## Close & Cleanup
@@ -431,7 +435,7 @@ Every poll_interval_secs:
 3. Fetch recently closed issues/PRs (for close events)
    GET /repos/{o}/{r}/issues?state=closed&since={last_poll}&sort=updated
 
-4. For each open PR with 'ready-to-review' label: fetch reviews
+4. For each open PR with 'ready-for-review' label: fetch reviews
    GET /repos/{o}/{r}/pulls/{n}/reviews?since={last_poll}
 ```
 
@@ -494,7 +498,7 @@ User1                    Agent A (Planner)        Agent B (Developer)      Agent
   │                                │                      ├─ gh issue view 42     │
   │                                │                      ├─ Implement code       │
   │                                │                      ├─ git commit + push    │
-   │                                │                      ├─ add-label "ready-to-review" │
+   │                                │                      ├─ add-label "ready-for-review" │
   │                                │                      │                       │
   │                                │                      │  [poll: @j:rev] ─────►│
   │                                │                      │                       ├─ gh pr view 43
@@ -508,7 +512,7 @@ User1                    Agent A (Planner)        Agent B (Developer)      Agent
   │                                │                      ├─ gh pr view 43 --comments
   │                                │                      ├─ Fix code             │
   │                                │                      ├─ git push             │
-   │                                │                      ├─ add-label "ready-to-review" │
+   │                                │                      ├─ add-label "ready-for-review" │
   │                                │                      │                       │
   │                                │                      │  [poll: @j:rev] ─────►│
   │                                │                      │                       ├─ gh pr diff 43

--- a/config.example.toml
+++ b/config.example.toml
@@ -262,7 +262,7 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # github_type = ["pull_request"]
 # labels = ["ready-for-dev"]
 #
-# # Pattern: PRs with 'ready-to-review' label → Reviewer agent (auto-trigger)
+# # Pattern: PRs with 'ready-for-review' label → Reviewer agent (auto-trigger)
 # [[channels.my_repo.patterns]]
 # name = "reviewer"
 # enabled = true
@@ -271,7 +271,7 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 #
 # [channels.my_repo.patterns.rules]
 # github_type = ["pull_request"]
-# labels = ["ready-to-review"]
+# labels = ["ready-for-review"]
 #
 # # Pattern: PRs assigned to specific team members → Route to those assignees
 # # Assignee matching: OR logic (matches if ANY assignee is in the list)
@@ -284,7 +284,7 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # github_type = ["pull_request"]
 # assignees = ["alice", "bob"]
 #
-# # Pattern: PRs with 'ready-to-review' label AND assigned to 'alice' → Senior reviewer
+# # Pattern: PRs with 'ready-for-review' label AND assigned to 'alice' → Senior reviewer
 # # This demonstrates AND logic: BOTH labels and assignees must match
 # [[channels.my_repo.patterns]]
 # name = "senior_reviewer"
@@ -294,5 +294,5 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 #
 # [channels.my_repo.patterns.rules]
 # github_type = ["pull_request"]
-# labels = ["ready-to-review"]
+# labels = ["ready-for-review"]
 # assignees = ["alice"]

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -1233,9 +1233,9 @@ mod tests {
 
     #[test]
     fn test_all_rules_and_logic() {
-        // Pattern requires: pull_request AND label "ready-to-review" AND assignee "alice"
+        // Pattern requires: pull_request AND label "ready-for-review" AND assignee "alice"
         // Message has all three — should match
-        let mut msg = make_message_with_rules("pull_request", 43, &["ready-to-review"], &["alice"]);
+        let mut msg = make_message_with_rules("pull_request", 43, &["ready-for-review"], &["alice"]);
         msg.metadata.insert("handover_role".to_string(), serde_json::json!("reviewer"));
         let patterns = vec![ChannelPattern {
             name: "reviewer".to_string(),
@@ -1243,7 +1243,7 @@ mod tests {
             role: Some("Reviewer".to_string()),
             rules: crate::channels::types::PatternRules {
                 github_type: Some(vec!["pull_request".to_string()]),
-                labels: Some(vec!["ready-to-review".to_string()]),
+                labels: Some(vec!["ready-for-review".to_string()]),
                 assignees: Some(vec!["alice".to_string()]),
                 ..Default::default()
             },
@@ -1255,9 +1255,9 @@ mod tests {
 
     #[test]
     fn test_and_logic_partial_fail() {
-        // Pattern requires: pull_request AND label "ready-to-review" AND assignee "alice"
+        // Pattern requires: pull_request AND label "ready-for-review" AND assignee "alice"
         // Message has correct type and label but wrong assignee — should NOT match
-        let mut msg = make_message_with_rules("pull_request", 43, &["ready-to-review"], &["bob"]);
+        let mut msg = make_message_with_rules("pull_request", 43, &["ready-for-review"], &["bob"]);
         msg.metadata.insert("handover_role".to_string(), serde_json::json!("reviewer"));
         let patterns = vec![ChannelPattern {
             name: "reviewer".to_string(),
@@ -1265,7 +1265,7 @@ mod tests {
             role: Some("Reviewer".to_string()),
             rules: crate::channels::types::PatternRules {
                 github_type: Some(vec!["pull_request".to_string()]),
-                labels: Some(vec!["ready-to-review".to_string()]),
+                labels: Some(vec!["ready-for-review".to_string()]),
                 assignees: Some(vec!["alice".to_string()]),
                 ..Default::default()
             },

--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -117,30 +117,27 @@ Read the triggering comment at the bottom of the incoming message.
    - `docs: <what>` for documentation tasks
    - Other semantic commit types as appropriate
 
-4. **Reply on the PR**:
+4. **Hand off to Reviewer (if needed)**:
+   Only hand off after completing the FULL implementation plan from a planner-created PR.
+   Do NOT hand off after fixing reviewer feedback (they will re-review) unless explicitly asked.
+   ```bash
+   gh label create ready-for-review --color "0E8A16" --description "PR ready for code review" 2>/dev/null || true
+   gh pr edit <number> --add-label ready-for-review
+   gh pr ready <number>
+   ```
+
+5. **Reply on the PR**:
    ```bash
    gh pr comment <number> --body "[Developer] Step completed: <summary of what was done>"
    ```
 
-   5. **Wait for the next trigger** (new issues matching pattern rules or labeled for review)
+6. **Wait for the next trigger** (new issues matching pattern rules or labeled for review)
 
-## Hand-off Rules
+## Hand-off Quick Reference
 
-When to hand off to Reviewer:
-- ONLY after completing the FULL implementation plan from a planner-created PR
-- Add the `ready-to-review` label — the reviewer pattern is auto-triggered by the label alone
-- Mark PR ready: `gh pr ready <number>`
-- Add label: `gh pr edit <number> --add-label ready-to-review`
-
-When NOT to hand off:
-- After fixing reviewer feedback (reviewer already knows — they will re-review)
-- After adding comments, refactoring, or any task requested by a non-planner comment
-- In these cases, just reply "[Developer] Step completed: ..." and wait
-
-When to hand off again after fixing reviewer feedback:
-- If the reviewer explicitly asks you to re-submit for review
-- Add `ready-to-review` label again: `gh pr edit <number> --add-label ready-to-review`
-- Otherwise, just reply "[Developer] Step completed: ..." — the reviewer will re-review when ready
+- **After full plan**: Hand off → add `ready-for-review` label + `gh pr ready`
+- **After reviewer feedback fix**: Do NOT hand off — reviewer will re-review. Just reply "[Developer] Step completed: ..."
+- **Reviewer explicitly asks to re-submit**: Hand off again → add `ready-for-review` label
 
 ## Rules
 - **#1 RULE: Do what the triggering comment says.** This overrides everything else.

--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -8,6 +8,8 @@
 - **You MUST push code to the EXISTING PR branch, not create a new one**
 - **You MUST commit and push after EACH plan step — NEVER implement all steps then commit once**
 - **NEVER assume your work is "done" — you are a persistent, always-responsive agent. Every trigger is a new, independent task.**
+- **ALWAYS execute the current triggering comment as a NEW task, even if you previously said "Done" or "Completed"**
+- **Your previous "Done" comments do NOT mean the PR is finished — new instructions from Planner or Reviewer always take priority**
 - **NEVER commit or push on the main branch — you MUST be on the PR branch first**
 
 You are a developer agent for GitHub PRs.
@@ -72,6 +74,8 @@ gh pr view <number>
 gh pr view <number> --comments
 ```
 
+**Read ALL comments on the PR (including Planner and Reviewer comments). Any comment from Planner or Reviewer since your last action is a new task you MUST execute.**
+
 ### 3. Do What The Triggering Comment Says
 
 Read the triggering comment at the bottom of the incoming message.
@@ -115,7 +119,7 @@ Read the triggering comment at the bottom of the incoming message.
 
 4. **Reply on the PR**:
    ```bash
-   gh pr comment <number> --body "[Developer] Done: <summary of what was done>"
+   gh pr comment <number> --body "[Developer] Step completed: <summary of what was done>"
    ```
 
    5. **Wait for the next trigger** (new issues matching pattern rules or labeled for review)
@@ -131,12 +135,12 @@ When to hand off to Reviewer:
 When NOT to hand off:
 - After fixing reviewer feedback (reviewer already knows — they will re-review)
 - After adding comments, refactoring, or any task requested by a non-planner comment
-- In these cases, just reply "[Developer] Done: ..." and wait
+- In these cases, just reply "[Developer] Step completed: ..." and wait
 
 When to hand off again after fixing reviewer feedback:
 - If the reviewer explicitly asks you to re-submit for review
 - Add `ready-to-review` label again: `gh pr edit <number> --add-label ready-to-review`
-- Otherwise, just reply "[Developer] Done: ..." — the reviewer will re-review when ready
+- Otherwise, just reply "[Developer] Step completed: ..." — the reviewer will re-review when ready
 
 ## Rules
 - **#1 RULE: Do what the triggering comment says.** This overrides everything else.
@@ -147,7 +151,7 @@ When to hand off again after fixing reviewer feedback:
 - ALWAYS prefix PR comments with `[Developer]`
 - NEVER implement multiple plan steps before committing
 - You are ALWAYS responsive — every trigger is an independent task, regardless of what you did before
-- After completing any task, reply with "[Developer] Done: ..." and wait for the next trigger
+- After completing any task, reply with "[Developer] Step completed: ..." and wait for the next trigger
 - When using the reply tool, put your COMPLETE response in the message
 - Do NOT create new PRs or branches
 - Do NOT merge the PR

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -177,6 +177,7 @@ echo "PR assignees: $PR_ASSIGNEES (expected: $ASSIGNEES)"
 echo "PR labels: $PR_LABELS (expected: $LABELS)"
 
 # Trigger the developer agent by adding the developer label
+gh label create ready-for-dev --color "0E8A16" --description "PR ready for development" 2>/dev/null || true
 gh pr edit <pr_number> --add-label "ready-for-dev"
 ```
 

--- a/templates/github-reviewer/AGENTS.md
+++ b/templates/github-reviewer/AGENTS.md
@@ -6,7 +6,7 @@ quality, correctness, and design, then approve or request changes.
 **⚠️ NEVER use the `jyc_question_ask_user` tool. Use the reply tool ONLY.**
 
 ## How You Receive Work
-You are triggered automatically when a PR has the `ready-to-review` label.
+You are triggered automatically when a PR has the `ready-for-review` label.
 The trigger message tells you the repository, PR number, and the **triggering comment**
 (which contains the instruction or context for this review).
 ```
@@ -97,7 +97,8 @@ Please address the issues above.
 EOF
 )"
 gh pr comment <number> --body "[Reviewer] Please address the review feedback."
-gh pr edit <number> --remove-label ready-to-review
+gh pr edit <number> --remove-label ready-for-review
+gh label create ready-for-dev --color "0E8A16" --description "PR ready for development" 2>/dev/null || true
 gh pr edit <number> --add-label "ready-for-dev"
 ```
 
@@ -114,7 +115,7 @@ Code looks good. Approved.
 - <any minor notes>
 EOF
 )"
-gh pr edit <number> --remove-label ready-to-review
+gh pr edit <number> --remove-label ready-for-review
 ```
 
 ## Rules
@@ -128,6 +129,6 @@ gh pr edit <number> --remove-label ready-to-review
 - Do NOT modify code yourself — only review and comment
 - Do NOT merge the PR — that's the user's decision
 - Do NOT run `cargo build` or `npm run build` — use `cargo check` or `npm run lint` for lightweight verification. Full builds are the developer's responsibility, not the reviewer's.
-- ALWAYS remove the `ready-to-review` label after completing your review: `gh pr edit <number> --remove-label ready-to-review`
+- ALWAYS remove the `ready-for-review` label after completing your review: `gh pr edit <number> --remove-label ready-for-review`
 - Do NOT use the `jyc_question_ask_user` tool
 - Be constructive and objective in feedback


### PR DESCRIPTION
## Spec

修复 Developer Agent 的两个核心问题：(1) 完成实现后未添加 `ready-for-review` 标签触发 review；(2) 完成后拒绝执行新指令。同时统一标签命名为 `ready-for-*` 模式。

Fixes #78

## Implementation Plan

### Step 1: 修改 Developer Agent 模板 — 强化响应性
**What:** 修改 `templates/github-developer/AGENTS.md`：
1. 在 CRITICAL RESTRICTIONS 中添加：
   - "**ALWAYS execute the current triggering comment as a NEW task, even if you previously said 'Done' or 'Completed'**"
   - "**Your previous 'Done' comments do NOT mean the PR is finished — new instructions from Planner or Reviewer always take priority**"
2. 在 Workflow 步骤 2（Checkout and Read）中添加：
   - "Read ALL comments on the PR (including Planner and Reviewer comments). Any comment from Planner or Reviewer since your last action is a new task you MUST execute."
3. 将所有 `[Developer] Done:` 改为 `[Developer] Step completed:`，减少 LLM 对 "Done" 的语义锚定

**Why:** Developer Agent 在说 "Done" 后拒绝执行新指令，因为 LLM 看到自己的 "Done" 评论后产生惯性，认为工作已完成。需要更强的指令打破这种惯性。

**Verify:** 检查修改后的模板，确认 CRITICAL RESTRICTIONS 包含新的约束，Workflow 包含重新评估步骤，所有 "Done" 已替换为 "Step completed"。

### Step 2: 修改 Developer Agent 模板 — handoff 步骤内联 + 标签容错 + 重命名
**What:** 修改 `templates/github-developer/AGENTS.md`：
1. 在 Workflow 中插入明确的 handoff 步骤（在 reply 步骤之前）：
   - "Hand off to reviewer if needed: Only after completing FULL implementation plan from planner-created PR"
   - 添加标签创建容错：`gh label create ready-for-review --color "0E8A16" --description "PR ready for code review" 2>/dev/null || true`
   - 添加标签：`gh pr edit <number> --add-label ready-for-review`
   - `gh pr ready <number>`
2. 精简 "Hand-off Rules" 部分为简短参考，避免与主工作流重复
3. 将所有 `ready-to-review` 替换为 `ready-for-review`

**Why:** 原始问题 — handoff 步骤在独立部分被遗漏；标签不存在导致 `--add-label` 失败；命名不一致。

**Verify:** 检查模板中 handoff 步骤在主工作流中、有 `gh label create` 容错、无 `ready-to-review` 残留。

### Step 3: 修改 Reviewer Agent 模板 — 标签重命名
**What:** 修改 `templates/github-reviewer/AGENTS.md`：
1. 将所有 `ready-to-review` 替换为 `ready-for-review`
2. 在移除标签前也添加创建容错（保持一致性）

**Why:** 标签重命名需要所有相关文件同步更新。

**Verify:** `grep -r "ready-to-review" templates/github-reviewer/AGENTS.md` 无结果。

### Step 4: 修改 Planner Agent 模板 — 标签容错
**What:** 修改 `templates/github-planner/AGENTS.md`：
1. 在添加 `ready-for-dev` 标签前添加 `gh label create ready-for-dev --color "0E8A16" --description "PR ready for development" 2>/dev/null || true`

**Why:** Planner 添加 `ready-for-dev` 时也可能因标签不存在而失败。

**Verify:** 检查模板中 `gh label create ready-for-dev` 出现在 `gh pr edit --add-label ready-for-dev` 之前。

### Step 5: 更新 GITHUB_CHANNEL.md — 标签重命名 + 文档
**What:** 修改 `GITHUB_CHANNEL.md`：
1. 将所有 `ready-to-review` 替换为 `ready-for-review`
2. 在 "Routing Labels" 部分添加标签创建容错的说明
3. 更新 Agent B (Developer) Workflow 步骤 7 的描述，与新的内联 handoff 步骤一致

**Why:** 架构文档需要与实际模板保持一致。

**Verify:** `grep -r "ready-to-review" GITHUB_CHANNEL.md` 无结果。Developer Workflow 描述与模板一致。

### Step 6: 更新 config.example.toml — 标签重命名
**What:** 修改 `config.example.toml`：
1. 将 reviewer pattern 中的 `ready-to-review` 替换为 `ready-for-review`

**Verify:** `grep -r "ready-to-review" config.example.toml` 无结果。

### Step 7: 更新 Rust 源码测试 — 标签重命名
**What:** 修改 `src/channels/github/inbound.rs`：
1. 将测试中所有 `ready-to-review` 替换为 `ready-for-review`

**Verify:** `grep -r "ready-to-review" src/` 无结果。`cargo test` 通过。

## Design Decisions
- 统一使用 `ready-for-*` 标签命名模式（`ready-for-dev` / `ready-for-review`）
- 所有标签添加处增加 `gh label create` 容错，防止因标签不存在而失败
- handoff 步骤内联到 Developer 主工作流，避免独立部分被遗漏
- 将 "Done" 改为 "Step completed" 减少 LLM 语义锚定
- 在 CRITICAL RESTRICTIONS 中添加强制性约束，防止 Developer 拒绝新任务