### PR TITLE
feat: bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,37 @@
 
 All notable changes to JYC will be documented in this file.
 
-## [Unreleased]
+## [0.2.0] - 2026-04-23
 
 ### Added
 
-- **AND/OR logic for labels in pattern matching** — Labels rule now supports nested arrays for boolean combinations. Flat arrays `["bug", "enhancement"]` retain backward-compatible OR logic. Nested arrays `[["bug", "enhancement"], ["test"]]` use CNF: outer AND, inner OR — each group must have at least one matching label. (#83)
+- **Multi-agent workflow refactor** — Developer agent is now a persistent reactive agent (#59), label-based reviewer trigger (#74), removed trigger_mode (#76), unconditional hand-off (#78, #85)
+- **Pattern mode triggers issue/PR directly** — No longer relies solely on comments (#69)
+- **AND/OR label logic** — LabelRule supports CNF nested array boolean combinations (#83)
+- **Dashboard TUI shows thread last active time** (#81)
+- **deploy-templates supports --as flag** (#87), integrated into jyc CLI (#94)
+- **Comment filtering for closed issues/PRs** (#89)
+- **Main branch protection** (#65)
+- **coding-principles skill integration** (#61)
+
+### Fixed
+
+- **Planner empty commit handling** (#93)
+- **SSE loop exit fix** (#89)
+- **Activity panel shows AI thinking and tool errors** (#78)
+- **Pattern mode self-loop protection** (#69)
+
+### Changed
+
+- **README documentation updates** (#96, #98)
+- **Developer agent template simplification** (#59)
+- **Removed model-override file** (#67)
+- **Removed @j:role mentions, use label-based handover instead** (#76)
+- **Dockerfile optimization for dummy main caching** (#57)
+
+### Removed
+
+- **TriggerMode enum and trigger_mode field** (#76)
 
 ## [0.1.11] - 2026-04-20
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "jyc"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-imap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jyc"
-version = "0.1.11"
+version = "0.2.0"
 edition = "2024"
 description = "Channel-agnostic AI agent"
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2494,7 +2494,7 @@ JSON line protocol over TCP. Client sends one JSON object per line, server respo
 // Response
 {
   "uptime_secs": 3600,
-  "version": "0.1.11",
+  "version": "0.2.0",
   "channels": [{"name": "emf", "channel_type": "github"}],
   "threads": [{"name": "issue-42", "channel": "emf", "pattern": "planner", "status": "processing", ...}],
   "stats": {"active_workers": 2, "total_threads": 3, "max_concurrent": 3, ...}
@@ -2521,7 +2521,7 @@ JSON line protocol over TCP. Client sends one JSON object per line, server respo
 │ │ Tokens: 45231 / 120000 (37%)                                 │  │
 │ │ Status: Processing                                           │  │
 │ └─────────────────────────────────────────────────────────────┘  │
-│ 2 active / 4 threads │ 156 recv │ 2 err │ up 1h03m │ v0.1.11   │
+│ 2 active / 4 threads │ 156 recv │ 2 err │ up 1h03m │ v0.2.0   │
 └──────────────────────────────────────────────────────────────────┘
 ```
 

--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -430,3 +430,37 @@ The Feishu channel implementation demonstrates the extensibility of JYC's channe
 
 ✅ **Completed** — Tested with Docker (Podman) and bare metal
 ✅ **Tested** — 283 tests pass (18 new: 6 types + 4 metrics + 4 server + 4 client)
+
+---
+
+## Phase 12: Multi-Agent Workflow & Label-Based Routing (v0.2.0)
+
+**Goal:** Refactor the agent system into a persistent reactive multi-agent architecture with label-based routing.
+
+### Overview
+
+v0.2.0 introduces a major architectural shift from single-shot agent invocations to a persistent reactive agent model. The system now supports multiple specialized agents (Planner, Developer, Reviewer) that communicate via GitHub labels rather than @mentions.
+
+### Key Changes
+
+**Multi-Agent Architecture:**
+- Developer agent is now a persistent reactive agent that maintains conversation context
+- Label-based reviewer trigger replaces explicit @j:reviewer mentions
+- Removed TriggerMode enum and trigger_mode field
+- Unconditional hand-off after each agent completes
+
+**Pattern Mode Enhancement:**
+- Pattern mode now directly triggers issues/PRs without relying on comments
+- Self-loop protection prevents infinite routing cycles
+
+**Label Routing:**
+- LabelRule supports CNF (Conjunctive Normal Form) nested array boolean combinations
+- Flat arrays `["bug", "enhancement"]` use OR logic (backward compatible)
+- Nested arrays `[["bug", "enhancement"], ["test"]]` use CNF: outer AND, inner OR
+
+**New Features:**
+- Dashboard TUI shows thread last active time
+- deploy-templates supports `--as` flag for custom naming
+- Comment filtering for closed issues/PRs
+- Main branch protection
+- coding-principles skill integration


### PR DESCRIPTION
## Spec

将 JYC 版本从 0.1.11 升级到 0.2.0，补全 CHANGELOG，更新所有版本引用。0.2.0 是一个 minor 版本升级，包含 v0.1.11 以来的 94 个非 merge 提交，涵盖多 agent 工作流重构、Pattern 模式触发、AND/OR 标签逻辑等重要新功能。

Fixes #99

## Implementation Plan

### Step 1: Update Cargo.toml version
**What:** 将 `Cargo.toml:3` 的 `version = "0.1.11"` 改为 `version = "0.2.0"`
**Why:** 这是 Rust crate 的权威版本号来源
**Verify:** `grep '^version' Cargo.toml` 输出 `version = "0.2.0"`

### Step 2: Update CHANGELOG.md
**What:** 将 `[Unreleased]` 节替换为 `[0.2.0] - 2026-04-23`，补全所有变更条目：
- **Added:**
  - 多 agent 工作流重构：Developer 改为持久响应式 agent (#59)、label-based reviewer 触发 (#74)、移除 trigger_mode (#76)、无条件 hand-off (#78, #85)
  - Pattern 模式直接触发 issue/PR，不再仅依赖评论 (#69)
  - AND/OR 标签逻辑：LabelRule 支持 CNF 嵌套数组布尔组合 (#83)
  - Dashboard TUI 显示线程最后活跃时间 (#81)
  - deploy-templates 支持 --as 标志 (#87)，集成到 jyc CLI (#94)
  - 已关闭 issue/PR 的评论过滤 (#89)
  - 主分支保护 (#65)
  - coding-principles skill 集成 (#61)
- **Fixed:**
  - Planner 空 commit 处理 (#93)
  - SSE 循环退出修复 (#89)
  - Activity panel 显示 AI thinking 和 tool errors (#78)
  - Pattern 模式自循环防护 (#69)
- **Changed:**
  - README 文档更新 (#96, #98)
  - 开发者 agent 模板简化 (#59)
  - 移除 model-override 文件 (#67)
  - 移除 @j:role mentions，改用 label-based handover (#76)
  - Dockerfile 优化 dummy main 缓存 (#57)
- **Removed:**
  - TriggerMode 枚举及 trigger_mode 字段 (#76)
**Why:** CHANGELOG 是版本发布的核心文档，必须完整记录所有变更
**Verify:** `head -50 CHANGELOG.md` 确认 `[0.2.0]` 节存在且条目完整

### Step 3: Update DESIGN.md version references
**What:** 将 `DESIGN.md:2497` 的 `"version": "0.1.11"` 改为 `"0.2.0"`，将 `DESIGN.md:2524` 的 `v0.1.11` 改为 `v0.2.0`
**Why:** DESIGN.md 中的示例输出应反映当前版本
**Verify:** `grep "0\.2\.0" DESIGN.md` 输出两行匹配

### Step 4: Update IMPLEMENTATION.md version reference
**What:** 在 `IMPLEMENTATION.md` 中添加 `## Phase 12: Multi-Agent Workflow & Label-Based Routing (v0.2.0)` 概述 0.2.0 的新功能，包括多 agent 工作流、label-based routing、Pattern 模式触发等。Phase 11 的 v0.1.11 标注保持不变（历史记录）。
**Why:** 保持实现文档与版本对应
**Verify:** `grep "0\.2\.0" IMPLEMENTATION.md` 确认引用存在

### Step 5: Verify build
**What:** 运行 `cargo check` 确认版本号更新没有破坏任何东西
**Why:** 确保版本变更不影响编译
**Verify:** `cargo check` 成功无错误

## Design Decisions
- 使用 0.2.0 (minor) 而非 0.1.12 (patch)：因为包含多 agent 工作流重构、Pattern 模式触发等 breaking/重大新功能
- git tag `v0.2.0` 不在本 PR 中创建，建议在 merge 后手动打 tag
- CHANGELOG 日期使用 PR merge 当天日期，如果延迟可更新
- IMPLEMENTATION.md 的 Phase 11 版本号为历史记录，Phase 11 仍标注 v0.1.11