### PR TITLE
fix: skip comments on closed issues/PRs to prevent developer triggering on close

### DIFF
--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -659,6 +659,10 @@ impl GithubInboundAdapter {
             }
         }
 
+        // Build set of current open issue numbers — needed in step 2 (comment
+        // filtering) and step 3 (close detection).
+        let current_open_numbers: HashSet<u64> = issues.iter().map(|i| i.number).collect();
+
         // 2. Fetch and process comments.
         // The issue cache is now populated, so lookups work correctly.
         let comments = client.list_comments_since(&poll_start).await?;
@@ -778,9 +782,6 @@ impl GithubInboundAdapter {
         // Since we fetched ALL open issues (not just recently-updated ones),
         // the comparison is reliable: if an issue was in the cache but is not
         // in the current open set, it was genuinely closed.
-        //
-        // Build set of current open issue numbers for comparison
-        let current_open_numbers: HashSet<u64> = issues.iter().map(|i| i.number).collect();
 
         // Find issues that were in cache but not in current open list
         let cached_numbers: Vec<u64> = issue_cache.keys().cloned().collect();

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -1819,4 +1819,45 @@ mod tests {
             assert_eq!(groups[1], vec!["test"]);
         }
     }
+
+    // --- Closed issue/PR comment filtering (issue #89) ---
+
+    /// Verifies that the `current_open_numbers` set correctly identifies
+    /// which issues/PRs are open vs closed, which is the basis for skipping
+    /// comments on closed issues/PRs in `poll_once` step 2.
+    ///
+    /// The actual filtering in `poll_once` uses:
+    ///   `if !current_open_numbers.contains(&issue_number) { continue; }`
+    /// This test validates that set membership works as expected for the
+    /// open/closed distinction.
+    #[test]
+    fn test_closed_issue_comment_filtering() {
+        // Simulate: issues #10, #20 are open; #30 was in cache but is now closed
+        let open_issues: Vec<u64> = vec![10, 20];
+        let current_open_numbers: HashSet<u64> = open_issues.into_iter().collect();
+
+        // Comment on open issue #10 → should NOT be skipped
+        assert!(
+            current_open_numbers.contains(&10),
+            "comment on open issue should be processed"
+        );
+
+        // Comment on open issue #20 → should NOT be skipped
+        assert!(
+            current_open_numbers.contains(&20),
+            "comment on open issue should be processed"
+        );
+
+        // Comment on closed issue #30 → should be skipped
+        assert!(
+            !current_open_numbers.contains(&30),
+            "comment on closed issue should be skipped"
+        );
+
+        // Edge case: issue_number 0 (parse failure) → should be skipped
+        assert!(
+            !current_open_numbers.contains(&0),
+            "comment with unparseable issue number should be skipped"
+        );
+    }
 }

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -10,7 +10,7 @@ use crate::channels::types::{
     LabelRule, MessageContent, PatternMatch, PatternRules,
 };
 use crate::utils::helpers::truncate_str;
-use super::client::GithubClient;
+use super::client::{GithubClient, GithubComment};
 use super::config::GithubConfig;
 
 /// GitHub channel matcher — stateless pattern matching for GitHub events.
@@ -701,7 +701,7 @@ impl GithubInboundAdapter {
 
             // Skip comments on closed issues/PRs — prevents triggering agents
             // for PRs/issues that were closed between poll cycles.
-            if !current_open_numbers.contains(&issue_number) {
+            if !should_process_comment(comment, &current_open_numbers) {
                 tracing::debug!(
                     channel = %self.channel_name,
                     comment_id = comment.id,
@@ -940,6 +940,17 @@ fn extract_mention_role(text: &str) -> Option<String> {
     re.captures(text)
         .and_then(|caps| caps.get(1))
         .map(|m| m.as_str().to_lowercase())
+}
+
+/// Check whether a comment should be processed based on whether its
+/// parent issue/PR is still open.
+///
+/// Returns `true` if the comment's issue is in the open set and should
+/// be routed to agents. Returns `false` if the issue is closed (not in
+/// the open set) or if the issue number could not be parsed from the URL.
+fn should_process_comment(comment: &GithubComment, open_numbers: &HashSet<u64>) -> bool {
+    let issue_number = comment.issue_number().unwrap_or(0);
+    open_numbers.contains(&issue_number)
 }
 
 #[cfg(test)]
@@ -1822,42 +1833,70 @@ mod tests {
 
     // --- Closed issue/PR comment filtering (issue #89) ---
 
-    /// Verifies that the `current_open_numbers` set correctly identifies
-    /// which issues/PRs are open vs closed, which is the basis for skipping
-    /// comments on closed issues/PRs in `poll_once` step 2.
-    ///
-    /// The actual filtering in `poll_once` uses:
-    ///   `if !current_open_numbers.contains(&issue_number) { continue; }`
-    /// This test validates that set membership works as expected for the
-    /// open/closed distinction.
+    /// Tests `should_process_comment` — the helper that decides whether a
+    /// comment should be routed to agents based on whether its parent
+    /// issue/PR is still open.
     #[test]
-    fn test_closed_issue_comment_filtering() {
-        // Simulate: issues #10, #20 are open; #30 was in cache but is now closed
-        let open_issues: Vec<u64> = vec![10, 20];
-        let current_open_numbers: HashSet<u64> = open_issues.into_iter().collect();
+    fn test_should_process_comment_open_issue() {
+        use super::super::client::{GithubComment, GithubUser};
 
-        // Comment on open issue #10 → should NOT be skipped
-        assert!(
-            current_open_numbers.contains(&10),
-            "comment on open issue should be processed"
-        );
+        let open_numbers: HashSet<u64> = [10, 20].into_iter().collect();
 
-        // Comment on open issue #20 → should NOT be skipped
+        // Comment on open issue #10 → should be processed
+        let comment = GithubComment {
+            id: 1,
+            user: GithubUser { login: "user1".to_string() },
+            body: "test".to_string(),
+            issue_url: "https://api.github.com/repos/owner/repo/issues/10".to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+        };
         assert!(
-            current_open_numbers.contains(&20),
-            "comment on open issue should be processed"
+            should_process_comment(&comment, &open_numbers),
+            "comment on open issue #10 should be processed"
         );
+    }
+
+    #[test]
+    fn test_should_process_comment_closed_issue() {
+        use super::super::client::{GithubComment, GithubUser};
+
+        let open_numbers: HashSet<u64> = [10, 20].into_iter().collect();
 
         // Comment on closed issue #30 → should be skipped
+        let comment = GithubComment {
+            id: 2,
+            user: GithubUser { login: "user1".to_string() },
+            body: "test".to_string(),
+            issue_url: "https://api.github.com/repos/owner/repo/issues/30".to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+        };
         assert!(
-            !current_open_numbers.contains(&30),
-            "comment on closed issue should be skipped"
+            !should_process_comment(&comment, &open_numbers),
+            "comment on closed issue #30 should be skipped"
         );
+    }
 
-        // Edge case: issue_number 0 (parse failure) → should be skipped
+    #[test]
+    fn test_should_process_comment_malformed_url() {
+        use super::super::client::{GithubComment, GithubUser};
+
+        let open_numbers: HashSet<u64> = [10, 20].into_iter().collect();
+
+        // Comment with malformed issue_url → issue_number() returns None,
+        // unwrap_or(0) yields 0, which is not in open set → should be skipped
+        let comment = GithubComment {
+            id: 3,
+            user: GithubUser { login: "user1".to_string() },
+            body: "test".to_string(),
+            issue_url: "not-a-valid-url".to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+        };
         assert!(
-            !current_open_numbers.contains(&0),
-            "comment with unparseable issue number should be skipped"
+            !should_process_comment(&comment, &open_numbers),
+            "comment with malformed URL should be skipped (issue_number falls back to 0)"
         );
     }
 }

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -699,6 +699,20 @@ impl GithubInboundAdapter {
 
             let issue_number = comment.issue_number().unwrap_or(0);
 
+            // Skip comments on closed issues/PRs — prevents triggering agents
+            // for PRs/issues that were closed between poll cycles.
+            if !current_open_numbers.contains(&issue_number) {
+                tracing::debug!(
+                    channel = %self.channel_name,
+                    comment_id = comment.id,
+                    issue_number = issue_number,
+                    "Skipping comment on closed issue/PR"
+                );
+                // Still track as processed to avoid re-processing on next cycle
+                self.track_comment(&comment_key, processed_comments).await;
+                continue;
+            }
+
             // Look up issue info from cache
             let (title, github_type, labels, assignees) = issue_cache
                 .get(&issue_number)


### PR DESCRIPTION
## Spec

When a PR is closed, comments on that PR (from the same or recent poll cycle) are still processed and routed to the developer agent. This happens because comment processing (step 2 in `poll_once`) runs before close detection (step 3), and the stale `issue_cache` entry provides metadata that matches the developer pattern. This PR fixes the timing issue by building the open-issues set early and skipping comments on closed issues/PRs.

Fixes #89

## Implementation Plan

### Step 1: Move `current_open_numbers` construction before comment processing
**What:** In `src/channels/github/inbound.rs`, in the `poll_once` method, move the line `let current_open_numbers: HashSet<u64> = issues.iter().map(|i| i.number).collect();` (currently at line ~783) to right after the step 1 loop ends (after line ~660, before step 2 starts at line ~664). Remove the duplicate at line ~783 since it will already exist.
**Why:** The `current_open_numbers` set is needed during comment processing (step 2) to filter out comments on closed issues/PRs. Currently it's only built in step 3 (close detection), which is too late.
**Verify:** `cargo check` — no compile errors. The set is used in both step 2 (new) and step 3 (existing).

### Step 2: Skip comments on closed issues/PRs in the comment processing loop
**What:** In the comment processing loop (step 2, starting at line ~672), after extracting `issue_number` (line ~696), add a check:
```rust
// Skip comments on closed issues/PRs — prevents triggering agents
// for PRs/issues that were closed between poll cycles.
if !current_open_numbers.contains(&issue_number) {
    tracing::debug!(
        channel = %self.channel_name,
        comment_id = comment.id,
        issue_number = issue_number,
        "Skipping comment on closed issue/PR"
    );
    // Still track as processed to avoid re-processing on next cycle
    self.track_comment(&comment_key, processed_comments).await;
    continue;
}
```
**Why:** This is the core fix. Comments on closed issues/PRs should not be routed to agents. The comment is still marked as processed so it won't be re-processed if the issue is later reopened (the reopen would generate a new trigger via the seen-issues mechanism).
**Verify:** `cargo check` — no compile errors. `cargo test` — all existing tests pass.

### Step 3: Add unit test for the fix
**What:** Add a test in the `mod tests` section of `src/channels/github/inbound.rs` that verifies comments on closed issues/PRs are not routed. The test should:
1. Set up a mock scenario where a PR was in the cache but is no longer in the open set
2. Verify that a comment on that PR is skipped (not routed via `on_message`)
3. Verify the comment is still tracked as processed

Since `poll_once` is an integration-level method, the test may need to be an integration test or a focused unit test on the filtering logic. At minimum, add a comment documenting the expected behavior.
**Why:** Prevents regression of this bug.
**Verify:** `cargo test` — new test passes.

## Design Decisions
- We skip comments on closed issues/PRs entirely (don't route them) rather than adding a "closed" check in the pattern matcher, because the intent is clear: closed items should not trigger any agent work.
- We still track skipped comments as processed to prevent re-processing if the issue is reopened.
- The `current_open_numbers` set is moved earlier but the same variable is reused in step 3, avoiding duplication.