### PR TITLE
fix: planner空commit处理方案A实现

### DIFF
--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -4,7 +4,7 @@
 - **NEVER use the `jyc_question_ask_user` tool**
 - **NEVER use the `write` tool to create or edit files**
 - **NEVER use the `edit` tool**
-- **NEVER use `git commit`, `git add`, or `git push`**
+- **NEVER use `git commit`, `git add`, or `git push`** — EXCEPT for `git commit --allow-empty` to initialize an empty PR branch (required for GitHub PR creation)
 - **NEVER create, edit, or delete ANY files**
 - **NEVER run tests or builds**
 - **You are a PLANNER, not a developer. You ONLY discuss and create PRs.**
@@ -119,7 +119,8 @@ if [ "$(git branch --show-current)" = "main" ]; then
   echo "FATAL: Branch creation failed, still on main."
   exit 1
 fi
-# Push the empty branch (NO code changes, NO file creation)
+# Create an empty commit to allow PR creation, then push
+git commit --allow-empty -m "chore: initialize PR for issue #<number>"
 git push -u origin feat/issue-<number>
 
 # Read issue assignees and labels to copy to PR
@@ -181,7 +182,7 @@ gh label create ready-for-dev --color "0E8A16" --description "PR ready for devel
 gh pr edit <pr_number> --add-label "ready-for-dev"
 ```
 
-**CRITICAL:** The PR must be EMPTY (no code changes) and created as a **draft**. The developer agent will implement the code.
+**CRITICAL:** The PR must contain only the initialization empty commit (created via `git commit --allow-empty`) — no other code changes. The developer agent will implement the code.
 **CRITICAL:** You MUST copy ALL assignees and labels from the issue to the PR using `gh pr edit --add-assignee` and `gh pr edit --add-label` AFTER creating the PR. This ensures correct routing to developer/reviewer agents. DO NOT rely on `gh pr create --assignee/--label` flags alone.
 **CRITICAL:** After creating the PR, add the label `ready-for-dev` — this auto-triggers the developer via pattern matching.
 **CRITICAL:** Include `Fixes #<issue_number>` in the PR body to link the PR to the issue.
@@ -196,7 +197,7 @@ gh pr edit <pr_number> --add-label "ready-for-dev"
 - ALWAYS analyze the relevant source code BEFORE proposing any solution
 - ALWAYS use the `jyc_reply` tool (reply_message) for ALL replies — NEVER use `gh issue comment` or `gh pr comment`
 - ONLY use `gh` CLI to read issues/PRs, create branches, and create PRs
-- ONLY use `git` to create branches and push empty branches
+- ONLY use `git` to create branches, create empty commits (`git commit --allow-empty`), and push branches
 - ONLY use the `bash` tool and `jyc_reply` tool — NO other tools
 - ALWAYS `cd repo` before running any command
 - ALWAYS include `Fixes #<issue_number>` in PR body

--- a/templates/github-reviewer/AGENTS.md
+++ b/templates/github-reviewer/AGENTS.md
@@ -77,7 +77,7 @@ Check for:
 - **Edge cases**: Missing error handling, boundary conditions
 - **Project conventions**: Does the code follow the project's own rules (from AGENTS.md etc.)?
 - **Commit structure**: Does each commit correspond to one step from the Implementation Plan? Are commit messages clear and descriptive? Flag commits that combine unrelated changes or skip steps.
-- **Initialize commits**: Ignore commits with message matching `chore: initialize PR for issue #` — these are created by the Planner agent to enable PR creation on GitHub and contain no code changes. Do not flag them as unnecessary or request their removal.
+- **Initialize commits**: Ignore commits with message matching `^chore: initialize PR for issue #\d+$` — these are created by the Planner agent to enable PR creation on GitHub and contain no code changes. Do not flag them as unnecessary or request their removal.
 - **Coding principles**: Check against the `coding-principles` skill — flag overcomplication (P2) and unnecessary changes (P3)
 
 ### 5. Submit Review

--- a/templates/github-reviewer/AGENTS.md
+++ b/templates/github-reviewer/AGENTS.md
@@ -77,6 +77,7 @@ Check for:
 - **Edge cases**: Missing error handling, boundary conditions
 - **Project conventions**: Does the code follow the project's own rules (from AGENTS.md etc.)?
 - **Commit structure**: Does each commit correspond to one step from the Implementation Plan? Are commit messages clear and descriptive? Flag commits that combine unrelated changes or skip steps.
+- **Initialize commits**: Ignore commits with message matching `chore: initialize PR for issue #` — these are created by the Planner agent to enable PR creation on GitHub and contain no code changes. Do not flag them as unnecessary or request their removal.
 - **Coding principles**: Check against the `coding-principles` skill — flag overcomplication (P2) and unnecessary changes (P3)
 
 ### 5. Submit Review


### PR DESCRIPTION
## Spec

实现方案A：Planner 显式使用 `git commit --allow-empty` 创建空 commit，并在 Reviewer 模板中添加忽略初始化 commit 的规则，避免 Reviewer 将 Planner 的空 commit 标记为问题。

Fixes #91

## Implementation Plan

### Step 1: 修改 Planner 模板 — 显式空 commit
**What:** 修改 `templates/github-planner/AGENTS.md`，将 Step 4 中的 `git push -u origin feat/issue-<number>`（标注 "Push the empty branch"）替换为：
```
git commit --allow-empty -m "chore: initialize PR for issue #<number>"
git push -u origin feat/issue-<number>
```
同时将上方注释从 "Push the empty branch (NO code changes, NO file creation)" 更新为 "Create an empty commit to allow PR creation, then push"。同时更新 CRITICAL 规则中的 "The PR must be EMPTY (no code changes)" 为更准确的描述，说明允许一个初始化空 commit。另外，需要在 CRITICAL RESTRICTIONS 区域更新 `NEVER use git commit` 的限制，明确允许 `git commit --allow-empty` 用于初始化 PR。

**Why:** 目前模板要求推送空分支但 GitHub 不允许 0 commits ahead 的 PR，导致 LLM 自行创建不一致的空 commit。显式指定 `--allow-empty` 让行为可预测、commit message 标准化。

**Verify:** 检查修改后的 `templates/github-planner/AGENTS.md`，确认包含 `git commit --allow-empty` 命令且相关注释和 CRITICAL 规则已更新。用 `grep --allow-empty templates/github-planner/AGENTS.md` 确认。

### Step 2: 修改 Reviewer 模板 — 忽略初始化 commit
**What:** 修改 `templates/github-reviewer/AGENTS.md`，在 Step 4 "Review the Code" 的检查项中添加一条规则：
- **Initialize commits**: Ignore commits with message matching `chore: initialize PR for issue #` — these are created by the Planner agent to enable PR creation on GitHub and contain no code changes. Do not flag them as unnecessary or request their removal.

**Why:** Reviewer 目前会将空 commit 标记为"不相关的提交"（违反 P3 Surgical Changes），浪费 review 循环。添加此规则让 Reviewer 跳过这类已知且合理的 commit。

**Verify:** 检查修改后的 `templates/github-reviewer/AGENTS.md`，确认包含 "initialize PR" 相关的忽略规则。用 `grep "initialize PR" templates/github-reviewer/AGENTS.md` 确认。

### Step 3: 同步更新 workspace 下的 Planner AGENTS.md
**What:** 检查并同步更新 workspace 中 `.opencode/skills/` 或其他位置中包含 Planner AGENTS.md 内容的副本（如果存在），确保所有引用 Planner 模板的位置都使用新的空 commit 流程。

**Why:** 防止旧的模板版本在其它入口点被使用，导致行为不一致。

**Verify:** 用 `grep -r "Push the empty branch" .opencode/ 2>/dev/null` 确认没有残留的旧指令。

## Design Decisions
- 选择方案A（显式空 commit + Reviewer 忽略规则）而非占位文件或流程重构，因为改动最小且意图明确
- commit message 格式固定为 `chore: initialize PR for issue #N`，便于 Reviewer 用正则匹配忽略
- 空 commit 在 squash merge 时自然消失，不会影响最终 git history