### PR TITLE
feat: deploy-templates.sh support --as flag for renaming template on deploy

### DIFF
--- a/deploy-templates.sh
+++ b/deploy-templates.sh
@@ -4,11 +4,12 @@ set -e
 # Deploy templates by composing AGENTS.md + referenced skills from .opencode/skills/
 #
 # Usage:
-#   ./deploy-templates.sh <target_dir> [template_name] [--model <model-id>]
+#   ./deploy-templates.sh <target_dir> [template_name] [--as <new_name>] [--model <model-id>]
 #
 # Examples:
 #   ./deploy-templates.sh /path/to/templates
 #   ./deploy-templates.sh /path/to/templates github-planner
+#   ./deploy-templates.sh /path/to/templates github-planner --as my-custom-planner
 #   ./deploy-templates.sh /path/to/templates --model tencent/glm-5.1
 #   ./deploy-templates.sh /path/to/templates github-planner --model ark/minimax-m2.5
 
@@ -18,12 +19,17 @@ SKILLS_DIR="${SCRIPT_DIR}/.opencode/skills"
 
 TARGET_DIR=""
 TEMPLATE_NAME=""
+AS_NAME=""
 MODEL_OVERRIDE=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --model)
             MODEL_OVERRIDE="$2"
+            shift 2
+            ;;
+        --as)
+            AS_NAME="$2"
             shift 2
             ;;
         -*)
@@ -45,13 +51,19 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [ -z "$TARGET_DIR" ]; then
-    echo "Usage: $0 <target_dir> [template_name] [--model <model-id>]"
+    echo "Usage: $0 <target_dir> [template_name] [--as <new_name>] [--model <model-id>]"
     echo ""
     echo "Examples:"
     echo "  $0 /path/to/templates"
     echo "  $0 /path/to/templates github-planner"
+    echo "  $0 /path/to/templates github-planner --as my-custom-planner"
     echo "  $0 /path/to/templates --model tencent/glm-5.1"
     echo "  $0 /path/to/templates github-planner --model ark/minimax-m2.5"
+    exit 1
+fi
+
+if [ -n "$AS_NAME" ] && [ -z "$TEMPLATE_NAME" ]; then
+    echo "Error: --as requires a template name to be specified" >&2
     exit 1
 fi
 
@@ -82,6 +94,9 @@ echo "Target:           ${TARGET_DIR}"
 if [ -n "$TEMPLATE_NAME" ]; then
     echo "Template filter: ${TEMPLATE_NAME}"
 fi
+if [ -n "$AS_NAME" ]; then
+    echo "Deploying as:    ${AS_NAME}"
+fi
 if [ -n "$MODEL_OVERRIDE" ]; then
     echo "Model override:  ${MODEL_OVERRIDE}"
 fi
@@ -94,9 +109,16 @@ for template_dir in "${TEMPLATES_DIR}"/*/; do
         continue
     fi
 
-    target="${TARGET_DIR}/${template_name}"
+    if [ -n "$AS_NAME" ]; then
+        target="${TARGET_DIR}/${AS_NAME}"
+    else
+        target="${TARGET_DIR}/${template_name}"
+    fi
 
     echo "--- ${template_name} ---"
+    if [ -n "$AS_NAME" ]; then
+        echo "  deploying as: ${AS_NAME}"
+    fi
 
     mkdir -p "${target}"
 


### PR DESCRIPTION
## Spec

Add `--as <new_name>` flag to `deploy-templates.sh` so that a source template can be deployed to the target directory under a different name. This enables deploying the same template multiple times with different configurations (e.g., different models).

Fixes #85

## Implementation Plan

### Step 1: Add `--as` option parsing to argument loop
**What:** In `deploy-templates.sh`, add `--as` as a new option in the `while` loop (lines 23-45), alongside the existing `--model` option. Store the value in a new `AS_NAME` variable.
**Why:** This is the entry point for the new feature — the CLI must accept and parse the new flag.
**Verify:** Run `./deploy-templates.sh /tmp/test --as foo` — should no longer error with "Unknown option: --as".

### Step 2: Add validation — `--as` requires a template name
**What:** After the argument parsing block (after line 45), add validation: if `AS_NAME` is set but `TEMPLATE_NAME` is empty, print an error and exit. Message: `"Error: --as requires a template name to be specified"`.
**Why:** Renaming only makes sense when deploying a single specific template, not when deploying all templates at once.
**Verify:** Run `./deploy-templates.sh /tmp/test --as foo` (no template name) — should print the error and exit 1.

### Step 3: Update usage/help text
**What:** Update the usage string (line 48) and examples (lines 49-55) to include `--as`:
- Usage: `./deploy-templates.sh <target_dir> [template_name] [--as <new_name>] [--model <model-id>]`
- Add example: `./deploy-templates.sh /path/to/templates github-planner --as my-custom-planner`
**Why:** Users need to know the new flag exists.
**Verify:** Run `./deploy-templates.sh` (no args) — should show updated usage with `--as`.

### Step 4: Use `AS_NAME` as target directory name when set
**What:** In the deployment loop (around line 97), change `target="${TARGET_DIR}/${template_name}"` to use `AS_NAME` when set:
```bash
if [ -n "$AS_NAME" ]; then
    target="${TARGET_DIR}/${AS_NAME}"
else
    target="${TARGET_DIR}/${template_name}"
fi
```
**Why:** This is the core change — the target directory name should reflect the `--as` value instead of the source template name.
**Verify:** Run `./deploy-templates.sh /tmp/test github-planner --as my-planner` then `ls /tmp/test/` — should see `my-planner/` instead of `github-planner/`.

### Step 5: Update echo output to show rename info
**What:** In the info section (lines 78-87), add output for `--as` if set. In the per-template loop, if `AS_NAME` is set, echo something like `"  deploying as: ${AS_NAME}"`.
**Why:** Visibility — users should confirm the rename is happening.
**Verify:** Run with `--as` flag and check that the output mentions the target name.

### Step 6: Keep `get_skills()` using source template name
**What:** No change needed — the existing code already calls `get_skills "$template_name"` (line 114) where `template_name` is the source directory name. Since we only rename the target, skill lookup remains correct.
**Why:** Skills are associated with the source template's identity, not the deployed name.
**Verify:** Deploy with `--as` and confirm skills are still copied (check `.opencode/skills/` in the target directory).

## Design Decisions
- `--as` requires `template_name` — cannot rename when deploying all templates
- Skills lookup uses the **source** template name (via `get_skills`), unaffected by renaming
- No Rust code changes needed — the runtime looks up templates by the name in config (`template = "xxx"`), which the user simply sets to the new name