### PR TITLE
docs: update DESIGN.md and README.md to reflect current implementation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -240,7 +240,7 @@ Each component has a single, clear responsibility. Data flows through the system
 - Adds `Re:` to subject, sets `In-Reply-To` and `References` headers for threading
 - Does NOT build quoted history, does NOT clean or transform content
 - **Structured error handling**: Uses lettre's structured SmtpError API for error classification: permanent errors (5xx) fail immediately, transient errors (4xx) retry with exponential backoff (3 attempts, 5-60s), connection/timeout errors reconnect with backoff (2 attempts).
- - **Shared instance**: A single `SmtpClient` (via `EmailOutboundAdapter`) is created at monitor startup and shared across ThreadManager fallback, monitor reply send path (when MCP tool appends to chat log), and AlertService
+ - **Shared instance**: A single `SmtpClient` (via `EmailOutboundAdapter`) is created at monitor startup and shared across ThreadManager fallback and monitor reply send path (when MCP tool appends to chat log)
 
 **Thread Event System**
 - **Thread Event Bus** - Thread-isolated event bus for SSE → ThreadEvent conversion
@@ -428,8 +428,7 @@ The Feishu (飞书) channel implementation provides real-time messaging capabili
 │  │             FeishuOutboundAdapter                   │  │
 │  │  • Feishu API client for message sending            │  │
 │  │  • Message formatting (markdown, text)              │  │
-│  │  • Heartbeat/progress updates                       │  │
-│  │  • Alert notifications                              │  │
+  │  │  • Heartbeat/progress updates                       │  │
 │  └─────────────────────────────────────────────────────┘  │
 │                                                             │
 │  ┌─────────────────────────────────────────────────────┐  │
@@ -550,7 +549,7 @@ The Feishu channel integrates seamlessly with the core JYC architecture:
 - Follows the same pattern matching system
 - Integrates with the thread manager and queue system
 - Supports all existing AI features and command system
-- Compatible with MCP reply tool and alert service
+- Compatible with MCP reply tool
 
 ### Testing
 
@@ -970,11 +969,11 @@ JYC uses **Tokio** as its async runtime. The message processing pipeline is buil
                               │
               ┌───────────────┼───────────────┐
               ▼               ▼               ▼
-     ┌────────────────┐ ┌────────────────┐ ┌────────────────┐
-     │ tokio::spawn   │ │ tokio::spawn   │ │ tokio::spawn   │
-     │ IMAP Monitor   │ │ FeiShu Monitor │ │ Alert Service  │
-     │ (channel: work)│ │ (WebSocket)    │ │ (flush timer)  │
-     └───────┬────────┘ └───────┬────────┘ └────────────────┘
+     ┌────────────────┐ ┌────────────────┐
+      │ tokio::spawn   │ │ tokio::spawn   │
+      │ IMAP Monitor   │ │ FeiShu Monitor │
+      │ (channel: work)│ │ (WebSocket)    │
+      └───────┬────────┘ └───────┬────────┘
              │                  │
              ▼                  ▼
       mpsc::Sender ─────> mpsc::Receiver
@@ -1349,53 +1348,7 @@ impl ThreadManager {
 - **Event Publishing**: Events are published to thread-isolated event bus
 - **Thread Manager Monitoring**: Listens for events and controls heartbeat rhythm
 
-### Alert Service: Event-Driven Architecture
 
-```
-┌──────────────────────────────────────────────────────────────────┐
-│                      Alert Service                                │
-│                                                                   │
-│  ┌───────────────┐                                               │
-│  │  AppLogger    │  (unified logging + alerting handle)           │
-│  │               │                                               │
-│  │ .error() ─────┼──> tracing::error!() + mpsc::Sender<Event>   │
-│  │ .info()  ─────┼──> tracing::info!()                           │
-│  │ .reply_by_tool()──> tracing + mpsc (health stats)             │
-│  └───────────────┘         │                                     │
-│                            ▼                                     │
-│              ┌─────────────────────────┐                         │
-│              │  Alert Service Task     │                         │
-│              │  (tokio::spawn)         │                         │
-│              │  span: alert            │                         │
-│              │                         │                         │
-│              │  tokio::select! {       │                         │
-│              │    event = rx.recv() => │                         │
-│              │      match event:       │                         │
-│              │        Error →          │                         │
-│              │          buffer_error() │                         │
-│              │        MessageReceived →│                         │
-│              │          track_stats()  │                         │
-│              │        ReplyByTool →    │                         │
-│              │          track_stats()  │                         │
-│              │                         │                         │
-│              │    _ = flush_tick =>    │                         │
-│              │      flush_errors()    │                         │
-│              │      → send digest     │                         │
-│              │                         │                         │
-│              │    _ = health_tick =>   │                         │
-│              │      send_health()     │                         │
-│              │      → send report     │                         │
-│              │                         │                         │
-│              │    _ = cancel =>        │                         │
-│              │      final_flush()     │                         │
-│              │      break             │                         │
-│              │  }                      │                         │
-│              └─────────────────────────┘                         │
-│                                                                   │
-│  AppLogger sends structured AlertEvent variants via mpsc.        │
-│  Self-protection: send failures use eprintln (not tracing).       │
-└──────────────────────────────────────────────────────────────────┘
-```
 
 ### Graceful Shutdown Sequence
 
@@ -1413,8 +1366,7 @@ Signal (SIGINT/SIGTERM)
        ├──> ThreadManager workers: finish current message → exit
        │    (in-queue messages are lost — IMAP re-fetch on restart)
        │
-       ├──> Alert Service: final flush → send pending errors → exit
-       │
+        │
        ├──> OpenCode Server: explicitly stopped via server.stop()
        │
        └──> SMTP connections: disconnect
@@ -1441,9 +1393,6 @@ root_cancel (top-level)
     │
     ├── thread_manager_cancel
     │       └── all worker tasks check this
-    │
-    ├── alert_service_cancel
-    │       └── triggers final flush
     │
     └── opencode_service_cancel
             └── aborts SSE streams
@@ -2530,7 +2479,7 @@ Key bindings: `q`/`Esc` quit, `↑`/`↓`/`j`/`k` select thread, `r` force refre
 
 ### MetricsCollector
 
-Replaces the old `AlertService`. Components report events via `MetricsHandle`:
+Replaces the legacy `AlertService`. Components report events via `MetricsHandle`:
 
 - `message_received(thread)`, `message_matched(thread)`
 - `reply_by_tool(thread)`, `reply_by_fallback(thread)`
@@ -2597,7 +2546,7 @@ jyc/
 │   │   ├── chat_log_store.rs           # Chat log storage (daily log files)
 │   │   ├── email_parser.rs             # Stripping, quoting, thread trail
 │   │   ├── state_manager.rs            # UID tracking, state persistence
-│   │   ├── metrics.rs                   # MetricsCollector (replaces AlertService)
+│   │   ├── metrics.rs                   # MetricsCollector (lightweight stats accumulation)
 │   │   ├── attachment_storage.rs       # Channel-agnostic attachment saving
 │   │   ├── template_utils.rs           # Template file copying
 │   │   ├── pending_delivery.rs         # Background reply delivery watcher
@@ -2761,7 +2710,6 @@ INFO worker{channel=jiny283, thread=weather}: Session idle — prompt complete
 INFO worker{channel=jiny283, thread=weather}: Reply sent by MCP tool
 INFO worker{channel=jiny283, thread=weather}: Agent complete reply_sent=true
 INFO worker{channel=jiny283, thread=weather}: Worker finished
-alert: Alert service stopped
 ```
 
 #### Key Rules
@@ -2781,15 +2729,6 @@ alert: Alert service stopped
 | INFO | Lifecycle: message received, matched, processed, reply sent, worker start/stop, step start, tool calls |
 | DEBUG | SSE events, session status changes, step finish with costs, AI response text, config details |
 | TRACE | IMAP polling, mailbox select, skipping heartbeat notifications |
-
-### Alert Service Integration
-
-The `AppLogger` provides a unified logging + alerting interface:
-
-1. **Logging methods** (`info()`, `error()`, etc.) delegate to `tracing` for console output
-2. **Structured event methods** (`message_received()`, `reply_by_tool()`, etc.) additionally send events to the alert service via `mpsc` channel
-3. The alert service buffers errors and periodically flushes them as digest emails
-4. Self-protection: alert send failures use `eprintln` (not tracing) to avoid feedback loops
 
 ## Command System
 


### PR DESCRIPTION
## Spec

更新 DESIGN.md 和 README.md 以反映当前实现状态。主要移除已废弃的 AlertService 章节，更新 GitHub 路由为 label-based，补充 LabelRule，清理过时配置，修正 README 中的文件名引用和缺失命令。

Fixes #126

## Implementation Plan

### Step 1: DESIGN.md — 移除 AlertService 相关章节
**What:** 删除 "Alert Service: Event-Driven Architecture" 章节及相关的 `AppLogger` 描述。这些在 v0.1.11 已被 MetricsCollector 替代。
**Why:** AlertService 已移除，文档仍大篇幅描述已不存在的架构。
**Verify:** 搜索 DESIGN.md 中不再包含 `AlertService`、`AppLogger`、`AlertEvent`、`alert_service` 关键词。

### Step 2: DESIGN.md — 更新 GitHub Channel 路由描述
**What:** 将 GitHub Channel 章节中的 "Mention-Driven Routing" (`@j:<role>`) 替换为 label-based routing 描述。更新 "Multi-Agent Workflow" 流程图，反映 label-based handoff（`jyc:develop`、`jyc:review`、`jyc:plan` 等）。移除 `extract_mention_role()` 相关描述，更新为 label change detection 机制。更新 "Pattern Rule Filtering" 章节，反映 role 字段隐式映射到 routing label 的逻辑。
**Why:** v0.2.0 (#76) 移除了 `@j:<role>` 提及路由，改为 label-based handover。
**Verify:** 搜索 DESIGN.md 不再包含 `@j:role`、`extract_mention_role`、`mention-driven`；确认包含 `label-based`、`jyc:develop`、`jyc:review`。

### Step 3: DESIGN.md — 补充 LabelRule (AND/OR label logic)
**What:** 在 `PatternRules` struct 中更新 `labels` 字段，反映 v0.2.0 (#83) 的 LabelRule CNF 嵌套数组设计。当前文档描述 `labels: Option<Vec<String>>` (OR logic)，需更新为嵌套数组结构 `[["A","B"],["C"]]` 表示 CNF (AND of ORs)。
**Why:** LabelRule 支持更复杂的布尔组合，当前文档仅描述简单 OR 逻辑。
**Verify:** 搜索源码 `src/channels/types.rs` 中 `LabelRule` 定义，确保文档 struct 与代码一致。

### Step 4: DESIGN.md — 清理 `[alerting]` 配置段
**What:** 从 Config Structs 章节移除 `AlertingConfig` 和 `HealthCheckConfig` 定义，在 TOML 配置示例中移除 `[alerting]` 段。添加注释说明 `[alerting]` 已废弃（如仍保留向后兼容 struct 则标注 deprecated）。
**Why:** 配置段已不再使用但文档仍完整描述。
**Verify:** DESIGN.md 中 `AlertingConfig` 仅出现在 deprecated 说明上下文中。

### Step 5: DESIGN.md — 修正 model-override 相关描述
**What:** 核实 CHANGELOG 中 "Removed model-override file (#67)" 的准确性。如果源码仍使用 model-override（`src/core/command/model_handler.rs`、`src/services/opencode/session.rs`），则保持文档描述不变，但需在 CHANGELOG 或文档中澄清 #67 的实际变更内容。如果 #67 仅移除了 config 级别的 model override 而保留了 per-thread override，则更新文档说明。
**Why:** CHANGELOG 条目与源码/文档不一致，需澄清。
**Verify:** model-override 相关描述与源码实际行为一致。

### Step 6: DESIGN.md — 移除 TriggerMode 残留引用
**What:** 检查并移除文档中任何 `trigger_mode`/`TriggerMode` 的残留引用。v0.2.0 (#76) 已移除此字段。
**Why:** 文档可能仍有残留描述。
**Verify:** 搜索 DESIGN.md 不包含 `trigger_mode` 或 `TriggerMode`。

### Step 7: README.md — 修正文件名引用
**What:** 将 README.md 中 `config_template.toml` 引用修正为 `config.example.toml`。
**Why:** 实际文件名是 `config.example.toml`。
**Verify:** README.md 中搜索 `config_template.toml` 返回无结果。

### Step 8: README.md — 补充 templates CLI 命令
**What:** 在 CLI Commands 章节补充 `jyc templates list` 和 `jyc templates deploy` 命令文档（v0.1.10 新增）。
**Why:** 这些命令已实现但 README 未文档化。
**Verify:** README.md 包含 `templates list` 和 `templates deploy` 命令描述。

## Design Decisions
- 仅更新 DESIGN.md 和 README.md，不涉及 IMPLEMENTATION.md 和 AGENTS.md（按用户要求）
- DESIGN.md 中的 AlertService 章节直接删除而非标注 deprecated，因为该功能已完全移除
- model-override 需先核实 #67 PR 的实际变更内容再决定文档更新方向