### PR TITLE
fix: idle cleanup per-thread skip flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,6 +1488,7 @@ dependencies = [
  "clap",
  "comrak",
  "crossterm",
+ "filetime",
  "futures",
  "glob",
  "htmd",
@@ -1557,6 +1569,18 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -2015,7 +2039,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2138,6 +2162,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -2475,6 +2505,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]

--- a/config.example.toml
+++ b/config.example.toml
@@ -297,7 +297,7 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 #
 # # Idle cleanup: automatically remove cloned repo directories from idle threads
 # # Only threads matching this pattern are affected; default is off.
-# idle_cleanup = { enabled = true, timeout_secs = 86400, clean_paths = ["repo"], interval_secs = 300 }
+# idle_cleanup = { enabled = true, timeout_secs = 86400, clean_paths = ["repo"], interval_secs = 300, skip_cleanup = true }
 #
 # # Pattern: PRs with 'ready-for-review' label → Reviewer agent (auto-trigger)
 # [[channels.my_repo.patterns]]

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -434,6 +434,11 @@ pub struct IdleCleanupConfig {
     /// Scan interval in seconds (default: 300 = 5 minutes)
     #[serde(default = "default_300")]
     pub interval_secs: u64,
+
+    /// Whether to skip cleanup for threads matching this pattern (default: true)
+    /// When true, a .jyc/idle-cleanup-skip.flag file is created on thread creation.
+    #[serde(default = "default_true")]
+    pub skip_cleanup: bool,
 }
 
 fn default_86400() -> u64 {

--- a/src/core/idle_cleanup.rs
+++ b/src/core/idle_cleanup.rs
@@ -230,6 +230,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_idle_cleanup_skips_skip_flag() {
+        let dir = tempdir().unwrap();
+        let workspace = dir.path();
+
+        let thread_dir = workspace.join("skipped-thread");
+        fs::create_dir_all(thread_dir.join(".jyc")).await.unwrap();
+        fs::create_dir_all(thread_dir.join("repo")).await.unwrap();
+
+        fs::write(thread_dir.join(".jyc").join("pattern"), "developer").await.unwrap();
+        fs::write(thread_dir.join(".jyc").join("idle-cleanup-skip.flag"), "").await.unwrap();
+
+        let old_time = SystemTime::now() - std::time::Duration::from_secs(86400 * 2);
+        let old_filetime = filetime::FileTime::from_system_time(old_time);
+        filetime::set_file_mtime(thread_dir.join(".jyc"), old_filetime).unwrap();
+
+        let mut pattern = ChannelPattern::default();
+        pattern.name = "developer".to_string();
+        pattern.idle_cleanup = Some(crate::config::types::IdleCleanupConfig {
+            enabled: true,
+            timeout_secs: 86400,
+            clean_paths: vec!["repo".to_string()],
+            interval_secs: 300,
+            skip_cleanup: false,
+        });
+
+        let patterns = vec![pattern];
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            cancel_clone.cancel();
+        });
+
+        start_idle_cleanup_sweep(workspace.to_path_buf(), patterns, cancel).await;
+
+        assert!(thread_dir.join("repo").exists());
+    }
+
+    #[tokio::test]
     async fn test_idle_cleanup_removes_stale_directories() {
         let dir = tempdir().unwrap();
         let workspace = dir.path();

--- a/src/core/idle_cleanup.rs
+++ b/src/core/idle_cleanup.rs
@@ -83,6 +83,11 @@ async fn sweep_once(
             continue;
         }
 
+        if jyc_dir.join("idle-cleanup-skip.flag").exists() {
+            tracing::debug!(thread = %thread_name, "Skipping thread with idle-cleanup-skip.flag");
+            continue;
+        }
+
         let pattern_file = jyc_dir.join("pattern");
         let pattern_name = if pattern_file.exists() {
             fs::read_to_string(&pattern_file).await?.trim().to_string()
@@ -207,6 +212,7 @@ mod tests {
             timeout_secs: 86400,
             clean_paths: vec!["repo".to_string()],
             interval_secs: 300,
+            skip_cleanup: false,
         });
 
         let patterns = vec![pattern];
@@ -245,6 +251,7 @@ mod tests {
             timeout_secs: 86400,
             clean_paths: vec!["repo".to_string()],
             interval_secs: 300,
+            skip_cleanup: false,
         });
 
         let patterns = vec![pattern];
@@ -284,6 +291,7 @@ mod tests {
             timeout_secs: 86400,
             clean_paths: vec!["repo".to_string()],
             interval_secs: 300,
+            skip_cleanup: false,
         });
 
         let patterns = vec![pattern];
@@ -324,6 +332,7 @@ mod tests {
             timeout_secs: 86400,
             clean_paths: vec!["repo".to_string()],
             interval_secs: 300,
+            skip_cleanup: false,
         });
 
         let patterns = vec![pattern];

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -424,6 +424,20 @@ impl ThreadManager {
                     if let Err(e) = tokio::fs::write(&pattern_file, &item.pattern_match.pattern_name).await {
                         tracing::warn!(error = %e, "Failed to write pattern file");
                     }
+
+                    // Write idle-cleanup-skip.flag if skip_cleanup is enabled (default)
+                    let skip_flag = thread_path.join(".jyc").join("idle-cleanup-skip.flag");
+                    let config = tm.config.load();
+                    let should_skip = config.channels.get(&tm.channel_name)
+                        .and_then(|ch| ch.patterns.as_ref())
+                        .and_then(|patterns| patterns.iter().find(|p| p.name == item.pattern_match.pattern_name))
+                        .map(|p| p.idle_cleanup.as_ref().map_or(true, |c| c.skip_cleanup))
+                        .unwrap_or(true);
+                    if should_skip && !skip_flag.exists() {
+                        if let Err(e) = tokio::fs::write(&skip_flag, "").await {
+                            tracing::warn!(error = %e, "Failed to write idle-cleanup-skip.flag");
+                        }
+                    }
                 }
 
                 // Update current message for event listeners

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -433,9 +433,13 @@ impl ThreadManager {
                         .and_then(|patterns| patterns.iter().find(|p| p.name == item.pattern_match.pattern_name))
                         .map(|p| p.idle_cleanup.as_ref().map_or(true, |c| c.skip_cleanup))
                         .unwrap_or(true);
-                    if should_skip && !skip_flag.exists() {
+                    if should_skip {
                         if let Err(e) = tokio::fs::write(&skip_flag, "").await {
                             tracing::warn!(error = %e, "Failed to write idle-cleanup-skip.flag");
+                        }
+                    } else if tokio::fs::metadata(&skip_flag).await.is_ok() {
+                        if let Err(e) = tokio::fs::remove_file(&skip_flag).await {
+                            tracing::warn!(error = %e, "Failed to remove idle-cleanup-skip.flag");
                         }
                     }
                 }


### PR DESCRIPTION
## Spec

Add per-thread opt-out support for idle cleanup via a `skip_cleanup` config flag and `.jyc/idle-cleanup-skip.flag` file, allowing fine-grained control so that threads under the same pattern can independently be kept or cleaned.

Fixes #112

## Implementation Plan

### Step 1: Add `skip_cleanup` field to `IdleCleanupConfig`
**What:** Add `skip_cleanup: bool` field (default `true`) to `IdleCleanupConfig` in `src/config/types.rs:421`.
**Why:** This provides the pattern-level default for whether new threads should be protected from cleanup. Default `true` ensures safe-by-default behavior.
**Verify:** `cargo check` passes; existing config files without `skip_cleanup` still deserialize correctly (default `true`).

### Step 2: Write `.jyc/idle-cleanup-skip.flag` on thread creation
**What:** In `src/core/thread_manager.rs`, after `.jyc/pattern` is written (around line 424), check the pattern's `idle_cleanup.skip_cleanup` value. If `true` (or `idle_cleanup` is `None`), write an empty `.jyc/idle-cleanup-skip.flag` file. The pattern's `idle_cleanup` config needs to be accessible here — pass it through `QueueItem` or look it up from the config snapshot.
**Why:** Threads need to be protected by default when created. The flag file provides per-thread persistence that survives restarts.
**Verify:** Create a thread with a pattern that has `idle_cleanup = { enabled = true, skip_cleanup = true }` → `.jyc/idle-cleanup-skip.flag` exists. With `skip_cleanup = false` → flag does not exist.

### Step 3: Check `idle-cleanup-skip.flag` in `sweep_once`
**What:** In `src/core/idle_cleanup.rs`, `sweep_once()` function (around line 82, after the `question-sent.flag` check), add a check: if `.jyc/idle-cleanup-skip.flag` exists, skip this thread with a `tracing::debug!` log.
**Why:** This is the core fix — threads with the skip flag must never be cleaned, regardless of idle duration.
**Verify:** `cargo test` — add a new test `test_idle_cleanup_skips_skip_flag` that creates a thread with `idle-cleanup-skip.flag`, sets old mtime, and verifies it is NOT cleaned.

### Step 4: Update existing tests to account for `skip_cleanup` default
**What:** In `src/core/idle_cleanup.rs` tests, the existing `ChannelPattern` test instances set `idle_cleanup` with `enabled: true` but don't set `skip_cleanup`. Since default is `true`, existing tests may fail because threads would be skipped. Add `skip_cleanup: false` to all existing test `IdleCleanupConfig` instances to maintain current test behavior.
**Why:** Existing tests assume threads are cleaned when idle. With `skip_cleanup` defaulting to `true`, they would break unless explicitly set to `false`.
**Verify:** `cargo test` — all existing idle cleanup tests pass.

### Step 5: Update `config.example.toml` documentation
**What:** Update the commented `idle_cleanup` line in `config.example.toml` (line 300) to include the `skip_cleanup` field with a brief comment explaining the default.
**Why:** Users need to know about this new option.
**Verify:** `cargo check` passes; the example config is valid TOML.

## Design Decisions
- `skip_cleanup` defaults to `true` (safe-by-default: new threads are protected from cleanup unless explicitly opted in)
- The flag file `.jyc/idle-cleanup-skip.flag` follows the existing convention of `.jyc/question-sent.flag` and `.jyc/idle-cleaned.flag`
- Agent can dynamically remove the skip flag to make a thread eligible for cleanup (e.g., after PR merge)
- No new CLI command needed in this PR — agent can use file operations via its existing tools