### PR TITLE
fix: update README CLI documentation to match actual commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,16 +140,39 @@ Place a `system.md` file in a thread's workspace directory to customize the AI's
 
 ## CLI Commands
 
+### Global Flags
+
 ```bash
-jyc monitor          # Start the agent (main command)
-jyc config init      # Generate config template
-jyc config validate  # Validate config file
-jyc patterns list    # List configured patterns
-jyc state            # Show monitoring state (processed UIDs, etc.)
-jyc dashboard        # Live TUI dashboard (connects via inspect server)
+-w, --workdir <PATH>   # Working directory (default: current directory)
+-d, --debug            # Enable debug logging
+-v, --verbose         # Enable verbose (trace) logging
 ```
 
-The `dashboard` command requires the `[inspect]` section to be enabled in config. Use `--addr` flag to connect to a different address (default: `127.0.0.1:9876`).
+### Subcommands
+
+```bash
+jyc monitor            # Start the agent (main command)
+                       #   --config <FILE>    Config file path (default: config.toml)
+                       #   --no-idle         Use polling instead of IMAP IDLE
+                       #   --reset           Reset monitoring state before starting
+jyc dashboard          # Live TUI dashboard (connects via inspect server)
+                       #   --addr <ADDR>     Inspect server address (default: 127.0.0.1:9876)
+                       #   Keyboard: q=quit, ↑/↓=select thread, r=refresh
+jyc config init        # Generate config template
+jyc config validate    # Validate config file
+                       #   --config <FILE>   Config file path (default: config.toml)
+jyc patterns list      # List configured patterns
+                       #   --config <FILE>   Config file path (default: config.toml)
+jyc templates list     # List available templates and their skills
+                       #   --source-dir <PATH>   Source directory containing templates/
+jyc templates deploy <target_dir>   # Deploy templates to a target directory
+                       #   <template_name>       Deploy only this template (optional)
+                       #   --as <NAME>           Rename the deployed template directory
+                       #   --model <MODEL>       Write a model override file
+                       #   --source-dir <PATH>   Source directory containing templates/
+```
+
+The `dashboard` command requires the `[inspect]` section to be enabled in config.
 
 ## MCP Tools
 


### PR DESCRIPTION
## Spec

Update the README.md "CLI Commands" section to accurately document all current `jyc` subcommands, global flags, and per-command arguments, removing the obsolete `jyc state` entry and adding the missing `templates` subcommand and all flag details.

Fixes #97

## Implementation Plan

### Step 1: Remove obsolete `jyc state` entry
**What:** In `README.md`, find the "CLI Commands" section and remove the line `jyc state            # Show monitoring state (processed UIDs, etc.)`.
**Why:** No `state` subcommand exists in the codebase (`src/main.rs`).
**Verify:** Grep README.md for `jyc state` — should return no matches.

### Step 2: Add global flags documentation
**What:** Before the subcommand table, add a "Global Flags" subsection documenting `--workdir` / `-w`, `--debug` / `-d`, and `--verbose` / `-v` with their descriptions (from `src/main.rs:20-30`).
**Why:** These global flags are available on all subcommands but are not documented.
**Verify:** Visual check that all three flags appear with correct descriptions.

### Step 3: Add `--config`, `--no-idle`, `--reset` to `monitor` command
**What:** Update the `jyc monitor` entry to list its flags: `--config` (default `config.toml`), `--no-idle` (use polling instead of IMAP IDLE), `--reset` (reset monitoring state). Source: `src/cli/monitor.rs:29-42`.
**Why:** These flags are available but undocumented.
**Verify:** Grep README.md for `--no-idle` and `--reset` — should find matches.

### Step 4: Expand `dashboard` documentation with keyboard shortcuts
**What:** Update the `jyc dashboard` entry to document: `--addr` flag (default `127.0.0.1:9876`), and TUI keyboard shortcuts (`q` quit, `↑/↓` select thread, `r` refresh). Source: `src/cli/dashboard.rs:22-27` and key handling at lines 119-137.
**Why:** The dashboard has interactive controls that users need to know about.
**Verify:** Grep README.md for `--addr` and keyboard shortcuts.

### Step 5: Add `--config` flag to `config validate` and `patterns list`
**What:** Update the entries for `jyc config validate` and `jyc patterns list` to show the `--config` flag with default `config.toml`. Source: `src/cli/config.rs:14-16`, `src/cli/patterns.rs:14-16`.
**Why:** These subcommands accept a `--config` flag but it's not documented.
**Verify:** Grep README.md for the updated entries.

### Step 6: Add `templates` subcommand documentation
**What:** Add entries for `jyc templates list` (with `--source-dir` flag) and `jyc templates deploy <target_dir>` (with `<template_name>`, `--as`, `--model`, `--source-dir` flags). Source: `src/cli/templates.rs:11-39`.
**Why:** The `templates` subcommand is completely missing from the README.
**Verify:** Grep README.md for `jyc templates` — should find `list` and `deploy`.

## Design Decisions
- Document all flags with their default values where applicable
- Keep the table format consistent with the existing README style
- Group global flags separately before subcommands for clarity