### PR TITLE
docs: update DESIGN.md and README.md to reflect current implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ All notable changes to JYC will be documented in this file.
 
 - **README documentation updates** (#96, #98)
 - **Developer agent template simplification** (#59)
-- **Removed model-override file** (#67)
+- **Removed config-level model-override** (#67) — per-thread `.jyc/model-override` still supported via `/model` command
 - **Removed @j:role mentions, use label-based handover instead** (#76)
 - **Dockerfile optimization for dummy main caching** (#57)
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -677,8 +677,9 @@ Pattern "restricted-dev" (rules: github_type=["pull_request"], assignees=["alice
 
 Rules:
 - **`github_type`**: `"issue"` or `"pull_request"` — OR logic within the list
-- **`labels`**: Match if ANY label on the issue/PR is in the pattern's label list — case-insensitive
+- **`labels`**: `LabelRule` — supports flat OR (`["bug", "enhancement"]`) or nested AND-OR/CNF (`[["bug", "enhancement"], ["test"]]`), case-insensitive. Auto-label from `role` is OR-merged with explicit labels.
 - **`assignees`**: Match if ANY assignee on the issue/PR is in the pattern's assignee list — case-insensitive
+- **`exclude_labels`**: If ANY label on the issue/PR matches, the pattern is excluded — OR logic
 - All present rules use **AND logic** (all must pass). `None` rules are considered matched.
 
 ### Close Detection
@@ -944,8 +945,23 @@ pub struct PatternRules {
 
     // --- GitHub rules ---
     pub github_type: Option<Vec<String>>,     // Entity type: "issue" or "pull_request" (OR logic)
-    pub labels: Option<Vec<String>>,          // Labels to match (OR logic)
+    pub labels: Option<LabelRule>,            // Label matching (OR or AND-OR logic, see LabelRule)
     pub assignees: Option<Vec<String>>,       // Assignees to match (OR logic, case-insensitive)
+    pub exclude_labels: Option<Vec<String>>,  // Labels that must NOT be present (OR logic)
+}
+
+/// Label matching rule supporting flat OR logic and nested AND-OR (CNF) logic.
+///
+/// Uses `#[serde(untagged)]` for backward compatibility: a flat `["bug"]`
+/// deserializes as `Flat`, while `[["bug"], ["test"]]` deserializes as `Nested`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum LabelRule {
+    /// Flat: `["bug", "enhancement"]` → OR logic (at least one label must match)
+    Flat(Vec<String>),
+    /// Nested: `[["bug", "enhancement"], ["test"]]` → CNF (AND of ORs)
+    /// Each inner group must have at least one matching label.
+    Nested(Vec<Vec<String>>),
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -2173,21 +2173,6 @@ allowed_extensions = [".ppt", ".pptx", ".doc", ".docx", ".txt", ".md"]
 enabled = true
 interval_secs = 600                # Default: 10 minutes (avoids SMTP rate limits)
 min_elapsed_secs = 60              # Default: 1 minute before first heartbeat
-
-# --- Alerting ---
-
-[alerting]
-enabled = true
-recipient = "ops@example.com"
-batch_interval_minutes = 5
-max_errors_per_batch = 50
-subject_prefix = "JYC Alert"
-include_reply_tool_log = true
-reply_tool_log_tail_lines = 50
-
-[alerting.health_check]
-enabled = true
-interval_hours = 6
 ```
 
 ### Config Structs
@@ -2276,30 +2261,6 @@ pub struct OpenCodeConfig {
     pub system_prompt: Option<String>,
     // Note: include_thread_history is deprecated — conversation history
     // is no longer injected into the prompt. OpenCode session memory handles it.
-}
-
-#[derive(Debug, Deserialize)]
-pub struct AlertingConfig {
-    pub enabled: bool,
-    pub recipient: String,
-    #[serde(default = "default_5")]
-    pub batch_interval_minutes: u64,
-    #[serde(default = "default_50")]
-    pub max_errors_per_batch: usize,
-    pub subject_prefix: Option<String>,
-    #[serde(default = "default_true")]
-    pub include_reply_tool_log: bool,
-    #[serde(default = "default_50")]
-    pub reply_tool_log_tail_lines: usize,
-    pub health_check: Option<HealthCheckConfig>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct HealthCheckConfig {
-    pub enabled: bool,
-    #[serde(default = "default_24")]
-    pub interval_hours: f64,
-    pub recipient: Option<String>,            // Falls back to alerting.recipient
 }
 
 /// Heartbeat configuration — controls progress updates during long AI processing.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1393,8 +1393,8 @@ Signal (SIGINT/SIGTERM)
        ▼
  CancellationToken::cancel()
        │
-       ├──> IMAP Monitors: exit IDLE/poll loop → disconnect
-       │
+        ├──> IMAP Monitors: exit IDLE/poll loop → disconnect
+        │
         ├──> ThreadManager workers: finish current message → exit
         │    (in-queue messages are lost — IMAP re-fetch on restart)
         │

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1399,8 +1399,8 @@ Signal (SIGINT/SIGTERM)
         │    (in-queue messages are lost — IMAP re-fetch on restart)
         │
         ├──> OpenCode Server: explicitly stopped via server.stop()
-       │
-       └──> SMTP connections: disconnect
+        │
+        └──> SMTP connections: disconnect
 
  All JoinHandles awaited → process exits cleanly
 ```

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -240,7 +240,7 @@ Each component has a single, clear responsibility. Data flows through the system
 - Adds `Re:` to subject, sets `In-Reply-To` and `References` headers for threading
 - Does NOT build quoted history, does NOT clean or transform content
 - **Structured error handling**: Uses lettre's structured SmtpError API for error classification: permanent errors (5xx) fail immediately, transient errors (4xx) retry with exponential backoff (3 attempts, 5-60s), connection/timeout errors reconnect with backoff (2 attempts).
- - **Shared instance**: A single `SmtpClient` (via `EmailOutboundAdapter`) is created at monitor startup and shared across ThreadManager fallback, monitor reply send path (when MCP tool appends to chat log), and AlertService
+ - **Shared instance**: A single `SmtpClient` (via `EmailOutboundAdapter`) is created at monitor startup and shared across ThreadManager fallback and monitor reply send path (when MCP tool appends to chat log)
 
 **Thread Event System**
 - **Thread Event Bus** - Thread-isolated event bus for SSE → ThreadEvent conversion
@@ -550,7 +550,7 @@ The Feishu channel integrates seamlessly with the core JYC architecture:
 - Follows the same pattern matching system
 - Integrates with the thread manager and queue system
 - Supports all existing AI features and command system
-- Compatible with MCP reply tool and alert service
+- Compatible with MCP reply tool
 
 ### Testing
 
@@ -968,15 +968,15 @@ JYC uses **Tokio** as its async runtime. The message processing pipeline is buil
                     │  (multi-threaded)    │
                     └─────────────────────┘
                               │
-              ┌───────────────┼───────────────┐
-              ▼               ▼               ▼
-     ┌────────────────┐ ┌────────────────┐ ┌────────────────┐
-     │ tokio::spawn   │ │ tokio::spawn   │ │ tokio::spawn   │
-     │ IMAP Monitor   │ │ FeiShu Monitor │ │ Alert Service  │
-     │ (channel: work)│ │ (WebSocket)    │ │ (flush timer)  │
-     └───────┬────────┘ └───────┬────────┘ └────────────────┘
-             │                  │
-             ▼                  ▼
+              ┌───────────────┴───────────────┐
+              ▼                               ▼
+     ┌────────────────┐               ┌────────────────┐
+     │ tokio::spawn   │               │ tokio::spawn   │
+     │ IMAP Monitor   │               │ FeiShu Monitor │
+     │ (channel: work)│               │ (WebSocket)    │
+     └───────┬────────┘               └───────┬────────┘
+             │                                │
+             ▼                                ▼
       mpsc::Sender ─────> mpsc::Receiver
       (bounded, 256)      (MessageRouter task)
                                 │
@@ -1349,54 +1349,6 @@ impl ThreadManager {
 - **Event Publishing**: Events are published to thread-isolated event bus
 - **Thread Manager Monitoring**: Listens for events and controls heartbeat rhythm
 
-### Alert Service: Event-Driven Architecture
-
-```
-┌──────────────────────────────────────────────────────────────────┐
-│                      Alert Service                                │
-│                                                                   │
-│  ┌───────────────┐                                               │
-│  │  AppLogger    │  (unified logging + alerting handle)           │
-│  │               │                                               │
-│  │ .error() ─────┼──> tracing::error!() + mpsc::Sender<Event>   │
-│  │ .info()  ─────┼──> tracing::info!()                           │
-│  │ .reply_by_tool()──> tracing + mpsc (health stats)             │
-│  └───────────────┘         │                                     │
-│                            ▼                                     │
-│              ┌─────────────────────────┐                         │
-│              │  Alert Service Task     │                         │
-│              │  (tokio::spawn)         │                         │
-│              │  span: alert            │                         │
-│              │                         │                         │
-│              │  tokio::select! {       │                         │
-│              │    event = rx.recv() => │                         │
-│              │      match event:       │                         │
-│              │        Error →          │                         │
-│              │          buffer_error() │                         │
-│              │        MessageReceived →│                         │
-│              │          track_stats()  │                         │
-│              │        ReplyByTool →    │                         │
-│              │          track_stats()  │                         │
-│              │                         │                         │
-│              │    _ = flush_tick =>    │                         │
-│              │      flush_errors()    │                         │
-│              │      → send digest     │                         │
-│              │                         │                         │
-│              │    _ = health_tick =>   │                         │
-│              │      send_health()     │                         │
-│              │      → send report     │                         │
-│              │                         │                         │
-│              │    _ = cancel =>        │                         │
-│              │      final_flush()     │                         │
-│              │      break             │                         │
-│              │  }                      │                         │
-│              └─────────────────────────┘                         │
-│                                                                   │
-│  AppLogger sends structured AlertEvent variants via mpsc.        │
-│  Self-protection: send failures use eprintln (not tracing).       │
-└──────────────────────────────────────────────────────────────────┘
-```
-
 ### Graceful Shutdown Sequence
 
 ```
@@ -1410,12 +1362,10 @@ Signal (SIGINT/SIGTERM)
        │
        ├──> IMAP Monitors: exit IDLE/poll loop → disconnect
        │
-       ├──> ThreadManager workers: finish current message → exit
-       │    (in-queue messages are lost — IMAP re-fetch on restart)
-       │
-       ├──> Alert Service: final flush → send pending errors → exit
-       │
-       ├──> OpenCode Server: explicitly stopped via server.stop()
+        ├──> ThreadManager workers: finish current message → exit
+        │    (in-queue messages are lost — IMAP re-fetch on restart)
+        │
+        ├──> OpenCode Server: explicitly stopped via server.stop()
        │
        └──> SMTP connections: disconnect
 
@@ -1441,9 +1391,6 @@ root_cancel (top-level)
     │
     ├── thread_manager_cancel
     │       └── all worker tasks check this
-    │
-    ├── alert_service_cancel
-    │       └── triggers final flush
     │
     └── opencode_service_cancel
             └── aborts SSE streams
@@ -2530,7 +2477,7 @@ Key bindings: `q`/`Esc` quit, `↑`/`↓`/`j`/`k` select thread, `r` force refre
 
 ### MetricsCollector
 
-Replaces the old `AlertService`. Components report events via `MetricsHandle`:
+Components report events via `MetricsHandle`:
 
 - `message_received(thread)`, `message_matched(thread)`
 - `reply_by_tool(thread)`, `reply_by_fallback(thread)`
@@ -2597,7 +2544,7 @@ jyc/
 │   │   ├── chat_log_store.rs           # Chat log storage (daily log files)
 │   │   ├── email_parser.rs             # Stripping, quoting, thread trail
 │   │   ├── state_manager.rs            # UID tracking, state persistence
-│   │   ├── metrics.rs                   # MetricsCollector (replaces AlertService)
+│   │   ├── metrics.rs                   # MetricsCollector
 │   │   ├── attachment_storage.rs       # Channel-agnostic attachment saving
 │   │   ├── template_utils.rs           # Template file copying
 │   │   ├── pending_delivery.rs         # Background reply delivery watcher
@@ -2761,7 +2708,6 @@ INFO worker{channel=jiny283, thread=weather}: Session idle — prompt complete
 INFO worker{channel=jiny283, thread=weather}: Reply sent by MCP tool
 INFO worker{channel=jiny283, thread=weather}: Agent complete reply_sent=true
 INFO worker{channel=jiny283, thread=weather}: Worker finished
-alert: Alert service stopped
 ```
 
 #### Key Rules
@@ -2781,15 +2727,6 @@ alert: Alert service stopped
 | INFO | Lifecycle: message received, matched, processed, reply sent, worker start/stop, step start, tool calls |
 | DEBUG | SSE events, session status changes, step finish with costs, AI response text, config details |
 | TRACE | IMAP polling, mailbox select, skipping heartbeat notifications |
-
-### Alert Service Integration
-
-The `AppLogger` provides a unified logging + alerting interface:
-
-1. **Logging methods** (`info()`, `error()`, etc.) delegate to `tracing` for console output
-2. **Structured event methods** (`message_received()`, `reply_by_tool()`, etc.) additionally send events to the alert service via `mpsc` channel
-3. The alert service buffers errors and periodically flushes them as digest emails
-4. Self-protection: alert send failures use `eprintln` (not tracing) to avoid feedback loops
 
 ## Command System
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -580,7 +580,7 @@ The GitHub channel enables multi-agent AI workflows on GitHub issues and pull re
 │  │ poll_once():     │         │ send_reply():      │                   │
 │  │  list open issues│         │  post comment with │                   │
 │  │  list comments   │         │  [Role] prefix     │                   │
-│  │  detect @j:role  │         │                    │                   │
+│  │  detect labels  │         │                    │                   │
 │  │  detect closes   │         │ send_heartbeat():  │                   │
 │  │  detect edits    │         │  post progress     │                   │
 │  └────────┬─────────┘         └──────────┬─────────┘                   │
@@ -601,62 +601,78 @@ The GitHub channel enables multi-agent AI workflows on GitHub issues and pull re
 
 ### Multi-Agent Workflow
 
-JYC supports a planner/developer/reviewer workflow on GitHub issues and PRs:
+JYC supports a planner/developer/reviewer workflow on GitHub issues and PRs. Agent hand-off is driven by **labels**, not mentions:
 
 ```
-User creates issue
+User creates issue with "jyc:plan" label
     │
-    ├── @j:planner comment
-    │       ↓
-    │   [Planner] analyzes codebase, discusses with user
+    ├── [Planner] analyzes codebase, discusses with user
     │   [Planner] creates empty PR with implementation plan
-    │   [Planner] posts @j:developer comment on PR
+    │   [Planner] adds "jyc:develop" label to PR
     │       ↓
-    ├── @j:developer triggered on PR
+    ├── "jyc:develop" label detected → Developer triggered
     │       ↓
     │   [Developer] implements code per plan
-    │   [Developer] pushes commits, posts @j:reviewer comment
+    │   [Developer] pushes commits, adds "jyc:review" label to PR
     │       ↓
-    ├── @j:reviewer triggered on PR
+    ├── "jyc:review" label detected → Reviewer triggered
     │       ↓
     │   [Reviewer] reviews code changes
-    │   [Reviewer] approves or requests changes via @j:developer
+    │   [Reviewer] approves or requests changes by adding "jyc:develop" label
     │       ↓
     └── Cycle continues until PR is approved and merged
 ```
 
 Each role maps to a pattern with a `role` field and a template that defines the agent's behavior. Templates are in `templates/github-{planner,developer,reviewer}/`.
 
-### Mention-Driven Routing
+### Label-Based Routing
 
-Routing is driven by `@j:<role>` mentions in comments:
+Routing is driven by **labels** on issues and PRs. Patterns with a `role` field get an implicit routing label:
 
-1. **Detection**: `poll_once()` scans comments for the regex `@j:(\w+)` via `extract_mention_role()`
-2. **Metadata**: The extracted role is stored as `handover_role` in message metadata
-3. **Matching**: `GithubMatcher::match_message()` iterates patterns, matching `pattern.role` against `handover_role` (case-insensitive)
-4. **Self-loop prevention**: If the comment's `[Role]` prefix matches the target pattern's role, the pattern is skipped (prevents a `[Developer]` comment with `@j:developer` from re-triggering the developer)
-5. **Rule filtering**: After role matching, `rules_match()` validates `github_type`, `labels`, and `assignees` rules (AND logic between rules, OR logic within each rule)
+| Role | Routing Label |
+|------|--------------|
+| `Developer` | `jyc:develop` |
+| `Reviewer` | `jyc:review` |
+| `Planner` | `jyc:plan` |
+
+1. **Auto-label**: When a pattern has a `role` field, the routing label is automatically included in label matching (OR-merged with any explicit `labels` in pattern config)
+2. **Matching**: `GithubMatcher::match_message()` iterates patterns, checking `rules_match()` against github_type, labels, and assignees
+3. **Self-loop prevention**: If the comment's `[Role]` prefix matches the target pattern's role, the pattern is skipped (prevents a `[Developer]` comment from re-triggering the developer)
+4. **Rule filtering**: After label matching, `rules_match()` validates `github_type`, `labels`, and `assignees` rules (AND logic between rules, OR logic within each rule)
+
+### Label Change Detection
+
+Adding labels to existing issues/PRs triggers routing:
+
+1. Each poll cycle tracks seen issues with key `number:sorted_labels`
+2. When labels change (e.g., user adds `jyc:plan`), the new key is not in the seen set
+3. A trigger message is generated for the issue/PR, allowing Pattern-mode patterns to match on the new label
+4. This enables users to manually add routing labels to route work to agents
 
 ### Pattern Rule Filtering
 
-When a `@j:<role>` mention matches a pattern's role, the pattern's rules are additionally checked:
+When a pattern's rules are evaluated, all rules must match (AND logic):
 
 ```
-@j:developer detected → find patterns with role="Developer"
+Pattern "developer" (rules: github_type=["pull_request"], labels=[["ready-for-dev"]])
     │
-    ├── Pattern "developer" (rules: github_type=["pull_request"], assignees=["alice"])
-    │       ↓
-    │   Check github_type: message is "pull_request" → ✓
-    │   Check assignees: PR assigned to "bob" → ✗
-    │   → SKIP (rules don't match)
-    │
-    ├── Pattern "developer-default" (rules: github_type=["pull_request"])
-    │       ↓
-    │   Check github_type: message is "pull_request" → ✓
-    │   No assignees rule → ✓
+    ├── Check github_type: message is "pull_request" → ✓
+    ├── Check labels: PR has "ready-for-dev" label → ✓
+    │   (auto-label "jyc:develop" is OR-merged with explicit labels)
     │   → MATCH
     │
-    └── Route to thread with "developer-default" pattern
+Pattern "developer-default" (rules: github_type=["pull_request"])
+    │
+    ├── Check github_type: message is "pull_request" → ✓
+    ├── No labels rule → ✓ (auto-label still applied for routing)
+    │   → MATCH
+    │
+Pattern "restricted-dev" (rules: github_type=["pull_request"], assignees=["alice"])
+    │
+    ├── Check github_type: message is "pull_request" → ✓
+    ├── Check assignees: PR assigned to "bob" → ✗
+    │   → SKIP (rules don't match)
+```
 ```
 
 Rules:
@@ -738,12 +754,13 @@ The reviewer gets a separate thread prefix so developer and reviewer can work on
 ### Testing
 
 Comprehensive unit tests (14 tests for rule filtering alone) cover:
-- Mention-driven routing (role matching, case-insensitive, unknown role)
+- Label-based routing (auto-label matching, role-to-label mapping)
 - Self-loop prevention (own-role skip, cross-role pass)
 - Rule filtering (github_type, labels, assignees — AND/OR logic, case-insensitive)
 - Pattern fallback (skip first pattern on rule failure, match second)
 - Thread name derivation (issue, PR, reviewer prefix)
 - Persistent comment tracking (track, reload, edit detection, compaction)
+- Label change detection (new label triggers routing)
 - Trigger message building (issue and PR variants)
 
 ## Core Types & Traits

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ vi /path/to/data/config.toml
 ./target/release/jyc config validate --workdir /path/to/data
 ```
 
-See `config_template.toml` for a full annotated example. Use `${ENV_VAR}` syntax for secrets (passwords, API keys).
+See `config.example.toml` for a full annotated example. Use `${ENV_VAR}` syntax for secrets (passwords, API keys).
 
 ### 3. Run
 
@@ -96,7 +96,7 @@ JYC is designed to be channel-agnostic. Currently implemented channels:
 
 ### ✅ GitHub
 - **Status:** Production ready (implemented in v0.1.10)
-- **Features:** Issue/PR comments, label routing, @j:role mention routing, multi-agent workflow
+- **Features:** Issue/PR comments, label-based routing, multi-agent workflow
 - **Protocols:** REST API polling (inbound), REST API (outbound)
 - **Authentication:** Personal Access Token (PAT)
 - **Agents:** Planner, Developer, Reviewer templates for full PR workflow


### PR DESCRIPTION
## Spec

更新 DESIGN.md 和 README.md 以反映当前实现状态。主要移除已废弃的 AlertService 章节，更新 GitHub 路由为 label-based，补充 LabelRule，清理过时配置，修正 README 中的文件名引用和缺失命令。

Fixes #126

## Implementation Plan

### Step 1: DESIGN.md — 移除 AlertService 相关章节
**What:** 删除 "Alert Service: Event-Driven Architecture" 章节及相关的 `AppLogger` 描述。这些在 v0.1.11 已被 MetricsCollector 替代。同时从 Components 列表（第 17 项 AlertService 相关描述）和 Graceful Shutdown Sequence 中移除 Alert Service 引用。
**Why:** AlertService 已移除，文档仍大篇幅描述已不存在的架构。
**Verify:** `grep -i "AlertService\|AppLogger\|AlertEvent\|alert_service\|alert service" DESIGN.md` 返回无结果（除了可能的 deprecated 注释）。

### Step 2: DESIGN.md — 更新 GitHub Channel 路由为 label-based
**What:** 将 GitHub Channel 章节中的 "Mention-Driven Routing" (`@j:<role>`) 替换为 "Label-Based Routing" 描述。更新内容：
- 将 "Mention-Driven Routing" 章节改为描述 label-based routing：Patterns with a `role` field get an implicit routing label (`Developer` → `jyc:develop`, `Reviewer` → `jyc:review`, `Planner` → `jyc:plan`)
- 移除 `extract_mention_role()`、`handover_role` 相关描述
- 更新 "Multi-Agent Workflow" 流程图：agent 之间通过添加 label 进行 hand-off（而非 `@j:<role>` 评论）
- 更新 "Pattern Rule Filtering" 章节：role 字段隐式映射到 routing label，auto-label 与 pattern 配置的 `labels` 做 OR 合并
- 补充 label change detection 机制描述（添加 label 到已有 issue/PR 时触发路由）
**Why:** v0.2.0 (#76) 移除了 `@j:<role>` 提及路由，改为 label-based handover。
**Verify:** `grep -i "@j:" DESIGN.md` 无结果；文档包含 `label-based`、`jyc:develop`、`jyc:review`、`jyc:plan`。

### Step 3: DESIGN.md — 补充 LabelRule (AND/OR label logic)
**What:** 在 `PatternRules` struct 中将 `labels: Option<Vec<String>>` 更新为 `labels: Option<LabelRule>`，反映 v0.2.0 (#83) 的 LabelRule 枚举设计。添加 `LabelRule` enum 定义：
```rust
#[serde(untagged)]
pub enum LabelRule {
    /// Flat: ["bug", "enhancement"] → OR logic
    Flat(Vec<String>),
    /// Nested: [["bug", "enhancement"], ["test"]] → CNF (AND of ORs)
    Nested(Vec<Vec<String>>),
}
```
**Why:** LabelRule 支持更复杂的布尔组合，当前文档仅描述简单 `Vec<String>` OR 逻辑。
**Verify:** DESIGN.md 中 `PatternRules.labels` 类型为 `LabelRule`，且包含 Flat/Nested 变体说明。

### Step 4: DESIGN.md — 清理 `[alerting]` 配置段
**What:** 从 Config Structs 章节移除 `AlertingConfig` 和 `HealthCheckConfig` 定义（或标注为 deprecated）。从 TOML 配置示例中移除 `[alerting]` 和 `[alerting.health_check]` 段。在 `AppConfig` struct 中将 `alerting` 字段标注为 deprecated。
**Why:** 配置段已不再使用但文档仍完整描述。
**Verify:** `AlertingConfig` 在 DESIGN.md 中仅出现在 deprecated 上下文；TOML 示例无 `[alerting]` 段。

### Step 5: DESIGN.md — 修正 model-override 描述
**What:** CHANGELOG v0.2.0 "Removed model-override file (#67)" 与源码不一致——`model-override` 仍在 `model_handler.rs`、`session.rs`、`service.rs` 中使用。经核实源码确认 per-thread `.jyc/model-override` 文件仍完整保留，`/model` 命令仍写入此文件。更新 CHANGELOG 中该条目或补充说明：#67 可能仅移除了 config 级别的 model override 而非 per-thread override。DESIGN.md 中 model-override 描述保持不变（与源码一致）。
**Why:** CHANGELOG 条目与源码/文档不一致，需澄清。
**Verify:** DESIGN.md 中 model-override 描述与 `src/core/command/model_handler.rs`、`src/services/opencode/session.rs` 实际行为一致。

### Step 6: DESIGN.md — 移除 TriggerMode 残留引用
**What:** 检查并移除文档中任何 `trigger_mode`/`TriggerMode` 的残留引用。v0.2.0 (#76) 已移除此字段。
**Why:** 文档可能有残留描述。
**Verify:** `grep -i "trigger_mode\|TriggerMode" DESIGN.md` 无结果。

### Step 7: README.md — 修正文件名引用
**What:** 将 README.md 中 `config_template.toml` 引用修正为 `config.example.toml`。
**Why:** 实际文件名是 `config.example.toml`。
**Verify:** `grep "config_template" README.md` 无结果。

### Step 8: README.md — 补充 templates CLI 命令
**What:** 在 CLI Commands 章节补充 `jyc templates list` 和 `jyc templates deploy` 命令文档（v0.1.10 新增）。参考 `src/cli/templates.rs` 中的实际 CLI 定义：
- `jyc templates list` — List available templates and their skills
- `jyc templates deploy <target_dir>` — Deploy templates to a target directory (支持 `--as`、`--model`、`--source-dir` 选项)
**Why:** 这些命令已实现但 README 未文档化。
**Verify:** README.md 包含 `templates list` 和 `templates deploy` 命令描述。

## Design Decisions
- 仅更新 DESIGN.md 和 README.md，不涉及 IMPLEMENTATION.md 和 AGENTS.md（按用户要求）
- AlertService 章节直接删除（功能已完全移除，非 deprecated）
- model-override 保留文档描述（源码仍在使用），仅澄清 CHANGELOG 条目
- LabelRule 使用 `#[serde(untagged)]` enum，向后兼容原有 `Vec<String>` 格式