### PR TITLE
docs: add GitHub channel to README introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JYC
 
-Channel-agnostic AI agent that operates through messaging channels. Users interact by sending messages (email, FeiShu, Slack, etc.), and the agent responds autonomously using OpenCode AI.
+Channel-agnostic AI agent that operates through messaging channels. Users interact by sending messages (Email, GitHub, FeiShu, etc.), and the agent responds autonomously using OpenCode AI.
 
 **Why Rust:** Single static binary, zero runtime dependencies, memory safety without GC, and predictable low-latency performance for long-running server processes.
 


### PR DESCRIPTION
## Spec

Update README.md line 3 to include GitHub in the list of supported channels alongside Email and FeiShu, replacing the current mention of Slack (not yet implemented) with GitHub (production ready since v0.1.10).

Fixes #95

## Implementation Plan

### Step 1: Update the channel list in README.md introduction
**What:** In `README.md` line 3, change `(email, FeiShu, Slack, etc.)` to `(Email, GitHub, FeiShu, etc.)`. This replaces Slack (a future/planned channel) with GitHub (production ready), and capitalizes channel names for consistency with the Supported Channels section.
**Why:** The introduction is the first thing readers see. Listing an unimplemented channel (Slack) while omitting a production-ready one (GitHub) is misleading.
**Verify:** Open `README.md` and confirm line 3 reads `Users interact by sending messages (Email, GitHub, FeiShu, etc.), and the agent responds autonomously using OpenCode AI.`

## Design Decisions
- Capitalize channel names (Email, GitHub, FeiShu) to match the style used in the "Supported Channels" section headers
- Keep "etc." to indicate the channel-agnostic architecture supports future channels
- No other changes needed — GitHub is already documented in the "Supported Channels" section and the Configuration section