### PR TITLE
feat: add high-level planner with feature-plan label routing

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -240,15 +240,28 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # poll_interval_secs = 60
 # # api_url = "https://api.github.com"  # Default. For GitHub Enterprise, use: https://github.example.com/api/v3
 #
-# # Pattern: Issues → Planner agent (auto-trigger via pattern matching)
+# # Pattern: Issues with 'feature-plan' label → High-Level Planner (product manager perspective)
 # [[channels.my_repo.patterns]]
-# name = "planner"
+# name = "high-level-planner"
+# enabled = true
+# role = "High-Level Planner"
+# template = "github-high-level-planner"
+#
+# [channels.my_repo.patterns.rules]
+# github_type = ["issue"]
+# labels = ["feature-plan"]
+#
+# # Pattern: Issues without 'feature-plan' label → Detail-Level Planner (technical architect)
+# # The exclude_labels rule ensures this pattern does NOT fire while High-Level Planner is active
+# [[channels.my_repo.patterns]]
+# name = "detail-planner"
 # enabled = true
 # role = "Planner"
 # template = "github-planner"
 #
 # [channels.my_repo.patterns.rules]
 # github_type = ["issue"]
+# exclude_labels = ["feature-plan"]
 #
 # # Pattern: PRs with 'ready-for-dev' label → Developer agent (auto-trigger)
 # [[channels.my_repo.patterns]]

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -114,19 +114,31 @@ impl GithubMatcher {
             }
         }
 
+        // Extract github_labels once for labels and exclude_labels checks
+        let msg_labels: Vec<String> = message
+            .metadata
+            .get("github_labels")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_lowercase()))
+                    .collect()
+            })
+            .unwrap_or_default();
+
         // Check labels rule (delegates to LabelRule::matches for flat OR / nested AND-OR logic)
         if let Some(ref label_rule) = rules.labels {
-            let msg_labels: Vec<String> = message
-                .metadata
-                .get("github_labels")
-                .and_then(|v| v.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(|s| s.to_lowercase()))
-                        .collect()
-                })
-                .unwrap_or_default();
             if !label_rule.matches(&msg_labels) {
+                return false;
+            }
+        }
+
+        // Check exclude_labels rule (OR logic: if ANY exclude label is present, pattern does not match)
+        if let Some(ref exclude_labels) = rules.exclude_labels {
+            let has_excluded = exclude_labels
+                .iter()
+                .any(|l| msg_labels.contains(&l.to_lowercase()));
+            if has_excluded {
                 return false;
             }
         }
@@ -147,26 +159,6 @@ impl GithubMatcher {
                 .iter()
                 .any(|a| msg_assignees.contains(&a.to_lowercase()));
             if !has_match {
-                return false;
-            }
-        }
-
-        // Check exclude_labels rule (OR logic: if ANY exclude label is present, pattern does not match)
-        if let Some(ref exclude_labels) = rules.exclude_labels {
-            let msg_labels: Vec<String> = message
-                .metadata
-                .get("github_labels")
-                .and_then(|v| v.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(|s| s.to_lowercase()))
-                        .collect()
-                })
-                .unwrap_or_default();
-            let has_excluded = exclude_labels
-                .iter()
-                .any(|l| msg_labels.contains(&l.to_lowercase()));
-            if has_excluded {
                 return false;
             }
         }
@@ -932,6 +924,7 @@ impl GithubInboundAdapter {
 ///   "[Developer] some text" → Some("Developer")
 ///   "[Reviewer] code looks good" → Some("Reviewer")
 ///   "[Planner] questions about requirements" → Some("Planner")
+///   "[High-Level Planner] planning" → Some("High-Level Planner")
 ///   "normal comment" → None
 ///   "[Unknown] something" → None
 ///

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -151,6 +151,26 @@ impl GithubMatcher {
             }
         }
 
+        // Check exclude_labels rule (OR logic: if ANY exclude label is present, pattern does not match)
+        if let Some(ref exclude_labels) = rules.exclude_labels {
+            let msg_labels: Vec<String> = message
+                .metadata
+                .get("github_labels")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_lowercase()))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let has_excluded = exclude_labels
+                .iter()
+                .any(|l| msg_labels.contains(&l.to_lowercase()));
+            if has_excluded {
+                return false;
+            }
+        }
+
         true
     }
 }
@@ -921,7 +941,7 @@ fn extract_comment_role(text: &str) -> Option<String> {
         if let Some(end) = text.find(']') {
             let role = &text[1..end];
             match role {
-                "Planner" | "Developer" | "Reviewer" => return Some(role.to_string()),
+                "Planner" | "Developer" | "Reviewer" | "High-Level Planner" => return Some(role.to_string()),
                 _ => {}
             }
         }
@@ -1377,6 +1397,7 @@ mod tests {
         assert_eq!(extract_comment_role("[Developer] some text"), Some("Developer".to_string()));
         assert_eq!(extract_comment_role("[Reviewer] code looks good"), Some("Reviewer".to_string()));
         assert_eq!(extract_comment_role("[Planner] questions"), Some("Planner".to_string()));
+        assert_eq!(extract_comment_role("[High-Level Planner] planning"), Some("High-Level Planner".to_string()));
         assert_eq!(extract_comment_role("normal comment"), None);
         assert_eq!(extract_comment_role("[Unknown] something"), None);
         assert_eq!(extract_comment_role(""), None);
@@ -1898,5 +1919,167 @@ mod tests {
             !should_process_comment(&comment, &open_numbers),
             "comment with malformed URL should be skipped (issue_number falls back to 0)"
         );
+    }
+
+    // --- exclude_labels tests ---
+
+    #[test]
+    fn test_exclude_labels_blocks_matching_label() {
+        // Message has "feature-plan", pattern has exclude_labels = ["feature-plan"] → should NOT match
+        let mut msg = make_message_with_rules("issue", 42, &["feature-plan"], &[]);
+        msg.metadata.insert("handover_role".to_string(), serde_json::json!("planner"));
+        let patterns = vec![ChannelPattern {
+            name: "detail-planner".to_string(),
+            enabled: true,
+            role: Some("Planner".to_string()),
+            rules: crate::channels::types::PatternRules {
+                github_type: Some(vec!["issue".to_string()]),
+                exclude_labels: Some(vec!["feature-plan".to_string()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
+        let result = GithubMatcher.match_message(&msg, &patterns);
+        assert!(result.is_none(), "exclude_labels should block matching when label is present");
+    }
+
+    #[test]
+    fn test_exclude_labels_allows_non_matching_label() {
+        // Message has "bug", pattern has exclude_labels = ["feature-plan"] → should match
+        let mut msg = make_message_with_rules("issue", 42, &["bug"], &[]);
+        msg.metadata.insert("handover_role".to_string(), serde_json::json!("planner"));
+        let patterns = vec![ChannelPattern {
+            name: "detail-planner".to_string(),
+            enabled: true,
+            role: Some("Planner".to_string()),
+            rules: crate::channels::types::PatternRules {
+                github_type: Some(vec!["issue".to_string()]),
+                exclude_labels: Some(vec!["feature-plan".to_string()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
+        let result = GithubMatcher.match_message(&msg, &patterns);
+        assert!(result.is_some(), "exclude_labels should not block when excluded label is absent");
+    }
+
+    #[test]
+    fn test_exclude_labels_multiple() {
+        // Message has "feature-plan", pattern has exclude_labels = ["feature-plan", "wip"] → should NOT match
+        let mut msg = make_message_with_rules("issue", 42, &["feature-plan"], &[]);
+        msg.metadata.insert("handover_role".to_string(), serde_json::json!("planner"));
+        let patterns = vec![ChannelPattern {
+            name: "detail-planner".to_string(),
+            enabled: true,
+            role: Some("Planner".to_string()),
+            rules: crate::channels::types::PatternRules {
+                github_type: Some(vec!["issue".to_string()]),
+                exclude_labels: Some(vec!["feature-plan".to_string(), "wip".to_string()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
+        let result = GithubMatcher.match_message(&msg, &patterns);
+        assert!(result.is_none(), "exclude_labels should block when any exclude label matches");
+    }
+
+    #[test]
+    fn test_exclude_labels_case_insensitive() {
+        // Message has "Feature-Plan", pattern has exclude_labels = ["feature-plan"] → should NOT match
+        let mut msg = make_message_with_rules("issue", 42, &["Feature-Plan"], &[]);
+        msg.metadata.insert("handover_role".to_string(), serde_json::json!("planner"));
+        let patterns = vec![ChannelPattern {
+            name: "detail-planner".to_string(),
+            enabled: true,
+            role: Some("Planner".to_string()),
+            rules: crate::channels::types::PatternRules {
+                github_type: Some(vec!["issue".to_string()]),
+                exclude_labels: Some(vec!["feature-plan".to_string()]),
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
+        let result = GithubMatcher.match_message(&msg, &patterns);
+        assert!(result.is_none(), "exclude_labels matching should be case-insensitive");
+    }
+
+    #[test]
+    fn test_exclude_labels_toml_deserialize() {
+        let pattern: ChannelPattern = toml::from_str(r#"
+            name = "test"
+            [rules]
+            github_type = ["issue"]
+            exclude_labels = ["feature-plan", "wip"]
+        "#).unwrap();
+        assert!(pattern.rules.exclude_labels.is_some(), "exclude_labels should deserialize");
+        let excl = pattern.rules.exclude_labels.unwrap();
+        assert_eq!(excl.len(), 2);
+        assert!(excl.contains(&"feature-plan".to_string()));
+        assert!(excl.contains(&"wip".to_string()));
+    }
+
+    #[test]
+    fn test_high_level_planner_with_feature_plan_label() {
+        // High-level planner pattern: labels = ["feature-plan"]
+        let mut msg = make_message_with_rules("issue", 42, &["feature-plan"], &[]);
+        msg.metadata.insert("handover_role".to_string(), serde_json::json!("planner"));
+        let patterns = vec![ChannelPattern {
+            name: "high-level-planner".to_string(),
+            enabled: true,
+            role: Some("High-Level Planner".to_string()),
+            template: Some("github-high-level-planner".to_string()),
+            rules: crate::channels::types::PatternRules {
+                github_type: Some(vec!["issue".to_string()]),
+                labels: Some(LabelRule::Flat(vec!["feature-plan".to_string()])),
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
+        let result = GithubMatcher.match_message(&msg, &patterns);
+        assert!(result.is_some(), "high-level planner should match issue with feature-plan label");
+        assert_eq!(result.unwrap().pattern_name, "high-level-planner");
+    }
+
+    #[test]
+    fn test_two_level_routing() {
+        // Issue with feature-plan → high-level planner
+        let mut msg1 = make_message_with_rules("issue", 42, &["feature-plan"], &[]);
+        msg1.metadata.insert("handover_role".to_string(), serde_json::json!("planner"));
+        let patterns = vec![
+            ChannelPattern {
+                name: "high-level-planner".to_string(),
+                enabled: true,
+                role: Some("High-Level Planner".to_string()),
+                template: Some("github-high-level-planner".to_string()),
+                rules: crate::channels::types::PatternRules {
+                    github_type: Some(vec!["issue".to_string()]),
+                    labels: Some(LabelRule::Flat(vec!["feature-plan".to_string()])),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ChannelPattern {
+                name: "detail-planner".to_string(),
+                enabled: true,
+                role: Some("Planner".to_string()),
+                template: Some("github-planner".to_string()),
+                rules: crate::channels::types::PatternRules {
+                    github_type: Some(vec!["issue".to_string()]),
+                    exclude_labels: Some(vec!["feature-plan".to_string()]),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        ];
+        let result1 = GithubMatcher.match_message(&msg1, &patterns);
+        assert!(result1.is_some());
+        assert_eq!(result1.unwrap().pattern_name, "high-level-planner");
+
+        // Issue with bug → detail planner (no feature-plan)
+        let mut msg2 = make_message_with_rules("issue", 43, &["bug"], &[]);
+        msg2.metadata.insert("handover_role".to_string(), serde_json::json!("planner"));
+        let result2 = GithubMatcher.match_message(&msg2, &patterns);
+        assert!(result2.is_some());
+        assert_eq!(result2.unwrap().pattern_name, "detail-planner");
     }
 }

--- a/src/channels/types.rs
+++ b/src/channels/types.rs
@@ -339,6 +339,10 @@ pub struct PatternRules {
     /// GitHub assignees to match (OR logic: match if ANY assignee is assigned to the issue/PR)
     #[serde(default)]
     pub assignees: Option<Vec<String>>,
+    /// GitHub labels that must NOT be present for the pattern to match.
+    /// OR logic: if ANY exclude label is found in the message labels, the pattern does not match.
+    #[serde(default)]
+    pub exclude_labels: Option<Vec<String>>,
 }
 
 impl Default for PatternRules {
@@ -352,6 +356,7 @@ impl Default for PatternRules {
             github_type: None,
             labels: None,
             assignees: None,
+            exclude_labels: None,
         }
     }
 }

--- a/templates/github-high-level-planner/AGENTS.md
+++ b/templates/github-high-level-planner/AGENTS.md
@@ -1,0 +1,91 @@
+# GitHub High-Level Planner Agent
+
+**⚠️ CRITICAL RESTRICTIONS — READ BEFORE DOING ANYTHING:**
+- **NEVER use the `jyc_question_ask_user` tool**
+- **NEVER use the `write` tool to create or edit files**
+- **NEVER use the `edit` tool**
+- **NEVER use `git commit`, `git add`, or `git push`**
+- **NEVER create, edit, or delete ANY files**
+- **NEVER run tests or builds**
+- **NEVER do technical architecture analysis**
+- **NEVER create PRs**
+- **You are a High-Level Planner (product manager perspective). You ONLY discuss requirements and planning.**
+- **NEVER commit or push on the main branch — you MUST be on the PR branch first**
+
+You are a high-level planner/product manager agent for GitHub issues. Your role is to
+understand requirements, produce a feature breakdown, discuss with the user, and
+hand off to the Detail-Level Planner by removing the `feature-plan` label.
+
+## How You Receive Work
+You are triggered automatically when an issue has the `feature-plan` label.
+No `@j:planner` mention is required.
+The trigger message tells you the repository and issue number.
+
+## Repository Setup
+Clone the repository from the trigger message to `repo/` if not already present,
+then `cd repo` before running any command:
+```bash
+if [ ! -d "repo" ]; then
+    gh repo clone <repository_from_trigger> repo
+fi
+cp -rn repo/.opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
+cd repo
+```
+
+## Workflow
+
+### 0. Check Status (MANDATORY — DO THIS FIRST)
+```bash
+cd repo
+gh issue view <number> --json state --jq '.state'
+```
+**If the issue is closed, STOP IMMEDIATELY. Do NOT reply, do NOT comment, do NOT do any work.**
+
+### 1. Read the Issue
+```bash
+cd repo
+gh issue view <number>
+gh issue view <number> --comments
+```
+
+### 2. Understand the Requirement
+- Read the issue title and body carefully
+- Identify the user/actor and their needs
+- Note any constraints, priorities, or success criteria mentioned
+- Review existing comments for context
+
+### 3. Produce High-Level Plan
+Present a structured analysis including:
+- **Requirement Analysis**: What is the user asking for? What problem does it solve?
+- **Feature Breakdown**: What are the major components or capabilities needed?
+- **Module划分**: How should the work be divided (not technical architecture, but logical units)?
+- **Priority**: What should be tackled first?
+- **Effort Estimation**: Rough estimate of complexity (Low/Medium/High)
+
+### 4. Discuss with User
+- Share your high-level plan with the user
+- Ask clarifying questions if needed
+- Wait for user confirmation before proceeding
+
+### 5. Hand Off — ONLY After User Confirms
+When the user explicitly confirms (e.g., "go ahead", "start development", "proceed"):
+```bash
+cd repo
+gh issue edit <number> --remove-label feature-plan
+```
+
+### 6. After Hand-off
+- Reply confirming the hand-off is complete
+- The Detail-Level Planner will take over automatically
+
+## Rules (MANDATORY)
+- ALWAYS analyze the issue BEFORE proposing any plan
+- ALWAYS use the `jyc_reply` tool (reply_message) for ALL replies — NEVER use `gh issue comment` directly
+- ONLY use `gh` CLI to read issues and edit labels
+- ALWAYS `cd repo` before running any command
+- NEVER write code, create files, or do technical analysis
+- Reply in the same language as the user
+
+## Behavioral Guidelines
+
+Follow the `coding-principles` skill — especially Principle 1 (Think Before Coding) and Principle 4 (Goal-Driven Execution).

--- a/templates/templates.toml
+++ b/templates/templates.toml
@@ -15,3 +15,6 @@ skills = ["coding-principles", "incremental-dev", "dev-workflow"]
 
 [templates.github-reviewer]
 skills = ["coding-principles", "pr-review"]
+
+[templates.github-high-level-planner]
+skills = ["coding-principles", "dev-workflow"]


### PR DESCRIPTION
## Spec

Add a two-level planner architecture for GitHub issues: a High-Level Planner (product manager perspective) handles issues with the `feature-plan` label, produces requirement breakdown and discusses with the user; upon user confirmation, it removes the `feature-plan` label, allowing the existing Detail-Level Planner (technical architect) to take over. Bug and other issues without `feature-plan` go directly to the Detail-Level Planner. This requires adding `exclude_labels` support to `PatternRules`, a new `github-high-level-planner` template, and updated config examples.

Fixes #101

## Implementation Plan

### Step 1: Add `exclude_labels` field to `PatternRules`
**What:** In `src/channels/types.rs`, add `pub exclude_labels: Option<Vec<String>>` to `PatternRules` struct, with `#[serde(default)]` and update `Default` impl. This field holds GitHub labels that must NOT be present on the issue for the pattern to match (AND logic: all must be absent).
**Why:** The Detail-Level Planner pattern needs to exclude issues with `feature-plan` label so it doesn't fire while the High-Level Planner is active.
**Verify:** `cargo check` passes; existing tests still compile.

### Step 2: Implement `exclude_labels` matching in `GithubMatcher::rules_match()`
**What:** In `src/channels/github/inbound.rs`, in the `rules_match()` method (around line 104), after the assignees check block (line 152), add a new check: if `rules.exclude_labels` is `Some`, extract `msg_labels` from `message.metadata["github_labels"]` (same logic as the labels check), and if any exclude label is found in msg_labels, return `false`. Use case-insensitive comparison consistent with existing label matching.
**Why:** This is the runtime enforcement that prevents patterns from matching when excluded labels are present.
**Verify:** `cargo test -- github::inbound` passes; add a manual test: a message with `feature-plan` label should not match a pattern with `exclude_labels = ["feature-plan"]`.

### Step 3: Add unit tests for `exclude_labels`
**What:** In `src/channels/github/inbound.rs`, add tests in the `#[cfg(test)]` module:
- `test_exclude_labels_blocks_matching_label`: Message has `feature-plan`, pattern has `exclude_labels = ["feature-plan"]` → should NOT match.
- `test_exclude_labels_allows_non_matching_label`: Message has `bug`, pattern has `exclude_labels = ["feature-plan"]` → should match.
- `test_exclude_labels_multiple`: Message has `feature-plan`, pattern has `exclude_labels = ["feature-plan", "wip"]` → should NOT match (any match blocks).
- `test_exclude_labels_toml_deserialize`: Deserialize a `ChannelPattern` TOML with `exclude_labels` and verify the field is populated correctly.
**Why:** Ensure the new feature works correctly and prevent regressions.
**Verify:** `cargo test -- github::inbound` — all new tests pass.

### Step 4: Create `templates/github-high-level-planner/` template
**What:** Create `templates/github-high-level-planner/AGENTS.md` with instructions for the High-Level Planner agent. Key directives:
- Read the issue and understand the requirement context
- Produce a high-level plan: requirement analysis, feature breakdown, module划分, priority, effort estimation
- Discuss with the user, wait for confirmation
- On confirmation: execute `gh issue edit <number> --remove-label feature-plan`
- NEVER do technical architecture analysis, NEVER create PRs, NEVER add code
- Role prefix: `[High-Level Planner]`
**Why:** This template defines the behavior of the new High-Level Planner agent.
**Verify:** Template directory and file exist; `templates/templates.toml` can be updated in next step.

### Step 5: Register the new template in `templates/templates.toml`
**What:** Add to `templates/templates.toml`:
```toml
[templates.github-high-level-planner]
skills = ["coding-principles", "dev-workflow"]
```
**Why:** The framework needs to know which skills to load for this template.
**Verify:** `cargo check` passes; the template name `github-high-level-planner` is referenced in config examples.

### Step 6: Update `config.example.toml` with two-level planner patterns
**What:** In the GitHub channel section of `config.example.toml`, replace the single `planner` pattern with two patterns:
```toml
# High-Level Planner — handles issues with feature-plan label
[[channels.my_repo.patterns]]
name = "high-level-planner"
enabled = true
role = "High-Level Planner"
template = "github-high-level-planner"

[channels.my_repo.patterns.rules]
github_type = ["issue"]
labels = ["feature-plan"]

# Detail-Level Planner — handles issues without feature-plan label
[[channels.my_repo.patterns]]
name = "detail-planner"
enabled = true
role = "Planner"
template = "github-planner"

[channels.my_repo.patterns.rules]
github_type = ["issue"]
exclude_labels = ["feature-plan"]
```
**Why:** This is the canonical configuration showing how the two-level routing works.
**Verify:** Config example is valid TOML; the routing logic matches the agreed design.

### Step 7: Update `extract_comment_role()` to recognize "High-Level Planner"
**What:** In `src/channels/github/inbound.rs`, update the `extract_comment_role()` function (around line 441) to also recognize `"High-Level Planner"` as a known role, so that the High-Level Planner's own comments don't trigger itself (self-loop prevention).
**Why:** Without this, when the High-Level Planner replies on an issue with `[High-Level Planner]` prefix, a subsequent comment event could re-trigger the same pattern.
**Verify:** `cargo test -- test_extract_comment_role` passes; add a test case for `"High-Level Planner"`.

### Step 8: Run full test suite and verify
**What:** Run `cargo test` to verify all existing tests pass and no regressions.
**Why:** Final verification before hand-off.
**Verify:** All tests pass; `cargo check` has no warnings related to the new code.

## Design Decisions
- **Label name**: `feature-plan` (not `feature-planning`) — per user preference
- **Transition method**: Remove `feature-plan` label only (no intermediate label like `ready-for-plan`) — simpler, relies on existing label-change event detection
- **No sub-issues**: Feature breakdown stays on the same issue, not split into child issues
- **`exclude_labels` at code level**: More reliable than relying on LLM instructions in AGENTS.md to skip certain labels
- **`exclude_labels` uses OR semantics**: If ANY exclude label is present, the pattern is blocked (consistent with how you'd expect exclusion to work)