### PR TITLE
fix: Developer agent always hands off to Reviewer after completing work

### DIFF
--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -117,9 +117,8 @@ Read the triggering comment at the bottom of the incoming message.
    - `docs: <what>` for documentation tasks
    - Other semantic commit types as appropriate
 
-4. **Hand off to Reviewer (if needed)**:
-   Only hand off after completing the FULL implementation plan from a planner-created PR.
-   Do NOT hand off after fixing reviewer feedback (they will re-review) unless explicitly asked.
+4. **Hand off to Reviewer**:
+   Always hand off to Reviewer after completing any task (initial implementation or reviewer feedback fix).
    ```bash
    gh label create ready-for-review --color "0E8A16" --description "PR ready for code review" 2>/dev/null || true
    gh pr edit <number> --add-label ready-for-review

--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -135,8 +135,7 @@ Read the triggering comment at the bottom of the incoming message.
 ## Hand-off Quick Reference
 
 - **After full plan**: Hand off → add `ready-for-review` label + `gh pr ready`
-- **After reviewer feedback fix**: Do NOT hand off — reviewer will re-review. Just reply "[Developer] Step completed: ..."
-- **Reviewer explicitly asks to re-submit**: Hand off again → add `ready-for-review` label
+- **After reviewer feedback fix**: Hand off → add `ready-for-review` label (reviewer needs the label to be re-triggered)
 
 ## Rules
 - **#1 RULE: Do what the triggering comment says.** This overrides everything else.


### PR DESCRIPTION
## Spec

Fix the Developer agent template so it always adds the `ready-for-review` label after completing any task — both initial implementation and reviewer feedback fixes. Currently, the Developer agent is instructed to NOT hand off after fixing reviewer feedback, but this breaks the workflow because the Reviewer agent is triggered by the `ready-for-review` label, which the Reviewer removes when requesting changes. Without re-adding the label, the Reviewer is never re-triggered.

Fixes #87

## Implementation Plan

### Step 1: Update the "Hand off to Reviewer" section in Developer template
**What:** In `templates/github-developer/AGENTS.md`, modify step 4 "Hand off to Reviewer (if needed)" (lines 120-126). Remove the conditional text "Only hand off after completing the FULL implementation plan from a planner-created PR. Do NOT hand off after fixing reviewer feedback (they will re-review) unless explicitly asked." Replace it with unconditional instructions: "Always hand off to Reviewer after completing any task (initial implementation or reviewer feedback fix)." Keep the `gh label create` / `gh pr edit --add-label ready-for-review` / `gh pr ready` commands unchanged.
**Why:** The current conditional logic is the root cause of the bug — it tells the Developer to skip the hand-off after reviewer feedback, but the Reviewer needs the label to be re-triggered.
**Verify:** Read the updated file and confirm the conditional language is removed. The hand-off commands (`gh label create`, `gh pr edit --add-label`, `gh pr ready`) should remain intact.

### Step 2: Update the Hand-off Quick Reference table
**What:** In `templates/github-developer/AGENTS.md`, update the "Hand-off Quick Reference" section (lines 136-140). Change the three bullet points from:
```
- After full plan: Hand off → add ready-for-review label + gh pr ready
- After reviewer feedback fix: Do NOT hand off — reviewer will re-review. Just reply "[Developer] Step completed: ..."
- Reviewer explicitly asks to re-submit: Hand off again → add ready-for-review label
```
To:
```
- After full plan: Hand off → add ready-for-review label + gh pr ready
- After reviewer feedback fix: Hand off → add ready-for-review label (reviewer needs the label to be re-triggered)
```
**Why:** The quick reference must be consistent with the updated step 4 instructions. The third bullet ("Reviewer explicitly asks to re-submit") is no longer needed since hand-off is now unconditional.
**Verify:** Read the updated Hand-off Quick Reference and confirm it has exactly two bullet points, both instructing to add the `ready-for-review` label.

### Step 3: Verify consistency across the full Developer template
**What:** Search the entire `templates/github-developer/AGENTS.md` file for any remaining references to "Do NOT hand off" or "reviewer will re-review" or similar conditional hand-off language. Remove or update any found.
**Why:** Ensure there are no contradictory instructions left in the template that could confuse the Developer agent.
**Verify:** `grep -i "do not hand off\|reviewer will re-review" templates/github-developer/AGENTS.md` should return no results.

## Design Decisions
- The fix is purely in the agent template instructions (`templates/github-developer/AGENTS.md`) — no Rust code changes needed
- The label-based triggering mechanism in `src/channels/github/inbound.rs` is correct; the bug is in the agent instructions
- We keep `gh pr ready` only for the initial implementation (first hand-off), since the PR is already marked ready after the first time
- The Reviewer template (`templates/github-reviewer/AGENTS.md`) is correct and needs no changes — it properly removes `ready-for-review` and adds `ready-for-dev` when requesting changes