### PR TITLE
feat: display last active time for threads in dashboard TUI

### DIFF
--- a/src/cli/dashboard.rs
+++ b/src/cli/dashboard.rs
@@ -235,6 +235,7 @@ fn render_threads(frame: &mut Frame, area: Rect, app: &mut App) {
         Cell::from("Pattern"),
         Cell::from("Status"),
         Cell::from("Tokens"),
+        Cell::from("Last Active"),
     ])
     .style(Style::default().add_modifier(Modifier::BOLD))
     .height(1);
@@ -262,12 +263,14 @@ fn render_threads(frame: &mut Frame, area: Rect, app: &mut App) {
                 Cell::from(t.pattern.clone().unwrap_or("-".into())),
                 Cell::from(Span::styled(format!("{}", t.status), status_style)),
                 Cell::from(tokens),
+                Cell::from(format_last_active(t.last_active_at.as_deref())),
             ])
         })
         .collect();
 
     let widths = [
         Constraint::Min(20),
+        Constraint::Length(12),
         Constraint::Length(12),
         Constraint::Length(12),
         Constraint::Length(12),
@@ -322,7 +325,7 @@ fn render_details(frame: &mut Frame, area: Rect, app: &App) {
     let detail_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(6), // Thread info
+            Constraint::Length(7), // Thread info
             Constraint::Min(4),   // Activity log
         ])
         .split(area);
@@ -370,6 +373,11 @@ fn render_details(frame: &mut Frame, area: Rect, app: &App) {
         status_line.push(Span::raw(format!("{cur} / {max} ({pct}%)")));
     }
     info_lines.push(Line::from(status_line));
+
+    info_lines.push(Line::from(vec![
+        Span::styled("Last Active: ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(format_last_active(selected.last_active_at.as_deref())),
+    ]));
 
     let info = Paragraph::new(info_lines).block(info_block);
     frame.render_widget(info, detail_chunks[0]);
@@ -454,4 +462,26 @@ fn format_duration(secs: u64) -> String {
     } else {
         format!("{mins}m")
     }
+}
+
+fn format_last_active(value: Option<&str>) -> String {
+    let value = match value {
+        Some(v) => v,
+        None => return "-".to_string(),
+    };
+    let dt = match chrono::DateTime::parse_from_rfc3339(value) {
+        Ok(dt) => dt.with_timezone(&chrono::Utc),
+        Err(_) => return "-".to_string(),
+    };
+    let now = chrono::Utc::now();
+    let diff = now.signed_duration_since(dt);
+    if diff.num_minutes() < 60 {
+        let mins = diff.num_minutes();
+        return format!("{}m ago", mins.max(0));
+    }
+    let dt_local = dt.format("%H:%M").to_string();
+    if dt.date_naive() == now.date_naive() {
+        return dt_local;
+    }
+    dt.format("%b %d").to_string()
 }

--- a/src/cli/dashboard.rs
+++ b/src/cli/dashboard.rs
@@ -475,13 +475,13 @@ fn format_last_active(value: Option<&str>) -> String {
     };
     let now = chrono::Utc::now();
     let diff = now.signed_duration_since(dt);
-    if diff.num_minutes() < 60 {
+    if diff.num_minutes() <= 60 {
         let mins = diff.num_minutes();
         return format!("{}m ago", mins.max(0));
     }
-    let dt_local = dt.format("%H:%M").to_string();
+    let dt_utc = dt.format("%H:%M").to_string();
     if dt.date_naive() == now.date_naive() {
-        return dt_local;
+        return dt_utc;
     }
     dt.format("%b %d").to_string()
 }

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -557,6 +557,7 @@ impl ThreadManager {
                 input_tokens,
                 max_tokens,
                 activity: vec![],  // Filled by InspectServer from event bus
+                last_active_at: None,  // Filled by InspectServer from event bus
             });
         }
 

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -547,6 +547,18 @@ impl ThreadManager {
                 ThreadStatus::Idle
             };
 
+            // Fallback: read .jyc directory mtime if no activity tracker data
+            let last_active_at = match tokio::fs::metadata(thread_path.join(".jyc")).await {
+                Ok(meta) => match meta.modified() {
+                    Ok(mtime) => {
+                        let dt: chrono::DateTime<chrono::Utc> = mtime.into();
+                        Some(dt.to_rfc3339())
+                    }
+                    Err(_) => None,
+                },
+                Err(_) => None,
+            };
+
             threads.push(ThreadInfo {
                 name,
                 channel: self.channel_name.clone(),
@@ -557,7 +569,7 @@ impl ThreadManager {
                 input_tokens,
                 max_tokens,
                 activity: vec![],  // Filled by InspectServer from event bus
-                last_active_at: None,  // Filled by InspectServer from event bus
+                last_active_at,  // Filled by activity tracker; falls back to .jyc mtime
             });
         }
 

--- a/src/inspect/server.rs
+++ b/src/inspect/server.rs
@@ -22,6 +22,7 @@ pub type SharedActivityMap = Arc<Mutex<HashMap<String, ThreadActivityState>>>;
 pub struct ThreadActivityState {
     pub entries: VecDeque<ActivityEntry>,
     pub is_processing: bool,
+    pub last_active_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 /// Shared state accessible by the inspect server.
@@ -179,6 +180,9 @@ impl InspectServer {
                 if state.is_processing {
                     thread.status = ThreadStatus::Processing;
                 }
+                if let Some(last_active) = state.last_active_at {
+                    thread.last_active_at = Some(last_active.to_rfc3339());
+                }
             }
         }
         drop(activity_map);
@@ -258,6 +262,7 @@ impl ActivityTracker {
                                                                 let mut map = map.lock().await;
                                                                 let state = map.entry(name.clone()).or_default();
                                                                 state.entries.push_back(entry);
+                                                                state.last_active_at = Some(event.timestamp());
                                                                 if state.entries.len() > MAX_ACTIVITY_ENTRIES {
                                                                     state.entries.pop_front();
                                                                 }

--- a/src/inspect/types.rs
+++ b/src/inspect/types.rs
@@ -64,6 +64,9 @@ pub struct ThreadInfo {
     /// Recent activity events (newest first, max ~20)
     #[serde(default)]
     pub activity: Vec<ActivityEntry>,
+    /// Last activity timestamp (RFC 3339), if known
+    #[serde(default)]
+    pub last_active_at: Option<String>,
 }
 
 /// A single activity event from the thread's SSE stream.
@@ -166,6 +169,7 @@ mod tests {
                 input_tokens: Some(45000),
                 max_tokens: Some(120000),
                 activity: vec![],
+                last_active_at: None,
             }],
             stats: GlobalStats {
                 active_workers: 2,


### PR DESCRIPTION
## Spec

Add "Last Active" time display to the dashboard TUI, showing when each thread was last active. The time appears both as a new column in the threads table and as a field in the thread detail panel.

Fixes #81

## Implementation Plan

### Step 1: Add `last_active_at` field to `ThreadInfo`
**What:** In `src/inspect/types.rs`, add `last_active_at: Option<String>` to the `ThreadInfo` struct. Add `#[serde(default)]` for backward compatibility. Update the test in the same file to include the new field.
**Why:** This is the data contract between inspect server and dashboard client.
**Verify:** `cargo check` passes.

### Step 2: Track `last_active_at` in `ThreadActivityState`
**What:** In `src/inspect/server.rs`, add `last_active_at: Option<chrono::DateTime<chrono::Utc>>` to `ThreadActivityState`. In the `ActivityTracker` spawned task (inside `ActivityTracker::start`), update `last_active_at` on every received `ThreadEvent` using `event.timestamp()`.
**Why:** The activity tracker already receives all thread events; updating a timestamp on each event is the most accurate source.
**Verify:** `cargo check` passes.

### Step 3: Populate `last_active_at` in `build_state()` with filesystem mtime fallback
**What:** In `src/inspect/server.rs`, in `InspectServer::build_state()`, after merging activity map data into threads:
1. If `ThreadActivityState.last_active_at` is `Some`, format it as RFC 3339 string and set `thread.last_active_at`.
2. If `None`, fall back to reading the `.jyc/` directory mtime from the thread's workspace path (`<workspace_dir>/<thread_name>/.jyc`). Use `tokio::fs::metadata` to get `modified()` time. Format as RFC 3339.
3. If both fail, leave as `None`.
**Why:** Filesystem mtime provides a persistent fallback after restarts when in-memory activity is lost.
**Verify:** `cargo check` passes.

### Step 4: Add "Last Active" column to threads table in dashboard
**What:** In `src/cli/dashboard.rs`, modify `render_threads()`:
1. Add `Cell::from("Last Active")` to the header row.
2. Add a `Cell` for `last_active_at` in each thread row, displaying the formatted time (using `format_last_active()`).
3. Update `widths` array to include `Constraint::Length(12)` for the new column.
4. Add `format_last_active()` function that takes `Option<&str>` and returns `String`:
   - Parse the RFC 3339 string to `DateTime<Utc>` using `chrono::DateTime::parse_from_rfc3339`.
   - Compare with `Utc::now()`:
     - Within 60 min: `Xm ago`
     - Today earlier: `HH:MM`
     - Yesterday or older: `Mon DD` (e.g., `Apr 22`)
   - On parse failure or `None`: return `-`
**Why:** Human-friendly relative/absolute time display in the table.
**Verify:** `cargo build` succeeds. Run `cargo run -- dashboard` to visually verify the new column.

### Step 5: Add "Last Active" to thread detail panel
**What:** In `src/cli/dashboard.rs`, modify `render_details()`:
1. After the existing status line (the one with Status + Tokens), add a new `Line` with:
   ```
   Span::styled("Last Active: ", bold)
   Span::raw(format_last_active value)
   ```
2. Increase the detail info panel `Constraint::Length` from 6 to 7 to accommodate the extra line.
**Why:** User requested last active time in the detail panel, not just the table.
**Verify:** `cargo build` succeeds. Run `cargo run -- dashboard` to visually verify the detail panel shows "Last Active".

### Step 6: Add `chrono` dependency for time formatting
**What:** Verify `chrono` is already in `Cargo.toml` (it is — used by `thread_event.rs`, `chat_log_store.rs`, etc.). No change needed unless the dashboard feature gate requires it.
**Why:** `format_last_active()` needs `chrono::DateTime::parse_from_rfc3339` and `chrono::Utc::now()`.
**Verify:** `cargo build` succeeds.

## Design Decisions
- `last_active_at` uses `Option<String>` (RFC 3339) in `ThreadInfo` to keep the serde contract simple and avoid requiring `chrono` in the inspect types module.
- In-memory `last_active_at` (from event timestamps) is the primary source; filesystem mtime is a fallback for after restarts.
- Time display uses relative format (`2m ago`) for recent activity and absolute format (`10:30`, `Apr 22`) for older activity — consistent with common TUI conventions.
- The detail panel info area grows from 6 to 7 lines to accommodate the new field.