### PR TITLE
feat: support AND/OR logic for labels in pattern matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to JYC will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **AND/OR logic for labels in pattern matching** — Labels rule now supports nested arrays for boolean combinations. Flat arrays `["bug", "enhancement"]` retain backward-compatible OR logic. Nested arrays `[["bug", "enhancement"], ["test"]]` use CNF: outer AND, inner OR — each group must have at least one matching label. (#83)
+
 ## [0.1.11] - 2026-04-20
 
 ### Added

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -1768,4 +1768,40 @@ mod tests {
         let result2 = GithubMatcher.match_message(&msg2, &patterns);
         assert!(result2.is_none(), "flat labels OR logic — no matching label");
     }
+
+    // --- TOML deserialization tests for LabelRule ---
+
+    #[test]
+    fn test_labels_toml_flat_deserialize() {
+        let pattern: ChannelPattern = toml::from_str(r#"
+            name = "test"
+            [rules]
+            labels = ["bug", "enhancement"]
+        "#).unwrap();
+        assert!(
+            matches!(pattern.rules.labels, Some(LabelRule::Flat(_))),
+            "flat TOML array should deserialize as LabelRule::Flat"
+        );
+        if let Some(LabelRule::Flat(labels)) = &pattern.rules.labels {
+            assert_eq!(labels, &["bug", "enhancement"]);
+        }
+    }
+
+    #[test]
+    fn test_labels_toml_nested_deserialize() {
+        let pattern: ChannelPattern = toml::from_str(r#"
+            name = "test"
+            [rules]
+            labels = [["bug", "enhancement"], ["test"]]
+        "#).unwrap();
+        assert!(
+            matches!(pattern.rules.labels, Some(LabelRule::Nested(_))),
+            "nested TOML array should deserialize as LabelRule::Nested"
+        );
+        if let Some(LabelRule::Nested(groups)) = &pattern.rules.labels {
+            assert_eq!(groups.len(), 2);
+            assert_eq!(groups[0], vec!["bug", "enhancement"]);
+            assert_eq!(groups[1], vec!["test"]);
+        }
+    }
 }

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -7,7 +7,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::channels::types::{
     ChannelMatcher, ChannelPattern, InboundAdapter, InboundAdapterOptions, InboundMessage,
-    MessageContent, PatternMatch, PatternRules,
+    LabelRule, MessageContent, PatternMatch, PatternRules,
 };
 use crate::utils::helpers::truncate_str;
 use super::client::GithubClient;
@@ -114,8 +114,8 @@ impl GithubMatcher {
             }
         }
 
-        // Check labels rule (OR logic: match if ANY label on the issue/PR is in the rule list)
-        if let Some(ref allowed_labels) = rules.labels {
+        // Check labels rule (delegates to LabelRule::matches for flat OR / nested AND-OR logic)
+        if let Some(ref label_rule) = rules.labels {
             let msg_labels: Vec<String> = message
                 .metadata
                 .get("github_labels")
@@ -126,10 +126,7 @@ impl GithubMatcher {
                         .collect()
                 })
                 .unwrap_or_default();
-            let has_match = allowed_labels
-                .iter()
-                .any(|l| msg_labels.contains(&l.to_lowercase()));
-            if !has_match {
+            if !label_rule.matches(&msg_labels) {
                 return false;
             }
         }

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -1179,7 +1179,7 @@ mod tests {
             role: Some("Developer".to_string()),
             rules: crate::channels::types::PatternRules {
                 github_type: Some(vec!["pull_request".to_string()]),
-                labels: Some(vec!["bug".to_string()]),
+                labels: Some(LabelRule::Flat(vec!["bug".to_string()])),
                 ..Default::default()
             },
             ..Default::default()
@@ -1199,7 +1199,7 @@ mod tests {
             role: Some("Developer".to_string()),
             rules: crate::channels::types::PatternRules {
                 github_type: Some(vec!["pull_request".to_string()]),
-                labels: Some(vec!["bug".to_string()]),
+                labels: Some(LabelRule::Flat(vec!["bug".to_string()])),
                 ..Default::default()
             },
             ..Default::default()
@@ -1219,7 +1219,7 @@ mod tests {
             role: Some("Developer".to_string()),
             rules: crate::channels::types::PatternRules {
                 github_type: Some(vec!["pull_request".to_string()]),
-                labels: Some(vec!["Bug".to_string()]),
+                labels: Some(LabelRule::Flat(vec!["Bug".to_string()])),
                 ..Default::default()
             },
             ..Default::default()
@@ -1240,7 +1240,7 @@ mod tests {
             role: Some("Reviewer".to_string()),
             rules: crate::channels::types::PatternRules {
                 github_type: Some(vec!["pull_request".to_string()]),
-                labels: Some(vec!["ready-for-review".to_string()]),
+                labels: Some(LabelRule::Flat(vec!["ready-for-review".to_string()])),
                 assignees: Some(vec!["alice".to_string()]),
                 ..Default::default()
             },
@@ -1262,7 +1262,7 @@ mod tests {
             role: Some("Reviewer".to_string()),
             rules: crate::channels::types::PatternRules {
                 github_type: Some(vec!["pull_request".to_string()]),
-                labels: Some(vec!["ready-for-review".to_string()]),
+                labels: Some(LabelRule::Flat(vec!["ready-for-review".to_string()])),
                 assignees: Some(vec!["alice".to_string()]),
                 ..Default::default()
             },

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -1635,4 +1635,137 @@ mod tests {
         let result = GithubMatcher.match_message(&msg, &patterns);
         assert!(result.is_none());
     }
+
+    // --- Nested AND/OR label logic tests ---
+
+    #[test]
+    fn test_labels_nested_and_or() {
+        // Nested: [["bug", "enhancement"], ["test"]] → (bug OR enhancement) AND test
+        // Message has ["bug", "test"] → should match
+        let mut msg = make_message_with_rules("pull_request", 43, &["bug", "test"], &[]);
+        msg.metadata.insert("handover_role".to_string(), serde_json::json!("developer"));
+        let patterns = vec![ChannelPattern {
+            name: "developer".to_string(),
+            enabled: true,
+            role: Some("Developer".to_string()),
+            rules: crate::channels::types::PatternRules {
+                github_type: Some(vec!["pull_request".to_string()]),
+                labels: Some(LabelRule::Nested(vec![
+                    vec!["bug".to_string(), "enhancement".to_string()],
+                    vec!["test".to_string()],
+                ])),
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
+        let result = GithubMatcher.match_message(&msg, &patterns);
+        assert!(result.is_some(), "should match when both AND groups are satisfied");
+
+        // Message has ["bug", "other"] → should NOT match (missing "test" group)
+        let mut msg2 = make_message_with_rules("pull_request", 44, &["bug", "other"], &[]);
+        msg2.metadata.insert("handover_role".to_string(), serde_json::json!("developer"));
+        let result2 = GithubMatcher.match_message(&msg2, &patterns);
+        assert!(result2.is_none(), "should not match when second AND group is not satisfied");
+    }
+
+    #[test]
+    fn test_labels_nested_single_group() {
+        // Nested with single group: [["bug"]] behaves same as flat ["bug"]
+        let mut msg = make_message_with_rules("pull_request", 43, &["bug"], &[]);
+        msg.metadata.insert("handover_role".to_string(), serde_json::json!("developer"));
+        let patterns = vec![ChannelPattern {
+            name: "developer".to_string(),
+            enabled: true,
+            role: Some("Developer".to_string()),
+            rules: crate::channels::types::PatternRules {
+                github_type: Some(vec!["pull_request".to_string()]),
+                labels: Some(LabelRule::Nested(vec![
+                    vec!["bug".to_string()],
+                ])),
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
+        let result = GithubMatcher.match_message(&msg, &patterns);
+        assert!(result.is_some(), "single nested group should behave like flat");
+    }
+
+    #[test]
+    fn test_labels_nested_all_and() {
+        // Nested: [["bug"], ["test"], ["v2"]] → requires all three labels
+        let mut msg = make_message_with_rules("pull_request", 43, &["bug", "test", "v2"], &[]);
+        msg.metadata.insert("handover_role".to_string(), serde_json::json!("developer"));
+        let patterns = vec![ChannelPattern {
+            name: "developer".to_string(),
+            enabled: true,
+            role: Some("Developer".to_string()),
+            rules: crate::channels::types::PatternRules {
+                github_type: Some(vec!["pull_request".to_string()]),
+                labels: Some(LabelRule::Nested(vec![
+                    vec!["bug".to_string()],
+                    vec!["test".to_string()],
+                    vec!["v2".to_string()],
+                ])),
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
+        let result = GithubMatcher.match_message(&msg, &patterns);
+        assert!(result.is_some(), "should match when all three labels are present");
+
+        // Missing one label → should NOT match
+        let mut msg2 = make_message_with_rules("pull_request", 44, &["bug", "test"], &[]);
+        msg2.metadata.insert("handover_role".to_string(), serde_json::json!("developer"));
+        let result2 = GithubMatcher.match_message(&msg2, &patterns);
+        assert!(result2.is_none(), "should not match when one required label is missing");
+    }
+
+    #[test]
+    fn test_labels_nested_empty_group() {
+        // Edge case: empty inner group [[]] should not block matching
+        let mut msg = make_message_with_rules("pull_request", 43, &["bug"], &[]);
+        msg.metadata.insert("handover_role".to_string(), serde_json::json!("developer"));
+        let patterns = vec![ChannelPattern {
+            name: "developer".to_string(),
+            enabled: true,
+            role: Some("Developer".to_string()),
+            rules: crate::channels::types::PatternRules {
+                github_type: Some(vec!["pull_request".to_string()]),
+                labels: Some(LabelRule::Nested(vec![
+                    vec!["bug".to_string()],
+                    vec![],  // empty group — should be treated as always-match
+                ])),
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
+        let result = GithubMatcher.match_message(&msg, &patterns);
+        assert!(result.is_some(), "empty inner group should not block matching");
+    }
+
+    #[test]
+    fn test_labels_flat_backward_compat() {
+        // Verify Flat(vec!["bug", "enhancement"]) still uses OR logic
+        let mut msg = make_message_with_rules("pull_request", 43, &["enhancement"], &[]);
+        msg.metadata.insert("handover_role".to_string(), serde_json::json!("developer"));
+        let patterns = vec![ChannelPattern {
+            name: "developer".to_string(),
+            enabled: true,
+            role: Some("Developer".to_string()),
+            rules: crate::channels::types::PatternRules {
+                github_type: Some(vec!["pull_request".to_string()]),
+                labels: Some(LabelRule::Flat(vec!["bug".to_string(), "enhancement".to_string()])),
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
+        let result = GithubMatcher.match_message(&msg, &patterns);
+        assert!(result.is_some(), "flat labels should use OR logic — enhancement matches");
+
+        // Neither label present → should NOT match
+        let mut msg2 = make_message_with_rules("pull_request", 44, &["other"], &[]);
+        msg2.metadata.insert("handover_role".to_string(), serde_json::json!("developer"));
+        let result2 = GithubMatcher.match_message(&msg2, &patterns);
+        assert!(result2.is_none(), "flat labels OR logic — no matching label");
+    }
 }

--- a/src/channels/types.rs
+++ b/src/channels/types.rs
@@ -331,9 +331,11 @@ pub struct PatternRules {
     /// GitHub entity type: "issue" or "pull_request" (OR logic within this rule)
     #[serde(default)]
     pub github_type: Option<Vec<String>>,
-    /// GitHub labels to match (OR logic: match if ANY label is present on the issue/PR)
+    /// GitHub labels to match.
+    /// - Flat list `["bug", "enhancement"]` → OR logic (backward compatible)
+    /// - Nested list `[["bug", "enhancement"], ["test"]]` → outer AND, inner OR
     #[serde(default)]
-    pub labels: Option<Vec<String>>,
+    pub labels: Option<LabelRule>,
     /// GitHub assignees to match (OR logic: match if ANY assignee is assigned to the issue/PR)
     #[serde(default)]
     pub assignees: Option<Vec<String>>,
@@ -372,6 +374,39 @@ pub struct SubjectRule {
     pub prefix: Option<Vec<String>>,
     /// Regex pattern to match against subject
     pub regex: Option<String>,
+}
+
+/// Label matching rule supporting both flat (OR) and nested (AND/OR) logic.
+///
+/// - `Flat(vec)` → OR logic: match if ANY label in the list is present (backward compatible)
+/// - `Nested(vec_of_vecs)` → CNF: outer AND, inner OR — each group must have at least one match
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum LabelRule {
+    /// Flat list: `["bug", "enhancement"]` → OR logic (backward compatible)
+    Flat(Vec<String>),
+    /// Nested list: `[["bug", "enhancement"], ["test"]]` → outer AND, inner OR
+    Nested(Vec<Vec<String>>),
+}
+
+impl LabelRule {
+    /// Check if the given message labels satisfy this rule.
+    ///
+    /// - Flat: OR logic — at least one label in the list matches
+    /// - Nested: outer AND, inner OR — each group must have at least one match
+    pub fn matches(&self, msg_labels: &[String]) -> bool {
+        match self {
+            LabelRule::Flat(labels) => {
+                labels.iter().any(|l| msg_labels.contains(&l.to_lowercase()))
+            }
+            LabelRule::Nested(groups) => {
+                groups.iter().all(|group| {
+                    group.is_empty()
+                        || group.iter().any(|l| msg_labels.contains(&l.to_lowercase()))
+                })
+            }
+        }
+    }
 }
 
 fn default_true() -> bool {

--- a/src/cli/patterns.rs
+++ b/src/cli/patterns.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use clap::Subcommand;
 use std::path::Path;
 
+use crate::channels::types::LabelRule;
 use crate::config::load_config;
 use crate::utils::constants::DEFAULT_CONFIG_FILENAME;
 
@@ -63,7 +64,18 @@ async fn run_list(workdir: &Path, config_file: &str) -> Result<()> {
                     println!("  github_type: {}", github_type.join(", "));
                 }
                 if let Some(ref labels) = pattern.rules.labels {
-                    println!("  labels: {}", labels.join(", "));
+                    match labels {
+                        LabelRule::Flat(list) => {
+                            println!("  labels: {}", list.join(", "));
+                        }
+                        LabelRule::Nested(groups) => {
+                            let display: Vec<String> = groups
+                                .iter()
+                                .map(|group| format!("({})", group.join(" OR ")))
+                                .collect();
+                            println!("  labels: {}", display.join(" AND "));
+                        }
+                    }
                 }
                 if let Some(ref assignees) = pattern.rules.assignees {
                     println!("  assignees: {}", assignees.join(", "));


### PR DESCRIPTION
## Spec

Support complex boolean logic for label matching in GitHub pattern rules. Currently `labels = ["bug", "enhancement"]` uses OR logic (match if ANY label is present). This PR adds support for nested arrays to express AND/OR combinations, e.g., `labels = [["bug", "enhancement"], ["test"]]` means `(bug OR enhancement) AND test`. Flat arrays remain backward compatible with existing OR behavior.

Fixes #83

## Implementation Plan

### Step 1: Add `LabelRule` enum to `src/channels/types.rs`
**What:** Create a new `LabelRule` enum with `#[serde(untagged)]` that supports both flat (`Vec<String>`) and nested (`Vec<Vec<String>>`) formats. Change the `labels` field in `PatternRules` from `Option<Vec<String>>` to `Option<LabelRule>`. Add a helper method `LabelRule::matches(&self, msg_labels: &[String]) -> bool` that implements the matching logic:
- `Flat(vec)` → OR logic (any label in vec matches any msg_label) — backward compatible
- `Nested(vec_of_vecs)` → outer AND, inner OR (each inner vec must have at least one label matching a msg_label)

```rust
#[derive(Debug, Clone, Serialize, Deserialize)]
#[serde(untagged)]
pub enum LabelRule {
    /// Flat list: ["bug", "enhancement"] → OR logic (backward compatible)
    Flat(Vec<String>),
    /// Nested list: [["bug", "enhancement"], ["test"]] → outer AND, inner OR
    Nested(Vec<Vec<String>>),
}

impl LabelRule {
    /// Check if the given message labels satisfy this rule.
    /// - Flat: OR logic — at least one label in the list matches
    /// - Nested: outer AND, inner OR — each group must have at least one match
    pub fn matches(&self, msg_labels: &[String]) -> bool {
        match self {
            LabelRule::Flat(labels) => {
                labels.iter().any(|l| msg_labels.contains(&l.to_lowercase()))
            }
            LabelRule::Nested(groups) => {
                groups.iter().all(|group| {
                    group.is_empty() || group.iter().any(|l| msg_labels.contains(&l.to_lowercase()))
                })
            }
        }
    }
}
```

**Why:** This is the core data model change. `serde(untagged)` lets serde auto-detect the TOML structure, so existing configs with flat arrays continue to work without modification.
**Verify:** `cargo check` — should compile with no errors. Existing tests that reference `rules.labels` will need updating in Step 3, so some test failures are expected here.

### Step 2: Update `rules_match()` in `src/channels/github/inbound.rs`
**What:** Replace the current labels matching block in `GithubMatcher::rules_match()` (lines ~130-151) to use `LabelRule::matches()` instead of the inline OR logic. The current code:
```rust
if let Some(ref allowed_labels) = rules.labels {
    let msg_labels: Vec<String> = ...;
    let has_match = allowed_labels.iter().any(|l| msg_labels.contains(&l.to_lowercase()));
    if !has_match { return false; }
}
```
Should become:
```rust
if let Some(ref label_rule) = rules.labels {
    let msg_labels: Vec<String> = message.metadata
        .get("github_labels")
        .and_then(|v| v.as_array())
        .map(|arr| arr.iter().filter_map(|v| v.as_str().map(|s| s.to_lowercase())).collect())
        .unwrap_or_default();
    if !label_rule.matches(&msg_labels) {
        return false;
    }
}
```

**Why:** Delegates matching logic to the `LabelRule` enum, keeping `rules_match()` clean.
**Verify:** `cargo check` — should compile. Existing label tests should still pass since flat arrays use the same OR logic.

### Step 3: Update `src/cli/patterns.rs` display
**What:** Update the labels display in `run_list()` (around line 75) to handle both `LabelRule::Flat` and `LabelRule::Nested` variants. For flat, display as before: `labels: bug, enhancement`. For nested, display with grouping: `labels: (bug OR enhancement) AND (test)`.
**Why:** Users need to see the configured label rules clearly in CLI output.
**Verify:** `cargo check` — should compile.

### Step 4: Update existing tests in `src/channels/github/inbound.rs`
**What:** Update all test functions that construct `PatternRules` with `labels: Some(vec![...])` to use `labels: Some(LabelRule::Flat(vec![...]))`. Affected tests:
- `test_labels_rule_blocks_wrong_label`
- `test_labels_rule_allows_matching_label`
- `test_labels_rule_case_insensitive`
- `test_all_rules_and_logic`
- `test_and_logic_partial_fail`

**Why:** The type changed from `Option<Vec<String>>` to `Option<LabelRule>`, so existing test code won't compile.
**Verify:** `cargo test` — all existing tests should pass with the updated syntax.

### Step 5: Add new tests for nested AND/OR logic
**What:** Add new test functions in `src/channels/github/inbound.rs`:
- `test_labels_nested_and_or` — `[["bug", "enhancement"], ["test"]]` matches issue with labels `["bug", "test"]` but not `["bug", "other"]`
- `test_labels_nested_single_group` — `[["bug"]]` behaves same as flat `["bug"]`
- `test_labels_nested_all_and` — `[["bug"], ["test"], ["v2"]]` requires all three labels
- `test_labels_nested_empty_group` — edge case: empty inner group `[[]]` should not block matching
- `test_labels_flat_backward_compat` — verify `Flat(vec!["bug", "enhancement"])` still uses OR logic

**Why:** Comprehensive test coverage for the new feature and edge cases.
**Verify:** `cargo test` — all new and existing tests should pass.

### Step 6: Update config validation in `src/config/validation.rs` (if needed)
**What:** Check if `validate_pattern()` has any labels-specific validation. If so, update it to handle `LabelRule` variants. Currently there's no labels validation, so this step may be a no-op — just verify.
**Why:** Ensure config validation doesn't reject the new nested format.
**Verify:** `cargo test` — full test suite passes. `cargo check` clean.

## Design Decisions
- **Backward compatible**: Flat arrays `["a", "b"]` continue to work as OR logic — no config migration needed
- **`serde(untagged)`**: Lets serde auto-detect flat vs nested format from TOML structure
- **CNF (Conjunctive Normal Form)**: Outer AND, inner OR — covers the most common use cases like `(bug OR enhancement) AND test`
- **Same pattern extensible to `assignees`**: If needed later, the same `LabelRule` enum approach can be applied to assignees matching