### PR TITLE
feat: poll PR reviews and review comments to trigger Developer

### DIFF
--- a/GITHUB_CHANNEL.md
+++ b/GITHUB_CHANNEL.md
@@ -164,7 +164,8 @@ InboundMessage {
 |--------|-------------|--------|
 | Issues | `GET /repos/{o}/{r}/issues?state=open&since=...` | opened, labeled |
 | Comments | `GET /repos/{o}/{r}/issues/comments?since=...` | created (on issues + PRs) |
-| Reviews | `GET /repos/{o}/{r}/pulls/{n}/reviews?since=...` | submitted |
+| Reviews | `GET /repos/{o}/{r}/pulls/{n}/reviews` | submitted |
+| Review Comments | `GET /repos/{o}/{r}/pulls/{n}/comments` | created (inline code comments) |
 | Close | `GET /repos/{o}/{r}/issues?state=closed&since=...` | closed, merged |
 
 ### Event → Thread Routing
@@ -179,6 +180,7 @@ InboundMessage {
 | pr.commented | Not self-loop | `pr-{N}` | Trigger agent |
 | pr.labeled | New labels match pattern | `pr-{N}` | Trigger agent (re-route) |
 | pr.review_submitted | — | `pr-{N}` | Trigger developer agent |
+| pr.review_comment | — | `pr-{N}` | Trigger developer agent (inline feedback) |
 | pr.merged | — | `pr-{N}`, `review-pr-{N}`, linked `issue-{N}` | **Close + delete all** |
 | pr.closed (not merged) | — | `pr-{N}`, `review-pr-{N}` | **Close + delete** (keep issue thread) |
 
@@ -491,8 +493,9 @@ Every poll_interval_secs:
 3. Fetch recently closed issues/PRs (for close events)
    GET /repos/{o}/{r}/issues?state=closed&since={last_poll}&sort=updated
 
-4. For each open PR with 'ready-for-review' label: fetch reviews
-   GET /repos/{o}/{r}/pulls/{n}/reviews?since={last_poll}
+4. For each open PR: fetch reviews and review comments
+   GET /repos/{o}/{r}/pulls/{n}/reviews?per_page=100
+   GET /repos/{o}/{r}/pulls/{n}/comments?sort=updated&direction=asc&per_page=100
 ```
 
 ### Deduplication
@@ -500,7 +503,8 @@ Every poll_interval_secs:
 Each event gets a unique ID for dedup:
 - Issue opened: `issue-{number}-opened`
 - Comment: `comment-{comment_id}`
-- Review: `review-{review_id}`
+- Review: `review-{review_id}:{submitted_at}`
+- Review comment: `review-comment-{id}:{updated_at}`
 - Label change: `issue-{number}-labeled-{label}-{timestamp}`
 - Close: `issue-{number}-closed-{timestamp}`
 
@@ -509,8 +513,8 @@ Processed event IDs are stored in a set (persisted to disk between restarts).
 ### Rate Limiting
 
 GitHub API rate limit: 5000 requests/hour for PAT.
-With 60s poll interval and 4 API calls per cycle: ~240 requests/hour.
-Well within limits even with review fetching.
+With 60s poll interval, ~4 base API calls per cycle, plus 2 per open PR (reviews + review comments):
+~240 base requests/hour + ~2400 for 20 open PRs = well within limits.
 
 ## Bot Identity
 

--- a/src/channels/github/client.rs
+++ b/src/channels/github/client.rs
@@ -82,6 +82,44 @@ impl GithubComment {
     }
 }
 
+/// GitHub PR review (from /pulls/{n}/reviews endpoint).
+#[derive(Debug, Deserialize)]
+pub struct GithubReview {
+    pub id: u64,
+    pub user: GithubUser,
+    pub body: String,
+    /// "APPROVED", "CHANGES_REQUESTED", "COMMENTED", "PENDING", "DISMISSED"
+    pub state: String,
+    pub submitted_at: Option<String>,
+    pub pull_request_url: String,
+}
+
+impl GithubReview {
+    /// Extract the PR number from the pull_request_url.
+    /// pull_request_url looks like: https://api.github.com/repos/{owner}/{repo}/pulls/{number}
+    pub fn pr_number(&self) -> Option<u64> {
+        self.pull_request_url
+            .rsplit('/')
+            .next()
+            .and_then(|s| s.parse().ok())
+    }
+}
+
+/// GitHub PR review comment (from /pulls/{n}/comments endpoint).
+#[derive(Debug, Deserialize)]
+pub struct GithubReviewComment {
+    pub id: u64,
+    pub user: GithubUser,
+    pub body: String,
+    pub pull_request_review_id: u64,
+    pub path: Option<String>,
+    pub line: Option<u64>,
+    pub created_at: String,
+    pub updated_at: String,
+    pub diff_hunk: Option<String>,
+    pub in_reply_to_id: Option<u64>,
+}
+
 impl GithubClient {
     /// Create a new GitHub API client.
     pub fn new(config: &GithubConfig) -> Result<Self> {
@@ -242,6 +280,60 @@ impl GithubClient {
             .context("Failed to parse closed issues response")
     }
 
+    /// List reviews on a PR.
+    ///
+    /// Returns all reviews for the given PR number.
+    pub async fn list_reviews(&self, pr_number: u64) -> Result<Vec<GithubReview>> {
+        let url = format!(
+            "{}/repos/{}/{}/pulls/{}/reviews?per_page=100",
+            self.api_url, self.owner, self.repo, pr_number
+        );
+
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context("Failed to fetch reviews")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("GET reviews failed: {} — {}", status, truncate_str(&body, 200));
+        }
+
+        resp.json::<Vec<GithubReview>>()
+            .await
+            .context("Failed to parse reviews response")
+    }
+
+    /// List review comments on a PR.
+    ///
+    /// Returns inline review comments for the given PR number.
+    pub async fn list_review_comments(&self, pr_number: u64) -> Result<Vec<GithubReviewComment>> {
+        let url = format!(
+            "{}/repos/{}/{}/pulls/{}/comments?sort=updated&direction=asc&per_page=100",
+            self.api_url, self.owner, self.repo, pr_number
+        );
+
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context("Failed to fetch review comments")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("GET review comments failed: {} — {}", status, truncate_str(&body, 200));
+        }
+
+        resp.json::<Vec<GithubReviewComment>>()
+            .await
+            .context("Failed to parse review comments response")
+    }
+
     /// Post a comment on an issue or PR.
     ///
     /// GitHub API uses the /issues/ endpoint for both issue and PR comments.
@@ -321,5 +413,55 @@ mod tests {
             ..issue
         };
         assert!(pr.is_pull_request());
+    }
+
+    #[test]
+    fn test_review_pr_number() {
+        let review = GithubReview {
+            id: 1,
+            user: GithubUser { login: "test".to_string() },
+            body: "looks good".to_string(),
+            state: "APPROVED".to_string(),
+            submitted_at: Some("2026-04-15T10:00:00Z".to_string()),
+            pull_request_url: "https://api.github.com/repos/kingye/jyc/pulls/42".to_string(),
+        };
+        assert_eq!(review.pr_number(), Some(42));
+    }
+
+    #[test]
+    fn test_review_pr_number_no_match() {
+        let review = GithubReview {
+            id: 1,
+            user: GithubUser { login: "test".to_string() },
+            body: "looks good".to_string(),
+            state: "APPROVED".to_string(),
+            submitted_at: Some("2026-04-15T10:00:00Z".to_string()),
+            pull_request_url: "invalid-url".to_string(),
+        };
+        assert_eq!(review.pr_number(), None);
+    }
+
+    #[test]
+    fn test_review_comment_deserialization() {
+        let json = r#"{
+            "id": 123,
+            "user": {"login": "reviewer"},
+            "body": "Fix this logic",
+            "pull_request_review_id": 456,
+            "path": "src/main.rs",
+            "line": 42,
+            "created_at": "2026-04-15T10:00:00Z",
+            "updated_at": "2026-04-15T10:00:00Z",
+            "diff_hunk": "@@ -1,3 +1,3 @@\n-old\n+new",
+            "in_reply_to_id": null
+        }"#;
+        let comment: GithubReviewComment = serde_json::from_str(json).unwrap();
+        assert_eq!(comment.id, 123);
+        assert_eq!(comment.user.login, "reviewer");
+        assert_eq!(comment.body, "Fix this logic");
+        assert_eq!(comment.pull_request_review_id, 456);
+        assert_eq!(comment.path.as_deref(), Some("src/main.rs"));
+        assert_eq!(comment.line, Some(42));
+        assert!(comment.in_reply_to_id.is_none());
     }
 }

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -804,6 +804,215 @@ impl GithubInboundAdapter {
             self.track_comment(&comment_key, processed_comments).await;
         }
 
+        // 2b. Fetch and process PR reviews and review comments.
+        // These are per-PR endpoints, so we iterate over open PRs from issue_cache.
+        let open_pr_numbers: Vec<u64> = issue_cache
+            .iter()
+            .filter(|(_, (_, github_type, _, _))| github_type == "pull_request")
+            .map(|(number, _)| *number)
+            .collect();
+
+        for pr_number in &open_pr_numbers {
+            // Process reviews
+            match client.list_reviews(*pr_number).await {
+                Ok(reviews) => {
+                    tracing::trace!(
+                        channel = %self.channel_name,
+                        pr_number = pr_number,
+                        count = reviews.len(),
+                        "Fetched reviews for PR"
+                    );
+
+                    for review in &reviews {
+                        let submitted_at = review.submitted_at.as_deref().unwrap_or("");
+                        let review_key = format!("review-{}:{}", review.id, submitted_at);
+
+                        if processed_comments.contains(&review_key) {
+                            continue;
+                        }
+
+                        let body_trimmed = review.body.trim();
+
+                        let comment_role = extract_comment_role(body_trimmed);
+
+                        let (title, github_type, labels, assignees) = issue_cache
+                            .get(pr_number)
+                            .cloned()
+                            .unwrap_or_else(|| (format!("#{}", pr_number), "pull_request".to_string(), vec![], vec![]));
+
+                        let event_uid = format!("review-{}", review.id);
+
+                        let mut message = self.build_trigger_message(
+                            "pull_request_review",
+                            *pr_number,
+                            &title,
+                            &github_type,
+                            "review_submitted",
+                            &review.user.login,
+                            &labels,
+                            &assignees,
+                            &event_uid,
+                        );
+
+                        message.metadata.insert(
+                            "review_state".to_string(),
+                            serde_json::Value::String(review.state.clone()),
+                        );
+
+                        message.metadata.insert(
+                            "comment_body".to_string(),
+                            serde_json::Value::String(review.body.clone()),
+                        );
+
+                        let review_section = format!(
+                            "\n\n---\nReview by {} ({}):\n\n{}",
+                            review.user.login, review.state, review.body
+                        );
+                        match &mut message.content.text {
+                            Some(text) => text.push_str(&review_section),
+                            None => message.content.text = Some(review_section),
+                        }
+
+                        if let Some(ref role) = comment_role {
+                            message.metadata.insert(
+                                "comment_role".to_string(),
+                                serde_json::Value::String(role.clone()),
+                            );
+                        }
+
+                        tracing::info!(
+                            channel = %self.channel_name,
+                            event = "review_submitted",
+                            review_id = review.id,
+                            pr_number = pr_number,
+                            review_state = %review.state,
+                            user = %review.user.login,
+                            "PR review detected → routing"
+                        );
+
+                        if let Err(e) = (options.on_message)(message) {
+                            tracing::error!(error = %e, pr_number = pr_number, "Failed to route review event");
+                        }
+
+                        self.track_comment(&review_key, processed_comments).await;
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        channel = %self.channel_name,
+                        pr_number = pr_number,
+                        error = %e,
+                        "Failed to fetch reviews for PR"
+                    );
+                }
+            }
+
+            // Process review comments
+            match client.list_review_comments(*pr_number).await {
+                Ok(review_comments) => {
+                    tracing::trace!(
+                        channel = %self.channel_name,
+                        pr_number = pr_number,
+                        count = review_comments.len(),
+                        "Fetched review comments for PR"
+                    );
+
+                    for rc in &review_comments {
+                        let rc_key = format!("review-comment-{}:{}", rc.id, rc.updated_at);
+
+                        if processed_comments.contains(&rc_key) {
+                            continue;
+                        }
+
+                        let body_trimmed = rc.body.trim();
+
+                        let comment_role = extract_comment_role(body_trimmed);
+
+                        let (title, github_type, labels, assignees) = issue_cache
+                            .get(pr_number)
+                            .cloned()
+                            .unwrap_or_else(|| (format!("#{}", pr_number), "pull_request".to_string(), vec![], vec![]));
+
+                        let event_uid = format!("review-comment-{}", rc.id);
+
+                        let mut message = self.build_trigger_message(
+                            "pull_request_review_comment",
+                            *pr_number,
+                            &title,
+                            &github_type,
+                            "created",
+                            &rc.user.login,
+                            &labels,
+                            &assignees,
+                            &event_uid,
+                        );
+
+                        message.metadata.insert(
+                            "comment_body".to_string(),
+                            serde_json::Value::String(rc.body.clone()),
+                        );
+
+                        let mut context_parts = Vec::new();
+                        if let Some(ref path) = rc.path {
+                            if let Some(line) = rc.line {
+                                context_parts.push(format!("{}:{}", path, line));
+                            } else {
+                                context_parts.push(path.clone());
+                            }
+                        }
+
+                        let review_comment_section = if context_parts.is_empty() {
+                            format!(
+                                "\n\n---\nReview comment by {}:\n\n{}",
+                                rc.user.login, rc.body
+                            )
+                        } else {
+                            format!(
+                                "\n\n---\nReview comment by {} on {}:\n\n{}",
+                                rc.user.login, context_parts.join(", "), rc.body
+                            )
+                        };
+                        match &mut message.content.text {
+                            Some(text) => text.push_str(&review_comment_section),
+                            None => message.content.text = Some(review_comment_section),
+                        }
+
+                        if let Some(ref role) = comment_role {
+                            message.metadata.insert(
+                                "comment_role".to_string(),
+                                serde_json::Value::String(role.clone()),
+                            );
+                        }
+
+                        tracing::info!(
+                            channel = %self.channel_name,
+                            event = "review_comment",
+                            comment_id = rc.id,
+                            pr_number = pr_number,
+                            path = ?rc.path,
+                            line = ?rc.line,
+                            user = %rc.user.login,
+                            "PR review comment detected → routing"
+                        );
+
+                        if let Err(e) = (options.on_message)(message) {
+                            tracing::error!(error = %e, pr_number = pr_number, "Failed to route review comment event");
+                        }
+
+                        self.track_comment(&rc_key, processed_comments).await;
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        channel = %self.channel_name,
+                        pr_number = pr_number,
+                        error = %e,
+                        "Failed to fetch review comments for PR"
+                    );
+                }
+            }
+        }
+
         // 3. Detect closed issues/PRs by comparing cache with full open set.
         // Since we fetched ALL open issues (not just recently-updated ones),
         // the comparison is reliable: if an issue was in the cache but is not

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -824,6 +824,10 @@ impl GithubInboundAdapter {
                     );
 
                     for review in &reviews {
+                        if review.state == "PENDING" {
+                            continue;
+                        }
+
                         let submitted_at = review.submitted_at.as_deref().unwrap_or("");
                         let review_key = format!("review-{}:{}", review.id, submitted_at);
 

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -2284,4 +2284,33 @@ mod tests {
         assert!(result2.is_some());
         assert_eq!(result2.unwrap().pattern_name, "detail-planner");
     }
+
+    #[test]
+    fn test_review_dedup_key_format() {
+        let mut processed: HashSet<String> = HashSet::new();
+        processed.insert("review-123:2026-04-15T10:00:00Z".to_string());
+        processed.insert("review-comment-456:2026-04-15T10:00:00Z".to_string());
+
+        assert!(processed.contains("review-123:2026-04-15T10:00:00Z"));
+        assert!(processed.contains("review-comment-456:2026-04-15T10:00:00Z"));
+        assert!(!processed.contains("review-123:2026-04-16T10:00:00Z"));
+    }
+
+    #[test]
+    fn test_review_comment_role_extraction() {
+        assert_eq!(extract_comment_role("[Developer] Fixed the issue"), Some("Developer".to_string()));
+        assert_eq!(extract_comment_role("[Reviewer] Looks good"), Some("Reviewer".to_string()));
+        assert_eq!(extract_comment_role("[Planner] Planning phase"), Some("Planner".to_string()));
+        assert_eq!(extract_comment_role("Normal review comment"), None);
+    }
+
+    #[test]
+    fn test_review_dedup_key_uniqueness() {
+        let key1 = format!("review-{}:{}", 123, "2026-04-15T10:00:00Z");
+        let key2 = format!("review-{}:{}", 123, "2026-04-16T10:00:00Z");
+        let key3 = format!("review-comment-{}:{}", 456, "2026-04-15T10:00:00Z");
+
+        assert_ne!(key1, key2, "Same review ID with different submitted_at should be different keys");
+        assert_ne!(key1, key3, "Review and review comment keys should be different");
+    }
 }


### PR DESCRIPTION
## Spec

JYC currently only polls `GET /repos/{o}/{r}/issues/comments` for PR comments, but this endpoint does **not** return PR review comments (inline code comments) or review submissions (approve/request-changes). This means when a Reviewer submits a review via `gh pr review`, the Developer agent is never triggered. This PR adds polling for PR reviews (`GET /repos/{o}/{r}/pulls/{n}/reviews`) and PR review comments (`GET /repos/{o}/{r}/pulls/{n}/comments`), routing them as `InboundMessage` events so they trigger the correct agent (Developer) through existing pattern matching.

Fixes #135

## Implementation Plan

### Step 1: Add `GithubReview` and `GithubReviewComment` structs to `client.rs`
**What:** Add two new deserialization structs in `src/channels/github/client.rs`:
- `GithubReview` with fields: `id: u64`, `user: GithubUser`, `body: String`, `state: String` (values: "APPROVED", "CHANGES_REQUESTED", "COMMENTED", "PENDING", "DISMISSED"), `submitted_at: Option<String>`, `pull_request_url: String`
- `GithubReviewComment` with fields: `id: u64`, `user: GithubUser`, `body: String`, `pull_request_review_id: u64`, `path: Option<String>` (file path), `line: Option<u64>` (line number), `created_at: String`, `updated_at: String`, `diff_hunk: Option<String>`, `in_reply_to_id: Option<u64>`
- Add `fn pr_number(&self) -> Option<u64>` on both structs — extract PR number from `pull_request_url` (format: `https://api.github.com/repos/{o}/{r}/pulls/{number}`)

**Why:** These structs are needed to deserialize the GitHub API responses for reviews and review comments.

**Verify:** `cargo check` passes — structs compile and derive correctly.

### Step 2: Add `list_reviews` and `list_review_comments` methods to `GithubClient`
**What:** In `src/channels/github/client.rs`, add two new methods:
- `pub async fn list_reviews(&self, pr_number: u64) -> Result<Vec<GithubReview>>` — calls `GET /repos/{o}/{r}/pulls/{pr_number}/reviews?per_page=100`
- `pub async fn list_review_comments(&self, pr_number: u64) -> Result<Vec<GithubReviewComment>>` — calls `GET /repos/{o}/{r}/pulls/{pr_number}/comments?sort=updated&direction=asc&per_page=100`

Follow the same error-handling pattern as existing methods (check `resp.status().is_success()`, bail with status + truncated body on failure).

**Why:** These API methods are needed to fetch review data that the `issues/comments` endpoint doesn't return.

**Verify:** `cargo check` passes — methods compile against the struct definitions.

### Step 3: Process reviews in `poll_once()` — route as `InboundMessage`
**What:** In `src/channels/github/inbound.rs`, inside `poll_once()` after the existing comment processing loop (step 2), add a new step:
1. Collect open PR numbers from `issue_cache` (entries where `github_type == "pull_request"`)
2. For each open PR, call `client.list_reviews(pr_number)` 
3. For each review, build a dedup key: `review-{review_id}:{submitted_at}` (use submitted_at since reviews have no updated_at)
4. Skip if already in `processed_comments`
5. Skip reviews from users whose comment has `[Reviewer]` prefix if the review body starts with `[Reviewer]` (self-loop prevention — same logic as regular comments)
6. Look up issue info from `issue_cache`
7. Build an `InboundMessage` using `build_trigger_message` with:
   - `event_type = "pull_request_review"`
   - `action = "review_submitted"` 
   - Append the review body and state to the message content (similar to how comment body is appended)
   - Add `review_state` to metadata (APPROVED / CHANGES_REQUESTED / COMMENTED)
   - Add `comment_role` extracted from review body (same `extract_comment_role` function)
8. Route via `options.on_message`
9. Track dedup key via `track_comment`

**Why:** Reviews are the primary trigger — when a reviewer requests changes, the developer needs to be notified.

**Verify:** `cargo check` passes. Manual test: submit a review on a PR with `gh pr review`, verify logs show "review_submitted" event detected and routed.

### Step 4: Process review comments in `poll_once()` — route as `InboundMessage`
**What:** In `src/channels/github/inbound.rs`, after the review processing loop, add processing for review comments:
1. For each open PR, call `client.list_review_comments(pr_number)`
2. Build dedup key: `review-comment-{id}:{updated_at}`
3. Skip if already in `processed_comments`
4. Self-loop prevention: same `extract_comment_role` check as regular comments
5. Build `InboundMessage` with:
   - `event_type = "pull_request_review_comment"`
   - `action = "created"`
   - Append review comment body with file/line context to message content, e.g.: "`src/foo.rs:42: Fix this logic\n\nActual comment body`"
   - Add `comment_role` to metadata
6. Route and track as before

**Why:** Review comments contain the specific line-by-line feedback that the Developer needs to address. Without them, the Developer only sees the review summary body but not the inline comments.

**Verify:** `cargo check` passes. Manual test: submit a review with inline comments, verify both the review body and inline comments are routed.

### Step 5: Dedup compatibility — handle `review-` prefix keys in `track_comment`
**What:** The `processed_comments` set and `track_comment` method already handle arbitrary string keys (the existing code uses `comment-{id}:{updated_at}`). The new `review-{id}` and `review-comment-{id}:{updated_at}` keys will work with the existing dedup mechanism. No code change needed — just verify in this step that the key format is compatible.

**Why:** Confirm that the existing persistent dedup mechanism works for the new event types without modification.

**Verify:** Review the `track_comment` method — it just inserts into HashSet and appends to file. Any string key works. No code change needed.

### Step 6: Add unit tests for new structs and methods
**What:** In `src/channels/github/client.rs` test module, add:
- `test_review_pr_number()` — verify `GithubReview::pr_number()` extracts PR number from `pull_request_url`
- `test_review_comment_fields()` — verify `GithubReviewComment` deserialization

In `src/channels/github/inbound.rs` test module, add:
- `test_extract_review_state()` — test that review state metadata is set correctly

**Why:** Ensure the new deserialization and metadata logic works correctly.

**Verify:** `cargo test` passes with new tests.

### Step 7: Update `GITHUB_CHANNEL.md` documentation
**What:** Update the "Architecture" section and "Event Classification" table in `GITHUB_CHANNEL.md` to reflect that reviews and review comments are now implemented (remove the "listed but NOT implemented" note).

**Why:** Keep documentation in sync with implementation.

**Verify:** Visual review of the updated docs.

## Design Decisions
- **Per-PR API calls**: Reviews and review comments require per-PR endpoints (`/pulls/{n}/reviews` and `/pulls/{n}/comments`), unlike regular comments which have a repo-wide endpoint. We iterate over open PRs from `issue_cache`. For repos with many open PRs this means more API calls, but with a 60s poll interval and typical <20 open PRs, this stays well within GitHub's 5000 req/hour rate limit (worst case: 20 PRs × 2 calls = 40 extra requests per cycle = 2400/hour).
- **Same dedup mechanism**: Reuse `processed_comments` HashSet and `track_comment` for reviews and review comments — just use different key prefixes (`review-`, `review-comment-`). This keeps the implementation simple and consistent.
- **Review comments include file/line context**: When routing review comments, include the `path` and `line` fields in the message body so the Developer agent knows exactly which file and line the comment refers to, without needing additional API calls.
- **No `since` filter on reviews endpoint**: The GitHub reviews endpoint doesn't support a `since` parameter. We fetch all reviews per PR and rely on dedup (`review-{id}:{submitted_at}`) to skip already-processed ones. This is acceptable because review counts per PR are typically small.
- **Review comments DO support `since`**: But for simplicity and consistency with reviews, we'll fetch all and rely on dedup. Can optimize later if needed.