### PR TITLE
feat: integrate oauth2-forwarder for browser-based OAuth2 in Docker/Podman containers

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -23,3 +23,17 @@ AGENT_SKILLS_DIR=/path/to/.agents/skills
 # Mount source dirs into specific thread workspaces in docker-compose.yml.
 # Example: mount jyc source into a bootstrapping thread:
 #   - /path/to/jyc:/opt/jyc/<channel>/workspace/<thread>/jyc
+
+# OAuth2 Forwarder (for browser-based OAuth2 in containers)
+# Required for MCP servers that need interactive OAuth2 login (e.g., Jira, Figma)
+# The o2f-server must be running on the host for this to work.
+# To disable the forwarder, set OAUTH2_FORWARDER_BROWSER= (empty)
+OAUTH2_FORWARDER_PORT=9191
+
+# Host address for o2f-server (container cannot use localhost on Podman/Mac)
+# Use host.containers.internal on Podman/Mac, localhost on Linux with host networking
+OAUTH2_FORWARDER_SERVER=localhost
+
+# Browser command for OAuth2 forwarder (default: o2f-browser)
+# Set to empty to disable forwarder and use system default browser
+OAUTH2_FORWARDER_BROWSER=o2f-browser

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,6 +25,9 @@ RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
+# Install oauth2-forwarder for browser-based OAuth2 in containers
+RUN npm install -g oauth2-forwarder
+
 # Directories and workdir
 RUN mkdir -p /root/.claude/skills /root/.agents/skills \
     /root/.config/opencode /root/.config/gh \

--- a/docker/README.md
+++ b/docker/README.md
@@ -138,3 +138,64 @@ Ensure the skills directories are mounted and readable:
 docker exec -it jyc ls /root/.claude/skills/
 docker exec -it jyc ls /root/.agents/skills/
 ```
+
+## OAuth2 Authentication
+
+Some MCP servers (e.g., Jira, Figma) require interactive browser-based OAuth2 login flows that don't work well inside containers by default. JYC includes [oauth2-forwarder](https://github.com/sam-mfb/oauth2-forwarder) to solve this.
+
+### How It Works
+
+- `o2f-browser` (in container): Intercepts browser-open requests and proxies them to the host
+- `o2f-client` (in container): Runs inside the container, proxies browser requests
+- `o2f-server` (on host): Receives browser requests from the container and opens them in the host's browser
+
+### Setup
+
+**1. Install oauth2-forwarder on your host:**
+
+```bash
+npm install -g oauth2-forwarder
+```
+
+**2. Start the host server:**
+
+```bash
+cd docker
+./o2f-server.sh
+```
+
+By default, the server listens on port 9191. To use a different port:
+
+```bash
+./o2f-server.sh 8080
+# or
+OAUTH2_FORWARDER_PORT=8080 ./o2f-server.sh
+```
+
+**3. Verify the connection:**
+
+The container shares host networking (`network_mode: host`), so it can reach `o2f-server` at `localhost:9191` automatically.
+
+### Disabling OAuth2 Forwarder
+
+The forwarder is enabled by default. To disable it and use the system default browser:
+
+```bash
+OAUTH2_FORWARDER_BROWSER=
+```
+
+in your `docker/.env` file. This tells tools inside the container to use their default browser behavior instead of routing through `o2f-browser`.
+
+### Passthrough Mode
+
+Passthrough mode (`OAUTH2_FORWARDER_PASSTHROUGH=true`) is enabled by default. This allows MCP tools that use device code flows (where the user authenticates on a different device or via a code) to work correctly. If you encounter issues with redirect-based OAuth2 flows, you may need to adjust this setting.
+
+### Troubleshooting
+
+**Connection refused when opening browser:**
+- Verify `o2f-server` is running on the host: `curl http://localhost:9191`
+- Check the port matches `OAUTH2_FORWARDER_PORT` in your `.env`
+
+**Port conflicts:**
+- If port 9191 is in use, specify a different port: `./o2f-server.sh 9192`
+- Update `OAUTH2_FORWARDER_PORT` in your `.env` to match

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,9 @@ services:
       - .env
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - OAUTH2_FORWARDER_PORT=${OAUTH2_FORWARDER_PORT:-9191}
+      - OAUTH2_FORWARDER_SERVER=${OAUTH2_FORWARDER_SERVER:-localhost}:${OAUTH2_FORWARDER_PORT:-9191}
+      - BROWSER=${OAUTH2_FORWARDER_BROWSER:-o2f-browser}
     volumes:
       # JYC data directory (config.toml, .env, channels, workspace)
       - ${JYC_DATA_DIR:-./}:/opt/jyc

--- a/docker/o2f-server.sh
+++ b/docker/o2f-server.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# OAuth2 Forwarder Host Server
+# Starts o2f-server on the host to enable browser-based OAuth2 for JYC container.
+#
+# Usage:
+#   ./o2f-server.sh                 # Start with default port 9191
+#   ./o2f-server.sh 8080             # Start with custom port
+#   OAUTH2_FORWARDER_PORT=8080 ./o2f-server.sh  # Alternative: via env var
+#
+# Prerequisites:
+#   - Node.js installed on host (for npx)
+#   - npm install -g oauth2-forwarder  # One-time setup
+#
+# The server runs in passthrough mode by default, allowing MCP tools
+# (like Jira, Figma) to use device code flows that don't follow
+# standard redirect patterns.
+
+set -e
+
+PORT="${1:-${OAUTH2_FORWARDER_PORT:-9191}}"
+
+echo "Starting oauth2-forwarder server on port $PORT..."
+
+if ! command -v o2f-server &> /dev/null; then
+    if ! npx --yes oauth2-forwarder --version &> /dev/null; then
+        echo "ERROR: oauth2-forwarder not found."
+        echo "Please install it with: npm install -g oauth2-forwarder"
+        exit 1
+    fi
+    echo "Using npx fallback..."
+    export OAUTH2_FORWARDER_PASSTHROUGH="${OAUTH2_FORWARDER_PASSTHROUGH:-true}"
+    exec npx --yes oauth2-forwarder --port "$PORT"
+fi
+
+export OAUTH2_FORWARDER_PASSTHROUGH="${OAUTH2_FORWARDER_PASSTHROUGH:-true}"
+exec o2f-server --port "$PORT"


### PR DESCRIPTION
## Spec

Integrate [oauth2-forwarder](https://github.com/sam-mfb/oauth2-forwarder) into JYC's Docker container to enable browser-based OAuth2 authentication flows for MCP servers (e.g., Jira, Figma) that require interactive login. The forwarder is installed by default and can be deactivated by not running `o2f-server` on the host.

Fixes #106

## Implementation Plan

### Step 1: Install oauth2-forwarder in Dockerfile
**What:** Add `npm install -g oauth2-forwarder` to the `base` stage in `docker/Dockerfile`. Set `ENV BROWSER=o2f-browser` and `ENV OAUTH2_FORWARDER_SERVER=localhost:9191` as defaults in the `base` stage.
**Why:** The forwarder npm package provides `o2f-browser` (intercepts BROWSER calls), `o2f-client` (proxies to host), and `o2f-server` (host-side). Installing in `base` makes it available in all stages. Setting `BROWSER=o2f-browser` ensures any tool that opens a browser (gh CLI, MCP servers) routes through the forwarder.
**Verify:** Build the Docker image and run `docker exec <container> which o2f-browser` and `docker exec <container> echo $BROWSER` — should output `/usr/local/bin/o2f-browser` and `o2f-browser` respectively.

### Step 2: Add OAuth2 forwarder env vars to docker-compose.yml
**What:** In `docker/docker-compose.yml`, add `OAUTH2_FORWARDER_ENABLED=${OAUTH2_FORWARDER_ENABLED:-true}` and `OAUTH2_FORWARDER_PORT=${OAUTH2_FORWARDER_PORT:-9191}` to the `jyc` service's `environment` section. Conditionally set `BROWSER` based on `OAUTH2_FORWARDER_ENABLED`: when disabled, unset `BROWSER` so tools use their default behavior.
**Why:** Makes the forwarder configurable via `.env` file without rebuilding the image. Users can deactivate it by setting `OAUTH2_FORWARDER_ENABLED=false`.
**Verify:** Run `docker compose config` and confirm the environment variables appear in the output.

### Step 3: Add OAuth2 forwarder config to .env.example
**What:** Add `OAUTH2_FORWARDER_ENABLED=true` and `OAUTH2_FORWARDER_PORT=9191` to `docker/.env.example` with descriptive comments.
**Why:** Documents the available configuration options for users.
**Verify:** Review the `.env.example` file for the new entries with clear comments.

### Step 4: Add host helper script for o2f-server
**What:** Create `docker/o2f-server.sh` — a small shell script that: (1) checks if `oauth2-forwarder` is installed on the host (via `npm list -g` or `npx`), (2) sets `OAUTH2_FORWARDER_PORT` from env or defaults to 9191, (3) starts `o2f-server` with `OAUTH2_FORWARDER_PASSTHROUGH=true`. Include usage instructions in the script header.
**Why:** Simplifies the host-side setup — users just run `./docker/o2f-server.sh` instead of manually installing and configuring the server. Passthrough mode is enabled by default because MCP tools (like Jira/Figma) may use device code flows.
**Verify:** Run `bash -n docker/o2f-server.sh` to check syntax. On a host with Node.js, run the script and verify it starts listening on the configured port.

### Step 5: Add OAuth2 Authentication section to docker/README.md
**What:** Add a new "OAuth2 Authentication" section to `docker/README.md` covering: (1) the problem (MCP tools need browser OAuth2 in containers), (2) how oauth2-forwarder solves it, (3) step-by-step setup: install on host (`npm install -g oauth2-forwarder`), run `o2f-server.sh`, verify connection, (4) how to disable it (`OAUTH2_FORWARDER_ENABLED=false`), (5) passthrough mode explanation for device code flows, (6) troubleshooting (connection refused when server not running, port conflicts).
**Why:** Users need clear documentation to set up and use the feature.
**Verify:** Review the README for completeness and accuracy.

## Design Decisions
- **o2f-server runs on host** (not containerized) — it needs access to the host's browser to open OAuth2 login pages
- **Default install, deactivate via env** — forwarder is always in the image; deactivation is runtime (don't run o2f-server on host, or set `OAUTH2_FORWARDER_ENABLED=false`)
- **`network_mode: host`** — the container shares host networking, so `o2f-client` connects to `o2f-server` at `localhost:PORT` directly
- **Passthrough mode enabled** — MCP servers may use device code flows that don't follow standard redirect patterns
- **Port 9191 default** — arbitrary but memorable, configurable via `OAUTH2_FORWARDER_PORT`