### PR TITLE
feat: idle thread directory auto-cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ crossterm = "0.28"
 
 [dev-dependencies]
 tempfile = "3"
+filetime = "0.2"
 
 [profile.dev]
 debug = 1                    # instead of default 2 (full debug info)

--- a/config.example.toml
+++ b/config.example.toml
@@ -295,6 +295,14 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # github_type = ["pull_request"]
 # labels = ["ready-for-dev"]
 #
+# # Idle cleanup: automatically remove cloned repo directories from idle threads
+# # Only threads matching this pattern are affected; default is off.
+# [channels.my_repo.patterns.idle_cleanup]
+# enabled = true
+# timeout_secs = 86400      # 24 hours idle before cleanup
+# clean_paths = ["repo"]    # directories to remove
+# interval_secs = 300       # scan every 5 minutes
+#
 # # Pattern: PRs with 'ready-for-review' label → Reviewer agent (auto-trigger)
 # [[channels.my_repo.patterns]]
 # name = "reviewer"

--- a/config.example.toml
+++ b/config.example.toml
@@ -297,11 +297,7 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 #
 # # Idle cleanup: automatically remove cloned repo directories from idle threads
 # # Only threads matching this pattern are affected; default is off.
-# [channels.my_repo.patterns.idle_cleanup]
-# enabled = true
-# timeout_secs = 86400      # 24 hours idle before cleanup
-# clean_paths = ["repo"]    # directories to remove
-# interval_secs = 300       # scan every 5 minutes
+# idle_cleanup = { enabled = true, timeout_secs = 86400, clean_paths = ["repo"], interval_secs = 300 }
 #
 # # Pattern: PRs with 'ready-for-review' label → Reviewer agent (auto-trigger)
 # [[channels.my_repo.patterns]]

--- a/src/channels/types.rs
+++ b/src/channels/types.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tokio_util::sync::CancellationToken;
 
-use crate::config::types::InboundAttachmentConfig;
+use crate::config::types::{IdleCleanupConfig, InboundAttachmentConfig};
 
 /// Channel type identifier (e.g., "email", "feishu", "slack")
 pub type ChannelType = String;
@@ -278,6 +278,10 @@ pub struct ChannelPattern {
     /// When false, messages queue and are processed sequentially.
     #[serde(default = "default_true")]
     pub live_injection: bool,
+    /// Idle cleanup configuration for this pattern.
+    /// When enabled, automatically removes specified subdirectories from idle threads.
+    #[serde(default)]
+    pub idle_cleanup: Option<IdleCleanupConfig>,
 }
 
 impl Default for ChannelPattern {
@@ -292,6 +296,7 @@ impl Default for ChannelPattern {
             thread_name: None,
             role: None,
             live_injection: true,
+            idle_cleanup: None,
         }
     }
 }

--- a/src/cli/monitor.rs
+++ b/src/cli/monitor.rs
@@ -231,6 +231,17 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
             "State loaded"
         );
 
+        let cleanup_patterns = patterns.clone();
+        let cleanup_workspace = workspace_dir.clone();
+        let cleanup_cancel = cancel.clone();
+        tokio::spawn(async move {
+            crate::core::idle_cleanup::start_idle_cleanup_sweep(
+                cleanup_workspace,
+                cleanup_patterns,
+                cleanup_cancel,
+            ).await;
+        });
+
         // Spawn the inbound monitor as a task (channel-type-specific)
         let cancel_child = cancel.clone();
         let channel_name_owned = channel_name.clone();

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -412,3 +412,34 @@ pub struct OutboundAttachmentConfig {
     /// Max number of attachments to send per message
     pub max_per_message: Option<usize>,
 }
+
+/// Idle cleanup configuration for a channel pattern.
+///
+/// When enabled, automatically removes large subdirectories (e.g., cloned `repo/`)
+/// from idle threads while preserving all metadata (`.jyc/`, chat history, sessions).
+#[derive(Debug, Clone, Deserialize)]
+pub struct IdleCleanupConfig {
+    /// Whether idle cleanup is enabled (default: false)
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Idle timeout in seconds before cleaning (default: 86400 = 24 hours)
+    #[serde(default = "default_86400")]
+    pub timeout_secs: u64,
+
+    /// Subdirectory paths to clean (e.g., ["repo"]) (default: [])
+    #[serde(default)]
+    pub clean_paths: Vec<String>,
+
+    /// Scan interval in seconds (default: 300 = 5 minutes)
+    #[serde(default = "default_300")]
+    pub interval_secs: u64,
+}
+
+fn default_86400() -> u64 {
+    86400
+}
+
+fn default_300() -> u64 {
+    300
+}

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -417,7 +417,7 @@ pub struct OutboundAttachmentConfig {
 ///
 /// When enabled, automatically removes large subdirectories (e.g., cloned `repo/`)
 /// from idle threads while preserving all metadata (`.jyc/`, chat history, sessions).
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IdleCleanupConfig {
     /// Whether idle cleanup is enabled (default: false)
     #[serde(default)]

--- a/src/core/idle_cleanup.rs
+++ b/src/core/idle_cleanup.rs
@@ -1,0 +1,197 @@
+use std::path::{Path, PathBuf};
+use tokio::fs;
+use tokio::time::{sleep, Duration};
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+use anyhow::Result;
+
+use crate::channels::types::ChannelPattern;
+
+/// Start the idle cleanup sweep task for a channel.
+///
+/// Each channel runs its own independent sweep task that periodically scans
+/// the workspace for idle threads and removes specified subdirectories.
+pub async fn start_idle_cleanup_sweep(
+    workspace_dir: PathBuf,
+    patterns: Vec<ChannelPattern>,
+    cancel: CancellationToken,
+) {
+    let enabled_patterns: Vec<(String, &ChannelPattern)> = patterns
+        .iter()
+        .filter(|p| p.idle_cleanup.as_ref().map_or(false, |c| c.enabled))
+        .map(|p| (p.name.clone(), p))
+        .collect();
+
+    if enabled_patterns.is_empty() {
+        return;
+    }
+
+    let interval_secs = enabled_patterns
+        .iter()
+        .filter_map(|(_, p)| p.idle_cleanup.as_ref())
+        .map(|c| c.interval_secs)
+        .min()
+        .unwrap_or(300);
+
+    let pattern_map: std::collections::HashMap<String, &ChannelPattern> = enabled_patterns
+        .into_iter()
+        .collect();
+
+    info!(
+        workspace_dir = %workspace_dir.display(),
+        pattern_count = pattern_map.len(),
+        scan_interval_secs = interval_secs,
+        "Starting idle cleanup sweep"
+    );
+
+    let mut interval = tokio::time::interval(Duration::from_secs(interval_secs));
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!("Idle cleanup sweep cancelled");
+                break;
+            }
+            _ = interval.tick() => {
+                if let Err(e) = sweep_once(&workspace_dir, &pattern_map).await {
+                    warn!(error = %e, "Idle cleanup sweep failed");
+                }
+            }
+        }
+    }
+}
+
+async fn sweep_once(
+    workspace_dir: &Path,
+    pattern_map: &std::collections::HashMap<String, &ChannelPattern>,
+) -> Result<()> {
+    let mut entries = fs::read_dir(workspace_dir).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let jyc_dir = path.join(".jyc");
+        if !jyc_dir.exists() {
+            continue;
+        }
+
+        let thread_name = entry.file_name().to_string_lossy().to_string();
+
+        if jyc_dir.join("question-sent.flag").exists() {
+            continue;
+        }
+
+        let pattern_file = jyc_dir.join("pattern");
+        let pattern_name = if pattern_file.exists() {
+            fs::read_to_string(&pattern_file).await?.trim().to_string()
+        } else {
+            continue;
+        };
+
+        let idle_config = match pattern_map.get(&pattern_name) {
+            Some(p) => p.idle_cleanup.as_ref(),
+            None => continue,
+        };
+
+        let idle_config = match idle_config {
+            Some(c) => c,
+            None => continue,
+        };
+
+        let last_active = match fs::metadata(&jyc_dir).await {
+            Ok(meta) => match meta.modified() {
+                Ok(mtime) => {
+                    let dt: chrono::DateTime<chrono::Utc> = mtime.into();
+                    dt
+                }
+                Err(_) => continue,
+            },
+            Err(_) => continue,
+        };
+
+        let now = chrono::Utc::now();
+        let idle_duration = now.signed_duration_since(last_active);
+        let timeout = chrono::Duration::seconds(idle_config.timeout_secs as i64);
+
+        let idle_cleaned_flag = jyc_dir.join("idle-cleaned.flag");
+
+        if idle_duration > timeout {
+            if idle_cleaned_flag.exists() {
+                continue;
+            }
+
+            for clean_path in &idle_config.clean_paths {
+                let target = path.join(clean_path);
+                if target.exists() {
+                    match fs::remove_dir_all(&target).await {
+                        Ok(_) => {
+                            info!(
+                                thread = %thread_name,
+                                path = %target.display(),
+                                idle_secs = idle_duration.num_seconds(),
+                                "Cleaned idle thread subdirectory"
+                            );
+                        }
+                        Err(e) => {
+                            warn!(
+                                error = %e,
+                                thread = %thread_name,
+                                path = %target.display(),
+                                "Failed to clean idle thread subdirectory"
+                            );
+                        }
+                    }
+                }
+            }
+
+            if let Err(e) = fs::write(&idle_cleaned_flag, "").await {
+                warn!(error = %e, "Failed to write idle-cleaned.flag");
+            }
+        } else if idle_cleaned_flag.exists() {
+            if let Err(e) = fs::remove_file(&idle_cleaned_flag).await {
+                warn!(error = %e, "Failed to remove idle-cleaned.flag");
+            } else {
+                info!(thread = %thread_name, "Thread became active, removed idle-cleaned.flag");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_idle_cleanup_skips_question_sent_flag() {
+        let dir = tempdir().unwrap();
+        let workspace = dir.path();
+
+        let thread_dir = workspace.join("waiting-thread");
+        fs::create_dir_all(thread_dir.join(".jyc")).await.unwrap();
+        fs::create_dir_all(thread_dir.join("repo")).await.unwrap();
+
+        fs::write(thread_dir.join(".jyc").join("pattern"), "developer").await.unwrap();
+        fs::write(thread_dir.join(".jyc").join("question-sent.flag"), "").await.unwrap();
+
+        let mut pattern = ChannelPattern::default();
+        pattern.name = "developer".to_string();
+        pattern.idle_cleanup = Some(crate::config::types::IdleCleanupConfig {
+            enabled: true,
+            timeout_secs: 86400,
+            clean_paths: vec!["repo".to_string()],
+            interval_secs: 300,
+        });
+
+        let patterns = vec![pattern];
+        let cancel = CancellationToken::new();
+
+        start_idle_cleanup_sweep(workspace.to_path_buf(), patterns, cancel).await;
+
+        assert!(thread_dir.join("repo").exists());
+    }
+}

--- a/src/core/idle_cleanup.rs
+++ b/src/core/idle_cleanup.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 use tokio::fs;
-use tokio::time::{sleep, Duration};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 use anyhow::Result;
@@ -122,9 +122,20 @@ async fn sweep_once(
                 continue;
             }
 
+            let mut cleaned_any = false;
             for clean_path in &idle_config.clean_paths {
+                if !is_safe_path(clean_path) {
+                    warn!(
+                        thread = %thread_name,
+                        path = %clean_path,
+                        "Skipping unsafe clean_path (contains path traversal)"
+                    );
+                    continue;
+                }
+
                 let target = path.join(clean_path);
                 if target.exists() {
+                    cleaned_any = true;
                     match fs::remove_dir_all(&target).await {
                         Ok(_) => {
                             info!(
@@ -146,8 +157,10 @@ async fn sweep_once(
                 }
             }
 
-            if let Err(e) = fs::write(&idle_cleaned_flag, "").await {
-                warn!(error = %e, "Failed to write idle-cleaned.flag");
+            if cleaned_any {
+                if let Err(e) = fs::write(&idle_cleaned_flag, "").await {
+                    warn!(error = %e, "Failed to write idle-cleaned.flag");
+                }
             }
         } else if idle_cleaned_flag.exists() {
             if let Err(e) = fs::remove_file(&idle_cleaned_flag).await {
@@ -161,9 +174,14 @@ async fn sweep_once(
     Ok(())
 }
 
+fn is_safe_path(path: &str) -> bool {
+    !path.contains("..") && !path.contains('/') && !path.contains('\\')
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::SystemTime;
     use tempfile::tempdir;
 
     #[tokio::test]
@@ -174,6 +192,10 @@ mod tests {
         let thread_dir = workspace.join("waiting-thread");
         fs::create_dir_all(thread_dir.join(".jyc")).await.unwrap();
         fs::create_dir_all(thread_dir.join("repo")).await.unwrap();
+
+        let old_time = SystemTime::now() - std::time::Duration::from_secs(86400 * 2);
+        let old_filetime = filetime::FileTime::from_system_time(old_time);
+        filetime::set_file_mtime(thread_dir.join(".jyc"), old_filetime).unwrap();
 
         fs::write(thread_dir.join(".jyc").join("pattern"), "developer").await.unwrap();
         fs::write(thread_dir.join(".jyc").join("question-sent.flag"), "").await.unwrap();
@@ -189,9 +211,145 @@ mod tests {
 
         let patterns = vec![pattern];
         let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            cancel_clone.cancel();
+        });
 
         start_idle_cleanup_sweep(workspace.to_path_buf(), patterns, cancel).await;
 
         assert!(thread_dir.join("repo").exists());
+    }
+
+    #[tokio::test]
+    async fn test_idle_cleanup_removes_stale_directories() {
+        let dir = tempdir().unwrap();
+        let workspace = dir.path();
+
+        let thread_dir = workspace.join("stale-thread");
+        fs::create_dir_all(thread_dir.join(".jyc")).await.unwrap();
+        fs::create_dir_all(thread_dir.join("repo")).await.unwrap();
+
+        let old_time = SystemTime::now() - std::time::Duration::from_secs(86400 * 2);
+        let old_filetime = filetime::FileTime::from_system_time(old_time);
+        filetime::set_file_mtime(thread_dir.join(".jyc"), old_filetime).unwrap();
+
+        fs::write(thread_dir.join(".jyc").join("pattern"), "developer").await.unwrap();
+
+        let mut pattern = ChannelPattern::default();
+        pattern.name = "developer".to_string();
+        pattern.idle_cleanup = Some(crate::config::types::IdleCleanupConfig {
+            enabled: true,
+            timeout_secs: 86400,
+            clean_paths: vec!["repo".to_string()],
+            interval_secs: 300,
+        });
+
+        let patterns = vec![pattern];
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            cancel_clone.cancel();
+        });
+
+        start_idle_cleanup_sweep(workspace.to_path_buf(), patterns, cancel).await;
+
+        assert!(!thread_dir.join("repo").exists());
+        assert!(thread_dir.join(".jyc").join("idle-cleaned.flag").exists());
+    }
+
+    #[tokio::test]
+    async fn test_idle_cleanup_preserves_active_threads() {
+        let dir = tempdir().unwrap();
+        let workspace = dir.path();
+
+        let thread_dir = workspace.join("active-thread");
+        fs::create_dir_all(thread_dir.join(".jyc")).await.unwrap();
+        fs::create_dir_all(thread_dir.join("repo")).await.unwrap();
+
+        let recent_time = SystemTime::now() - std::time::Duration::from_secs(60);
+        let recent_filetime = filetime::FileTime::from_system_time(recent_time);
+        filetime::set_file_mtime(thread_dir.join(".jyc"), recent_filetime).unwrap();
+
+        fs::write(thread_dir.join(".jyc").join("pattern"), "developer").await.unwrap();
+
+        let mut pattern = ChannelPattern::default();
+        pattern.name = "developer".to_string();
+        pattern.idle_cleanup = Some(crate::config::types::IdleCleanupConfig {
+            enabled: true,
+            timeout_secs: 86400,
+            clean_paths: vec!["repo".to_string()],
+            interval_secs: 300,
+        });
+
+        let patterns = vec![pattern];
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            cancel_clone.cancel();
+        });
+
+        start_idle_cleanup_sweep(workspace.to_path_buf(), patterns, cancel).await;
+
+        assert!(thread_dir.join("repo").exists());
+        assert!(!thread_dir.join(".jyc").join("idle-cleaned.flag").exists());
+    }
+
+    #[tokio::test]
+    async fn test_idle_cleanup_flag_removed_when_active() {
+        let dir = tempdir().unwrap();
+        let workspace = dir.path();
+
+        let thread_dir = workspace.join("reactivated-thread");
+        fs::create_dir_all(thread_dir.join(".jyc")).await.unwrap();
+        fs::create_dir_all(thread_dir.join("repo")).await.unwrap();
+
+        let recent_time = SystemTime::now() - std::time::Duration::from_secs(60);
+        let recent_filetime = filetime::FileTime::from_system_time(recent_time);
+        filetime::set_file_mtime(thread_dir.join(".jyc"), recent_filetime).unwrap();
+
+        fs::write(thread_dir.join(".jyc").join("pattern"), "developer").await.unwrap();
+        fs::write(thread_dir.join(".jyc").join("idle-cleaned.flag"), "").await.unwrap();
+
+        let mut pattern = ChannelPattern::default();
+        pattern.name = "developer".to_string();
+        pattern.idle_cleanup = Some(crate::config::types::IdleCleanupConfig {
+            enabled: true,
+            timeout_secs: 86400,
+            clean_paths: vec!["repo".to_string()],
+            interval_secs: 300,
+        });
+
+        let patterns = vec![pattern];
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            cancel_clone.cancel();
+        });
+
+        start_idle_cleanup_sweep(workspace.to_path_buf(), patterns, cancel).await;
+
+        assert!(thread_dir.join("repo").exists());
+        assert!(!thread_dir.join(".jyc").join("idle-cleaned.flag").exists());
+    }
+
+    #[test]
+    fn test_is_safe_path() {
+        assert!(is_safe_path("repo"));
+        assert!(is_safe_path("src"));
+        assert!(is_safe_path("workspace"));
+        assert!(!is_safe_path("../etc"));
+        assert!(!is_safe_path("foo/../bar"));
+        assert!(!is_safe_path("foo\\..\\bar"));
+        assert!(!is_safe_path(".."));
+        assert!(!is_safe_path("repo/../etc"));
     }
 }

--- a/src/core/idle_cleanup.rs
+++ b/src/core/idle_cleanup.rs
@@ -193,12 +193,12 @@ mod tests {
         fs::create_dir_all(thread_dir.join(".jyc")).await.unwrap();
         fs::create_dir_all(thread_dir.join("repo")).await.unwrap();
 
+        fs::write(thread_dir.join(".jyc").join("pattern"), "developer").await.unwrap();
+        fs::write(thread_dir.join(".jyc").join("question-sent.flag"), "").await.unwrap();
+
         let old_time = SystemTime::now() - std::time::Duration::from_secs(86400 * 2);
         let old_filetime = filetime::FileTime::from_system_time(old_time);
         filetime::set_file_mtime(thread_dir.join(".jyc"), old_filetime).unwrap();
-
-        fs::write(thread_dir.join(".jyc").join("pattern"), "developer").await.unwrap();
-        fs::write(thread_dir.join(".jyc").join("question-sent.flag"), "").await.unwrap();
 
         let mut pattern = ChannelPattern::default();
         pattern.name = "developer".to_string();
@@ -232,11 +232,11 @@ mod tests {
         fs::create_dir_all(thread_dir.join(".jyc")).await.unwrap();
         fs::create_dir_all(thread_dir.join("repo")).await.unwrap();
 
+        fs::write(thread_dir.join(".jyc").join("pattern"), "developer").await.unwrap();
+
         let old_time = SystemTime::now() - std::time::Duration::from_secs(86400 * 2);
         let old_filetime = filetime::FileTime::from_system_time(old_time);
         filetime::set_file_mtime(thread_dir.join(".jyc"), old_filetime).unwrap();
-
-        fs::write(thread_dir.join(".jyc").join("pattern"), "developer").await.unwrap();
 
         let mut pattern = ChannelPattern::default();
         pattern.name = "developer".to_string();
@@ -271,11 +271,11 @@ mod tests {
         fs::create_dir_all(thread_dir.join(".jyc")).await.unwrap();
         fs::create_dir_all(thread_dir.join("repo")).await.unwrap();
 
+        fs::write(thread_dir.join(".jyc").join("pattern"), "developer").await.unwrap();
+
         let recent_time = SystemTime::now() - std::time::Duration::from_secs(60);
         let recent_filetime = filetime::FileTime::from_system_time(recent_time);
         filetime::set_file_mtime(thread_dir.join(".jyc"), recent_filetime).unwrap();
-
-        fs::write(thread_dir.join(".jyc").join("pattern"), "developer").await.unwrap();
 
         let mut pattern = ChannelPattern::default();
         pattern.name = "developer".to_string();
@@ -310,12 +310,12 @@ mod tests {
         fs::create_dir_all(thread_dir.join(".jyc")).await.unwrap();
         fs::create_dir_all(thread_dir.join("repo")).await.unwrap();
 
+        fs::write(thread_dir.join(".jyc").join("pattern"), "developer").await.unwrap();
+        fs::write(thread_dir.join(".jyc").join("idle-cleaned.flag"), "").await.unwrap();
+
         let recent_time = SystemTime::now() - std::time::Duration::from_secs(60);
         let recent_filetime = filetime::FileTime::from_system_time(recent_time);
         filetime::set_file_mtime(thread_dir.join(".jyc"), recent_filetime).unwrap();
-
-        fs::write(thread_dir.join(".jyc").join("pattern"), "developer").await.unwrap();
-        fs::write(thread_dir.join(".jyc").join("idle-cleaned.flag"), "").await.unwrap();
 
         let mut pattern = ChannelPattern::default();
         pattern.name = "developer".to_string();

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,6 +2,7 @@ pub mod attachment_storage;
 pub mod chat_log_store;
 pub mod command;
 pub mod email_parser;
+pub mod idle_cleanup;
 pub mod message_router;
 pub mod message_storage;
 pub mod metrics;


### PR DESCRIPTION
## Spec

Add per-pattern configurable idle cleanup that automatically removes large subdirectories (e.g., cloned `repo/`) from idle threads while preserving all metadata (`.jyc/`, chat history, sessions). Only patterns explicitly configured with `idle_cleanup.enabled = true` are affected; default is off. Each channel runs its own sweep task with a configurable scan interval.

Fixes #109

## Implementation Plan

### Step 1: Add `IdleCleanupConfig` struct
**What:** Add `IdleCleanupConfig` in `src/config/types.rs` with fields: `enabled: bool` (default false), `timeout_secs: u64` (default 86400), `clean_paths: Vec<String>` (default []), `interval_secs: u64` (default 300). Add corresponding `default_*` functions.
**Why:** Provides the configuration structure for per-pattern idle cleanup settings.
**Verify:** `cargo check` compiles without errors.

### Step 2: Add `idle_cleanup` field to `ChannelPattern`
**What:** Add `pub idle_cleanup: Option<IdleCleanupConfig>` field to `ChannelPattern` in `src/channels/types.rs`. Update the `Default` impl to set it to `None`.
**Why:** Attaches idle cleanup config to specific patterns so only matching threads are cleaned.
**Verify:** `cargo check` compiles without errors.

### Step 3: Create `src/core/idle_cleanup.rs` with sweep logic
**What:** Create a new module with a `start_idle_cleanup_sweep` async function:
- Takes: `workspace_dir: PathBuf`, `patterns: Vec<ChannelPattern>`, `cancel: CancellationToken`
- On start, collects patterns with `idle_cleanup.enabled = true`, computes scan interval as min of their `interval_secs`
- Loops: `tokio::time::sleep(interval)`, then scans workspace for thread dirs with `.jyc/`
- For each thread: reads `.jyc/pattern` file → looks up pattern's `idle_cleanup` config
- Reads `.jyc/` dir mtime as `last_active_at` (same approach as `ThreadManager::list_threads()` at `src/core/thread_manager.rs:553`)
- If `now - last_active > timeout_secs` and `.jyc/idle-cleaned.flag` doesn't exist: `tokio::fs::remove_dir_all(thread_path.join(path))` for each path in `clean_paths`, then write `.jyc/idle-cleaned.flag`
- If not timed out and flag exists: delete the flag (thread became active again)
- Skip threads with `question-sent.flag` (waiting for user answer)
- Log cleanup actions with `tracing::info!`
- Exits on `cancel.cancelled()`
**Why:** Core sweep logic that performs the actual cleanup, strictly reusing existing path resolution (workspace dir passed in) and mtime approach.
**Verify:** `cargo check` compiles. Unit test: create temp dirs with `.jyc/pattern` and stale mtime, verify `clean_paths` dirs are removed and flag is written.

### Step 4: Register `idle_cleanup` module
**What:** Add `pub mod idle_cleanup;` to `src/core/mod.rs`.
**Why:** Makes the module accessible from `cli/monitor.rs`.
**Verify:** `cargo check` compiles.

### Step 5: Start sweep task per channel in `cli/monitor.rs`
**What:** In the channel loop in `run()`, after creating the `ThreadManager` and before spawning the inbound task, spawn the idle cleanup sweep task:
```rust
let cleanup_patterns = patterns.clone();
let cleanup_workspace = workspace_dir.clone();
let cleanup_cancel = cancel.clone();
tokio::spawn(async move {
    crate::core::idle_cleanup::start_idle_cleanup_sweep(
        cleanup_workspace,
        cleanup_patterns,
        cleanup_cancel,
    ).await;
});
```
**Why:** Each channel gets its own sweep task, matching existing per-channel task architecture.
**Verify:** `cargo check` compiles. Manual: configure a pattern with `idle_cleanup`, start monitor, verify log output shows sweep running and stale dirs cleaned.

### Step 6: Update `config.example.toml`
**What:** Add an example `idle_cleanup` section under a pattern in `config.example.toml` with comments explaining each field.
**Why:** Documents the new configuration option for users.
**Verify:** `cargo check` still compiles; example config is valid TOML.

## Design Decisions
- **Per-pattern, not per-channel**: allows fine-grained control (e.g., only "developer" patterns need repo cleanup, not "invoice" patterns)
- **Per-channel sweep task**: each channel has independent workspace and config; aligns with existing per-channel inbound task architecture
- **Default disabled**: `enabled` defaults to `false`, no behavior change without explicit opt-in
- **`clean_paths` defaults to empty**: user must explicitly list directories to clean (e.g., `["repo"]`)
- **Reuse `.jyc/` mtime**: same approach as `list_threads()`, no new `last-active` file needed
- **`idle-cleaned.flag`**: prevents repeated cleanup attempts; cleared when thread becomes active again
- **Skip `question-sent.flag` threads**: don't clean while waiting for user answer