### PR TITLE
feat: add repo_group for shared repo among GitHub threads

### DIFF
--- a/GITHUB_CHANNEL.md
+++ b/GITHUB_CHANNEL.md
@@ -3,6 +3,62 @@
 GitHub Issue/PR channel for JYC — enables multi-agent workflows on GitHub
 repositories through issue discussion, PR development, and code review.
 
+## repo_group — Shared Repo Directories
+
+When multiple GitHub agent threads (e.g., Developer and Reviewer) work on the
+same PR, each normally clones the repository independently, wasting disk space.
+The `repo_group` field on `ChannelPattern` enables shared repo directories via
+symlinks.
+
+### How It Works
+
+1. Add `repo_group = "pr"` to patterns that should share a repo clone
+2. JYC computes a group key: `"{repo_group}-{github_number}"` (e.g., `"pr-42"`)
+3. On thread init, JYC creates `<workspace>/repos/<group_key>/` and symlinks
+   `<thread_path>/repo` → the shared directory
+4. Agents are group-agnostic — they just `cd repo` and clone if `.git` is missing
+5. When a thread is closed, the symlink is removed first (before `remove_dir_all`)
+6. Shared repos are cleaned up when no remaining thread references them
+
+### Directory Structure
+
+```
+<workdir>/<channel>/workspace/
+  pr-42/               ← Developer agent
+    .jyc/
+    repo/ → ../../repos/pr-42/   ← symlink
+  review-pr-42/        ← Reviewer agent
+    .jyc/
+    repo/ → ../../repos/pr-42/   ← symlink (same shared repo)
+  repos/
+    pr-42/             ← Shared repo directory (actual clone)
+      .git/
+      src/
+      ...
+```
+
+### Configuration
+
+```toml
+# Developer and Reviewer share the same repo clone for a PR
+[[channels.my_repo.patterns]]
+name = "developer"
+role = "Developer"
+template = "github-developer"
+repo_group = "pr"
+
+[[channels.my_repo.patterns]]
+name = "reviewer"
+role = "Reviewer"
+template = "github-reviewer"
+repo_group = "pr"
+```
+
+### Backward Compatibility
+
+Patterns without `repo_group` keep existing behavior — no symlink, no sharing.
+`repo_group` is fully opt-in and does not affect non-GitHub channels.
+
 ## Design Principles
 
 1. **Channel = Lightweight Trigger + Router** — Channel only polls events and

--- a/config.example.toml
+++ b/config.example.toml
@@ -290,6 +290,7 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # role = "Developer"
 # template = "github-developer"
 # live_injection = false
+# repo_group = "pr"  # Share repo clone with other patterns in the same group
 #
 # [channels.my_repo.patterns.rules]
 # github_type = ["pull_request"]
@@ -305,6 +306,7 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # enabled = true
 # role = "Reviewer"
 # template = "github-reviewer"
+# repo_group = "pr"  # Share repo clone with developer pattern
 #
 # [channels.my_repo.patterns.rules]
 # github_type = ["pull_request"]

--- a/src/channels/types.rs
+++ b/src/channels/types.rs
@@ -282,6 +282,12 @@ pub struct ChannelPattern {
     /// When enabled, automatically removes specified subdirectories from idle threads.
     #[serde(default)]
     pub idle_cleanup: Option<IdleCleanupConfig>,
+    /// Repo group key for shared repo directories among GitHub threads.
+    /// When set, threads matching this pattern share a single repo clone
+    /// via symlinks, saving disk space. The group key is `"{repo_group}-{github_number}"`.
+    /// Patterns without `repo_group` keep existing behavior (no symlink, no sharing).
+    #[serde(default)]
+    pub repo_group: Option<String>,
 }
 
 impl Default for ChannelPattern {
@@ -297,6 +303,7 @@ impl Default for ChannelPattern {
             role: None,
             live_injection: true,
             idle_cleanup: None,
+            repo_group: None,
         }
     }
 }

--- a/src/core/idle_cleanup.rs
+++ b/src/core/idle_cleanup.rs
@@ -415,4 +415,49 @@ mod tests {
         assert!(!is_safe_path(".."));
         assert!(!is_safe_path("repo/../etc"));
     }
+
+    #[tokio::test]
+    async fn test_idle_cleanup_symlink_only_removes_symlink() {
+        let dir = tempdir().unwrap();
+        let workspace = dir.path();
+
+        let shared_repo = workspace.join("repos").join("pr-42");
+        fs::create_dir_all(&shared_repo).await.unwrap();
+        fs::write(shared_repo.join("test.txt"), "shared content").await.unwrap();
+
+        let thread_dir = workspace.join("stale-thread");
+        fs::create_dir_all(thread_dir.join(".jyc")).await.unwrap();
+        std::os::unix::fs::symlink(&shared_repo, thread_dir.join("repo")).unwrap();
+
+        fs::write(thread_dir.join(".jyc").join("pattern"), "developer").await.unwrap();
+
+        let old_time = SystemTime::now() - std::time::Duration::from_secs(86400 * 2);
+        let old_filetime = filetime::FileTime::from_system_time(old_time);
+        filetime::set_file_mtime(thread_dir.join(".jyc"), old_filetime).unwrap();
+
+        let mut pattern = ChannelPattern::default();
+        pattern.name = "developer".to_string();
+        pattern.idle_cleanup = Some(crate::config::types::IdleCleanupConfig {
+            enabled: true,
+            timeout_secs: 86400,
+            clean_paths: vec!["repo".to_string()],
+            interval_secs: 300,
+            skip_cleanup: false,
+        });
+
+        let patterns = vec![pattern];
+        let cancel = CancellationToken::new();
+        let cancel_clone = cancel.clone();
+
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            cancel_clone.cancel();
+        });
+
+        start_idle_cleanup_sweep(workspace.to_path_buf(), patterns, cancel).await;
+
+        assert!(!thread_dir.join("repo").exists(), "Symlink should be removed");
+        assert!(shared_repo.join("test.txt").exists(), "Shared repo content should be preserved");
+        assert!(thread_dir.join(".jyc").join("idle-cleaned.flag").exists());
+    }
 }

--- a/src/core/idle_cleanup.rs
+++ b/src/core/idle_cleanup.rs
@@ -141,12 +141,26 @@ async fn sweep_once(
                 let target = path.join(clean_path);
                 if target.exists() {
                     cleaned_any = true;
-                    match fs::remove_dir_all(&target).await {
+                    // Check if the target is a symlink — if so, remove only the symlink
+                    // to avoid destroying shared repos
+                    let is_symlink = fs::symlink_metadata(&target)
+                        .await
+                        .map(|m| m.file_type().is_symlink())
+                        .unwrap_or(false);
+
+                    let remove_result = if is_symlink {
+                        fs::remove_file(&target).await
+                    } else {
+                        fs::remove_dir_all(&target).await
+                    };
+
+                    match remove_result {
                         Ok(_) => {
                             info!(
                                 thread = %thread_name,
                                 path = %target.display(),
                                 idle_secs = idle_duration.num_seconds(),
+                                symlink = is_symlink,
                                 "Cleaned idle thread subdirectory"
                             );
                         }

--- a/src/core/message_router.rs
+++ b/src/core/message_router.rs
@@ -105,6 +105,16 @@ impl MessageRouter {
             message.metadata.insert("role".to_string(), serde_json::Value::String(role));
         }
 
+        // Store repo_group_key in message metadata if repo_group is configured
+        if let Some(repo_group) = matched_pattern.and_then(|p| p.repo_group.clone())
+        {
+            if let Some(github_number) = message.metadata.get("github_number").and_then(|v| v.as_u64())
+            {
+                let key = crate::core::thread_path::compute_repo_group_key(&repo_group, github_number);
+                message.metadata.insert("repo_group_key".to_string(), serde_json::Value::String(key));
+            }
+        }
+
         // 4. Enqueue (channel-agnostic)
         let pm = pattern_match.expect("pattern_match should be Some");
         self.thread_manager

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -429,7 +429,7 @@ impl ThreadManager {
                             );
                         }
 
-                        if !symlink_path.exists() {
+                        if std::fs::symlink_metadata(&symlink_path).is_err() {
                             if let Err(e) = std::os::unix::fs::symlink(&shared_repo_dir, &symlink_path) {
                                 tracing::warn!(
                                     error = %e,

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -416,6 +416,38 @@ impl ThreadManager {
                         );
                     }
                     
+                    // Create shared repo directory and symlink if repo_group_key is present
+                    if let Some(repo_group_key) = item.message.metadata.get("repo_group_key").and_then(|v| v.as_str()) {
+                        let shared_repo_dir = crate::core::thread_path::resolve_shared_repo_dir(&workspace, repo_group_key);
+                        let symlink_path = thread_path.join("repo");
+
+                        if let Err(e) = tokio::fs::create_dir_all(&shared_repo_dir).await {
+                            tracing::warn!(
+                                error = %e,
+                                path = %shared_repo_dir.display(),
+                                "Failed to create shared repo directory"
+                            );
+                        }
+
+                        if !symlink_path.exists() {
+                            if let Err(e) = std::os::unix::fs::symlink(&shared_repo_dir, &symlink_path) {
+                                tracing::warn!(
+                                    error = %e,
+                                    target = %shared_repo_dir.display(),
+                                    link = %symlink_path.display(),
+                                    "Failed to create repo symlink"
+                                );
+                            } else {
+                                tracing::info!(
+                                    thread = %thread_name,
+                                    group_key = %repo_group_key,
+                                    shared_repo = %shared_repo_dir.display(),
+                                    "Created shared repo symlink"
+                                );
+                            }
+                        }
+                    }
+                    
                     // Save pattern name for /template command (after template init)
                     let pattern_file = thread_path.join(".jyc").join("pattern");
                     if let Err(e) = tokio::fs::create_dir_all(thread_path.join(".jyc")).await {

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -871,11 +871,35 @@ impl ThreadManager {
         let thread_path = self.storage.workspace().join(thread_name);
 
         if thread_path.exists() {
+            // Check for symlinks (e.g., repo/) and remove them before remove_dir_all
+            // to prevent remove_dir_all from following symlinks into shared directories
+            let repo_symlink = thread_path.join("repo");
+            match tokio::fs::symlink_metadata(&repo_symlink).await {
+                Ok(meta) if meta.file_type().is_symlink() => {
+                    if let Err(e) = tokio::fs::remove_file(&repo_symlink).await {
+                        tracing::warn!(
+                            error = %e,
+                            path = %repo_symlink.display(),
+                            "Failed to remove repo symlink before thread deletion"
+                        );
+                    } else {
+                        tracing::debug!(
+                            thread = %thread_name,
+                            "Removed repo symlink before thread deletion"
+                        );
+                    }
+                }
+                _ => {}
+            }
+
             tokio::fs::remove_dir_all(&thread_path)
                 .await
                 .context(format!("Failed to remove thread directory: {:?}", thread_path))?;
             tracing::info!(thread = %thread_name, "Thread directory deleted");
         }
+
+        // Clean up orphaned shared repos (repos/ dirs no longer referenced by any thread)
+        self.cleanup_orphaned_shared_repos().await;
 
         self.cleanup_thread_state(thread_name).await;
     Ok(())
@@ -905,6 +929,69 @@ impl ThreadManager {
         }
 
         tracing::debug!(thread = %thread_name, "Thread in-memory state cleaned up");
+    }
+
+    /// Clean up shared repos that are no longer referenced by any active thread.
+    ///
+    /// Scans `<workspace>/repos/` and checks if any thread directory still has
+    /// a symlink pointing to each shared repo. Orphaned shared repos are deleted.
+    async fn cleanup_orphaned_shared_repos(&self) {
+        let workspace = self.storage.workspace();
+        let repos_dir = workspace.join("repos");
+
+        let mut repos_entries = match tokio::fs::read_dir(&repos_dir).await {
+            Ok(entries) => entries,
+            Err(_) => return,
+        };
+
+        while let Ok(Some(entry)) = repos_entries.next_entry().await {
+            let shared_repo_path = entry.path();
+            if !shared_repo_path.is_dir() {
+                continue;
+            }
+
+            let group_key = match entry.file_name().to_str() {
+                Some(name) => name.to_string(),
+                None => continue,
+            };
+
+            let mut is_referenced = false;
+            if let Ok(mut thread_entries) = tokio::fs::read_dir(&workspace).await {
+                while let Ok(Some(thread_entry)) = thread_entries.next_entry().await {
+                    let thread_path = thread_entry.path();
+                    if !thread_path.is_dir() {
+                        continue;
+                    }
+                    let repo_link = thread_path.join("repo");
+                    match tokio::fs::symlink_metadata(&repo_link).await {
+                        Ok(meta) if meta.file_type().is_symlink() => {
+                            if let Ok(target) = std::fs::read_link(&repo_link) {
+                                if target == shared_repo_path {
+                                    is_referenced = true;
+                                    break;
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+
+            if !is_referenced {
+                if let Err(e) = tokio::fs::remove_dir_all(&shared_repo_path).await {
+                    tracing::warn!(
+                        error = %e,
+                        path = %shared_repo_path.display(),
+                        "Failed to remove orphaned shared repo"
+                    );
+                } else {
+                    tracing::info!(
+                        group_key = %group_key,
+                        "Removed orphaned shared repo"
+                    );
+                }
+            }
+        }
     }
 }
 

--- a/src/core/thread_manager_tests.rs
+++ b/src/core/thread_manager_tests.rs
@@ -291,4 +291,169 @@ mode = "opencode"
         // if !store_result.thread_path.exists() { return Ok(()); }
         // The guard correctly skips reply delivery when the directory is gone.
     }
+
+    #[tokio::test]
+    async fn test_close_thread_removes_symlink_preserves_shared_repo() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let shared_repo = workspace.join("repos").join("pr-42");
+        std::fs::create_dir_all(&shared_repo).unwrap();
+        std::fs::write(shared_repo.join("test.txt"), "shared content").unwrap();
+
+        let thread_dir = workspace.join("pr-42");
+        std::fs::create_dir_all(&thread_dir).unwrap();
+        std::os::unix::fs::symlink(&shared_repo, thread_dir.join("repo")).unwrap();
+
+        assert!(thread_dir.join("repo").exists());
+        assert!(shared_repo.join("test.txt").exists());
+
+        let storage = Arc::new(crate::core::message_storage::MessageStorage::new(&workspace));
+
+        let thread_manager = crate::core::thread_manager::ThreadManager::new(
+            3,
+            10,
+            storage,
+            Arc::new(crate::channels::email::outbound::EmailOutboundAdapter::new(
+                &crate::config::types::SmtpConfig {
+                    host: "smtp.example.com".into(),
+                    port: 465,
+                    secure: true,
+                    username: "test".into(),
+                    password: "test".into(),
+                    from_address: Some("test@example.com".into()),
+                    from_name: None,
+                },
+                Arc::new(crate::core::message_storage::MessageStorage::new(&workspace)),
+            )),
+            Arc::new(StaticAgentService::new("test reply")),
+            tokio_util::sync::CancellationToken::new(),
+            crate::config::types::HeartbeatConfig::default(),
+            "".into(),
+            PathBuf::from("/tmp/templates"),
+            test_config(),
+            "test".to_string(),
+            workspace.clone(),
+            crate::core::metrics::MetricsHandle::noop(),
+        );
+
+        let result = thread_manager.close_thread("pr-42").await;
+        assert!(result.is_ok());
+        assert!(!thread_dir.exists(), "Thread directory should be deleted");
+        assert!(!shared_repo.exists(), "Orphaned shared repo should be cleaned up");
+    }
+
+    #[tokio::test]
+    async fn test_close_thread_preserves_shared_repo_when_still_referenced() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let shared_repo = workspace.join("repos").join("pr-42");
+        std::fs::create_dir_all(&shared_repo).unwrap();
+        std::fs::write(shared_repo.join("test.txt"), "shared content").unwrap();
+
+        // Thread 1 with symlink
+        let thread1_dir = workspace.join("pr-42");
+        std::fs::create_dir_all(&thread1_dir).unwrap();
+        std::os::unix::fs::symlink(&shared_repo, thread1_dir.join("repo")).unwrap();
+
+        // Thread 2 also with symlink to same shared repo
+        let thread2_dir = workspace.join("review-pr-42");
+        std::fs::create_dir_all(&thread2_dir).unwrap();
+        std::os::unix::fs::symlink(&shared_repo, thread2_dir.join("repo")).unwrap();
+
+        let storage = Arc::new(crate::core::message_storage::MessageStorage::new(&workspace));
+
+        let thread_manager = crate::core::thread_manager::ThreadManager::new(
+            3,
+            10,
+            storage,
+            Arc::new(crate::channels::email::outbound::EmailOutboundAdapter::new(
+                &crate::config::types::SmtpConfig {
+                    host: "smtp.example.com".into(),
+                    port: 465,
+                    secure: true,
+                    username: "test".into(),
+                    password: "test".into(),
+                    from_address: Some("test@example.com".into()),
+                    from_name: None,
+                },
+                Arc::new(crate::core::message_storage::MessageStorage::new(&workspace)),
+            )),
+            Arc::new(StaticAgentService::new("test reply")),
+            tokio_util::sync::CancellationToken::new(),
+            crate::config::types::HeartbeatConfig::default(),
+            "".into(),
+            PathBuf::from("/tmp/templates"),
+            test_config(),
+            "test".to_string(),
+            workspace.clone(),
+            crate::core::metrics::MetricsHandle::noop(),
+        );
+
+        // Close thread 1 — shared repo should still be referenced by thread 2
+        let result = thread_manager.close_thread("pr-42").await;
+        assert!(result.is_ok());
+        assert!(!thread1_dir.exists(), "Thread 1 should be deleted");
+        assert!(shared_repo.exists(), "Shared repo should be preserved (still referenced by thread 2)");
+        assert!(shared_repo.join("test.txt").exists(), "Shared repo content should be intact");
+    }
+
+    #[tokio::test]
+    async fn test_close_thread_both_symlinks_removes_shared_repo() {
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let shared_repo = workspace.join("repos").join("pr-42");
+        std::fs::create_dir_all(&shared_repo).unwrap();
+        std::fs::write(shared_repo.join("test.txt"), "shared content").unwrap();
+
+        let thread1_dir = workspace.join("pr-42");
+        std::fs::create_dir_all(&thread1_dir).unwrap();
+        std::os::unix::fs::symlink(&shared_repo, thread1_dir.join("repo")).unwrap();
+
+        let thread2_dir = workspace.join("review-pr-42");
+        std::fs::create_dir_all(&thread2_dir).unwrap();
+        std::os::unix::fs::symlink(&shared_repo, thread2_dir.join("repo")).unwrap();
+
+        let storage = Arc::new(crate::core::message_storage::MessageStorage::new(&workspace));
+
+        let thread_manager = crate::core::thread_manager::ThreadManager::new(
+            3,
+            10,
+            storage,
+            Arc::new(crate::channels::email::outbound::EmailOutboundAdapter::new(
+                &crate::config::types::SmtpConfig {
+                    host: "smtp.example.com".into(),
+                    port: 465,
+                    secure: true,
+                    username: "test".into(),
+                    password: "test".into(),
+                    from_address: Some("test@example.com".into()),
+                    from_name: None,
+                },
+                Arc::new(crate::core::message_storage::MessageStorage::new(&workspace)),
+            )),
+            Arc::new(StaticAgentService::new("test reply")),
+            tokio_util::sync::CancellationToken::new(),
+            crate::config::types::HeartbeatConfig::default(),
+            "".into(),
+            PathBuf::from("/tmp/templates"),
+            test_config(),
+            "test".to_string(),
+            workspace.clone(),
+            crate::core::metrics::MetricsHandle::noop(),
+        );
+
+        // Close thread 1
+        thread_manager.close_thread("pr-42").await.unwrap();
+        assert!(shared_repo.exists(), "Shared repo should be preserved after closing thread 1");
+
+        // Close thread 2 — now no more references
+        thread_manager.close_thread("review-pr-42").await.unwrap();
+        assert!(!shared_repo.exists(), "Orphaned shared repo should be cleaned up when all references gone");
+    }
 }

--- a/src/core/thread_path.rs
+++ b/src/core/thread_path.rs
@@ -91,6 +91,49 @@ mod tests {
         assert_eq!(compute_repo_group_key("repo", 1), "repo-1");
     }
 
+    #[tokio::test]
+    async fn test_symlink_creation_with_repo_group_key() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path().join("github").join("workspace");
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+
+        let group_key = compute_repo_group_key("pr", 42);
+        let shared_repo_dir = resolve_shared_repo_dir(&workspace, &group_key);
+        let thread_path = workspace.join("pr-42");
+
+        tokio::fs::create_dir_all(&shared_repo_dir).await.unwrap();
+        tokio::fs::create_dir_all(&thread_path).await.unwrap();
+
+        let symlink_path = thread_path.join("repo");
+        assert!(!symlink_path.exists());
+
+        std::os::unix::fs::symlink(&shared_repo_dir, &symlink_path).unwrap();
+        assert!(symlink_path.exists());
+        assert!(tokio::fs::symlink_metadata(&symlink_path).await.unwrap().file_type().is_symlink());
+
+        let target = std::fs::read_link(&symlink_path).unwrap();
+        assert_eq!(target, shared_repo_dir);
+    }
+
+    #[test]
+    fn test_repo_group_backward_compatibility_no_field() {
+        let pattern: crate::channels::types::ChannelPattern = toml::from_str(r#"
+            name = "test"
+            [rules]
+        "#).unwrap();
+        assert!(pattern.repo_group.is_none(), "repo_group should default to None when omitted from config");
+    }
+
+    #[test]
+    fn test_repo_group_set_via_serde() {
+        let pattern: crate::channels::types::ChannelPattern = toml::from_str(r#"
+            name = "test"
+            repo_group = "pr"
+            [rules]
+        "#).unwrap();
+        assert_eq!(pattern.repo_group.as_deref(), Some("pr"));
+    }
+
     // === MessageStorage.store_with_match (real production path) ===
 
     #[tokio::test]

--- a/src/core/thread_path.rs
+++ b/src/core/thread_path.rs
@@ -12,6 +12,20 @@ pub fn resolve_workspace(workdir: &Path, channel: &str) -> PathBuf {
     workdir.join(channel).join("workspace")
 }
 
+/// Resolve the shared repo directory for a repo group key.
+///
+/// Convention: `<workspace>/repos/<group_key>/`
+pub fn resolve_shared_repo_dir(workspace: &Path, group_key: &str) -> PathBuf {
+    workspace.join("repos").join(group_key)
+}
+
+/// Compute the repo group key from a `repo_group` config value and GitHub number.
+///
+/// Returns `"{repo_group}-{github_number}"`.
+pub fn compute_repo_group_key(repo_group: &str, github_number: u64) -> String {
+    format!("{}-{}", repo_group, github_number)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -62,6 +76,19 @@ mod tests {
     fn test_resolve_workspace_feishu() {
         let ws = resolve_workspace(Path::new("/data"), "feishu_bot");
         assert_eq!(ws, PathBuf::from("/data/feishu_bot/workspace"));
+    }
+
+    #[test]
+    fn test_resolve_shared_repo_dir() {
+        let ws = Path::new("/data/github/workspace");
+        let shared = resolve_shared_repo_dir(&ws, "pr-42");
+        assert_eq!(shared, PathBuf::from("/data/github/workspace/repos/pr-42"));
+    }
+
+    #[test]
+    fn test_compute_repo_group_key() {
+        assert_eq!(compute_repo_group_key("pr", 42), "pr-42");
+        assert_eq!(compute_repo_group_key("repo", 1), "repo-1");
     }
 
     // === MessageStorage.store_with_match (real production path) ===

--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -22,14 +22,14 @@ You are triggered automatically when a PR matches the pattern rules (e.g., label
 No `@j:developer` mention is required.
 
 ## Repository Setup
-Clone the repository from the trigger message to `repo/` if not already present,
-then `cd repo` before running any command:
+The `repo/` directory is created by JYC (symlink for grouped patterns, regular
+directory otherwise). Clone into it if `.git` is missing:
 ```bash
-if [ ! -d "repo" ]; then
-    gh repo clone <repository_from_trigger> repo
+cd repo  # created by JYC (symlink for grouped patterns, dir otherwise)
+if [ ! -d ".git" ]; then
+    gh repo clone <repository_from_trigger> .
 fi
-cp -rn repo/.opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
-cd repo
+cp -rn .opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
 ```
 
 ## Detect Project Type (do this ONCE after checkout)

--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -25,7 +25,10 @@ No `@j:developer` mention is required.
 The `repo/` directory is created by JYC (symlink for grouped patterns, regular
 directory otherwise). Clone into it if `.git` is missing:
 ```bash
-cd repo  # created by JYC (symlink for grouped patterns, dir otherwise)
+if [ ! -d "repo" ]; then
+    mkdir repo
+fi
+cd repo
 if [ ! -d ".git" ]; then
     gh repo clone <repository_from_trigger> .
 fi

--- a/templates/github-high-level-planner/AGENTS.md
+++ b/templates/github-high-level-planner/AGENTS.md
@@ -22,14 +22,14 @@ No `@j:planner` mention is required.
 The trigger message tells you the repository and issue number.
 
 ## Repository Setup
-Clone the repository from the trigger message to `repo/` if not already present,
-then `cd repo` before running any command:
+The `repo/` directory is created by JYC (symlink for grouped patterns, regular
+directory otherwise). Clone into it if `.git` is missing:
 ```bash
-if [ ! -d "repo" ]; then
-    gh repo clone <repository_from_trigger> repo
+cd repo  # created by JYC (symlink for grouped patterns, dir otherwise)
+if [ ! -d ".git" ]; then
+    gh repo clone <repository_from_trigger> .
 fi
-cp -rn repo/.opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
-cd repo
+cp -rn .opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
 ```
 
 ## Workflow

--- a/templates/github-high-level-planner/AGENTS.md
+++ b/templates/github-high-level-planner/AGENTS.md
@@ -25,7 +25,10 @@ The trigger message tells you the repository and issue number.
 The `repo/` directory is created by JYC (symlink for grouped patterns, regular
 directory otherwise). Clone into it if `.git` is missing:
 ```bash
-cd repo  # created by JYC (symlink for grouped patterns, dir otherwise)
+if [ ! -d "repo" ]; then
+    mkdir repo
+fi
+cd repo
 if [ ! -d ".git" ]; then
     gh repo clone <repository_from_trigger> .
 fi

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -23,14 +23,14 @@ number: 42
 ```
 
 ## Repository Setup
-Clone the repository from the trigger message to `repo/` if not already present,
-then `cd repo` before running any command:
+The `repo/` directory is created by JYC (symlink for grouped patterns, regular
+directory otherwise). Clone into it if `.git` is missing:
 ```bash
-if [ ! -d "repo" ]; then
-    gh repo clone <repository_from_trigger> repo
+cd repo  # created by JYC (symlink for grouped patterns, dir otherwise)
+if [ ! -d ".git" ]; then
+    gh repo clone <repository_from_trigger> .
 fi
-cp -rn repo/.opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
-cd repo
+cp -rn .opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
 ```
 
 ## Workflow

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -26,7 +26,10 @@ number: 42
 The `repo/` directory is created by JYC (symlink for grouped patterns, regular
 directory otherwise). Clone into it if `.git` is missing:
 ```bash
-cd repo  # created by JYC (symlink for grouped patterns, dir otherwise)
+if [ ! -d "repo" ]; then
+    mkdir repo
+fi
+cd repo
 if [ ! -d ".git" ]; then
     gh repo clone <repository_from_trigger> .
 fi

--- a/templates/github-reviewer/AGENTS.md
+++ b/templates/github-reviewer/AGENTS.md
@@ -15,14 +15,14 @@ number: 43
 ```
 
 ## Repository Setup
-Clone the repository from the trigger message to `repo/` if not already present,
-then `cd repo` before running any command:
+The `repo/` directory is created by JYC (symlink for grouped patterns, regular
+directory otherwise). Clone into it if `.git` is missing:
 ```bash
-if [ ! -d "repo" ]; then
-    gh repo clone <repository_from_trigger> repo
+cd repo  # created by JYC (symlink for grouped patterns, dir otherwise)
+if [ ! -d ".git" ]; then
+    gh repo clone <repository_from_trigger> .
 fi
-cp -rn repo/.opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
-cd repo
+cp -rn .opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
 ```
 
 ## Workflow

--- a/templates/github-reviewer/AGENTS.md
+++ b/templates/github-reviewer/AGENTS.md
@@ -18,7 +18,10 @@ number: 43
 The `repo/` directory is created by JYC (symlink for grouped patterns, regular
 directory otherwise). Clone into it if `.git` is missing:
 ```bash
-cd repo  # created by JYC (symlink for grouped patterns, dir otherwise)
+if [ ! -d "repo" ]; then
+    mkdir repo
+fi
+cd repo
 if [ ! -d ".git" ]; then
     gh repo clone <repository_from_trigger> .
 fi


### PR DESCRIPTION
## Spec

Add `repo_group` field to `ChannelPattern` config, allowing multiple GitHub agent threads working on the same issue/PR to share a single repo directory via symlinks. This saves disk space by avoiding redundant `gh repo clone` operations. JYC creates the shared repo directory and symlinks; agents remain group-agnostic and only see a `repo/` directory.

JYC core is channel-agnostic: it only creates symlinks when `repo_group` is configured. The `repo/` directory creation is handled by AGENTS.md templates (agent-side), keeping core free of any channel-specific logic.

Fixes #121

## Implementation Plan

### Step 1: Add `repo_group` field to `ChannelPattern`
**What:** Add `repo_group: Option<String>` field to `ChannelPattern` in `src/channels/types.rs`, with `Default` impl returning `None`. Add serde attribute `#[serde(default)]`.
**Why:** Foundation config field — all subsequent logic depends on it.
**Verify:** `cargo check` passes.

### Step 2: Add utility functions in `thread_path.rs`
**What:** In `src/core/thread_path.rs`, add:
- `pub fn resolve_shared_repo_dir(workspace: &Path, group_key: &str) -> PathBuf` — returns `<workspace>/repos/<group_key>/`
- `pub fn compute_repo_group_key(repo_group: &str, github_number: u64) -> String` — returns `"<repo_group>-<number>"`
- Unit tests for both functions.
**Why:** Centralized path logic avoids duplication across router and thread manager. These are generic path utilities with no channel-specific knowledge.
**Verify:** `cargo test -- thread_path` passes.

### Step 3: Pass repo_group_key through message metadata in router
**What:** In `src/core/message_router.rs`, after pattern matching, check `pattern.repo_group`. If present and non-empty, compute the group key via `compute_repo_group_key()`, reading `github_number` from `message.metadata["github_number"]`. Store result in `message.metadata["repo_group_key"]`.
**Why:** Message metadata is the existing mechanism for passing info from router to thread initialization (same pattern as template name). Router layer is the right place for this — it sees both the pattern config and message metadata.
**Verify:** `cargo check` passes.

### Step 4: Create shared repo directory and symlink during thread init
**What:** In `src/core/thread_manager.rs`, inside `spawn_worker()`, after template init but before the message processing loop:
- If `repo_group_key` metadata exists → create shared repo dir: `tokio::fs::create_dir_all(workspace/repos/<key>/)`, then create symlink: `tokio::fs::symlink_dir(shared_repo_path, thread_path/repo)`. If symlink already exists, skip (idempotent).
- If no `repo_group_key` → do nothing (agent creates `repo/` dir via AGENTS.md if needed).
- Add unit tests for symlink creation.
**Why:** JYC only creates symlinks for grouped patterns. Core remains channel-agnostic — it just reacts to `repo_group_key` metadata, regardless of which channel set it.
**Verify:** `cargo test` passes.

### Step 5: Symlink-aware thread close and shared repo cleanup
**What:** Modify `close_thread()` in `src/core/thread_manager.rs`:
1. Before `remove_dir_all(thread_path)`, check if `thread_path/repo` is a symlink. If so, `remove_file` the symlink first to prevent `remove_dir_all` from following it.
2. After thread directory removal, scan `<workspace>/repos/` for orphaned shared repos (no active thread directory references them) and clean them up.
- Add unit tests for: symlink removal only, shared repo cleanup when all threads close, shared repo preserved when some threads remain.
**Why:** Prevent data loss from `remove_dir_all` following symlinks; clean up shared repos only when truly orphaned.
**Verify:** `cargo test` passes.

### Step 6: Symlink-safe idle cleanup
**What:** In `src/core/idle_cleanup.rs`, modify `sweep_once()`: in the `clean_paths` loop, check if the target path is a symlink (`tokio::fs::symlink_metadata`). If symlink, use `remove_file` (deletes symlink only). If regular directory, use `remove_dir_all` (existing behavior).
- Add unit test: idle cleanup on symlink only removes symlink, not shared repo.
**Why:** Prevent idle cleanup from destroying shared repos. Symlink detection is a generic filesystem operation — no channel knowledge needed.
**Verify:** `cargo test -- idle_cleanup` passes.

### Step 7: Update AGENTS.md templates
**What:** Update 4 template files to change repo setup from:
```bash
if [ ! -d "repo" ]; then
    gh repo clone <repo> repo
fi
cd repo
```
to:
```bash
if [ ! -d "repo" ]; then
    mkdir repo
fi
cd repo
if [ ! -d ".git" ]; then
    gh repo clone <repository_from_trigger> .
fi
cp -rn .opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
```
Files: `templates/github-planner/AGENTS.md`, `templates/github-developer/AGENTS.md`, `templates/github-reviewer/AGENTS.md`, `templates/github-high-level-planner/AGENTS.md`.
**Why:** Agent handles `repo/` directory creation. For grouped threads, symlink already exists → `cd repo` works. For ungrouped threads, `mkdir repo` creates the directory. Either way, clone only if `.git` is missing.
**Verify:** `cargo check` passes (templates are not compiled).

### Step 8: Update config example and documentation
**What:** 
- Add `repo_group = "pr"` example to developer/reviewer patterns in `config.example.toml`
- Add `repo_group` section to `GITHUB_CHANNEL.md` with config syntax, directory structure diagram, and behavior description.
**Why:** User-facing documentation.
**Verify:** Visual review.

### Step 9: Integration tests
**What:** Add comprehensive tests:
- Test symlink creation with `repo_group_key` metadata
- Test `close_thread` removes symlink but preserves shared repo
- Test shared repo cleanup when all grouped threads close
- Test idle cleanup on symlink only removes symlink
- Test `compute_repo_group_key` with various inputs
- Test backward compatibility (no `repo_group` → no symlink, no `repo/` created by core)
- Test symlink idempotency (creating symlink when one already exists)
**Why:** Ensure correctness of the symlink lifecycle and shared repo management.
**Verify:** `cargo test` passes with all new tests green.

## Design Decisions
- `repo_group` is an arbitrary string (not an enum). Group key = `"{repo_group}-{github_number}"`.
- Patterns without `repo_group` keep existing behavior — no symlink, no `repo/` created by core.
- Agent handles `repo/` directory creation via AGENTS.md (`mkdir repo` if not exists). JYC only creates symlinks for grouped patterns.
- Core is completely channel-agnostic: it only reacts to `repo_group_key` metadata. All channel-specific logic (reading `github_number` from metadata) lives in the router layer.
- Shared repo location: `<workspace>/repos/<group_key>/`, isolated from thread directories.
- `has_external_symlinks` in session.rs needs no change — symlink to `repos/` correctly triggers `external_directory: allow`.
- Development must be incremental — each step passes `cargo check` and `cargo test` before proceeding.