### PR TITLE
feat: persist activity logs to .jyc/activity.jsonl for dashboard retention across restarts

### DIFF
--- a/src/cli/monitor.rs
+++ b/src/cli/monitor.rs
@@ -77,7 +77,6 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
     let mut all_thread_managers: Vec<Arc<ThreadManager>> = Vec::new();
     let mut all_channels: Vec<crate::inspect::types::ChannelInfo> = Vec::new();
     let mut all_workspace_dirs: Vec<std::path::PathBuf> = Vec::new();
-    let mut all_channel_names: Vec<String> = Vec::new();
     let config_snapshot = config.load();
     let agent_config = Arc::new(config_snapshot.agent.clone());
     let opencode_server = Arc::new(OpenCodeServer::new());
@@ -213,7 +212,6 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
             channel_type: channel_type.to_string(),
         });
         all_workspace_dirs.push(workspace_dir);
-        all_channel_names.push(channel_name.clone());
 
         let router = Arc::new(MessageRouter::new(thread_manager.clone(), storage.clone()));
 
@@ -456,7 +454,6 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
             config_path: Some(config_path.clone()),
             config: Some(config.clone()),
             workspace_dirs: all_workspace_dirs.clone(),
-            channel_names: all_channel_names.clone(),
         });
 
         // Start activity tracker (subscribes to thread event buses)

--- a/src/cli/monitor.rs
+++ b/src/cli/monitor.rs
@@ -76,6 +76,8 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
     let mut tasks = Vec::new();
     let mut all_thread_managers: Vec<Arc<ThreadManager>> = Vec::new();
     let mut all_channels: Vec<crate::inspect::types::ChannelInfo> = Vec::new();
+    let mut all_workspace_dirs: Vec<std::path::PathBuf> = Vec::new();
+    let mut all_channel_names: Vec<String> = Vec::new();
     let config_snapshot = config.load();
     let agent_config = Arc::new(config_snapshot.agent.clone());
     let opencode_server = Arc::new(OpenCodeServer::new());
@@ -210,6 +212,8 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
             name: channel_name.clone(),
             channel_type: channel_type.to_string(),
         });
+        all_workspace_dirs.push(workspace_dir);
+        all_channel_names.push(channel_name.clone());
 
         let router = Arc::new(MessageRouter::new(thread_manager.clone(), storage.clone()));
 
@@ -451,12 +455,15 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
             start_time: std::time::Instant::now(),
             config_path: Some(config_path.clone()),
             config: Some(config.clone()),
+            workspace_dirs: all_workspace_dirs.clone(),
+            channel_names: all_channel_names.clone(),
         });
 
         // Start activity tracker (subscribes to thread event buses)
         let _activity_task = crate::inspect::server::ActivityTracker::start(
             all_thread_managers,
             activity_map,
+            all_workspace_dirs,
             cancel.clone(),
         );
 

--- a/src/core/activity_log_store.rs
+++ b/src/core/activity_log_store.rs
@@ -1,0 +1,133 @@
+use std::fs::{File, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+
+use crate::inspect::types::ActivityEntry;
+
+const DEFAULT_MAX_ENTRIES: usize = 200;
+const ROTATION_THRESHOLD: f64 = 1.5;
+
+pub struct ActivityLogStore;
+
+impl ActivityLogStore {
+    fn jsonl_path(thread_path: &Path) -> std::path::PathBuf {
+        thread_path.join(".jyc").join("activity.jsonl")
+    }
+
+    pub fn append(thread_path: &Path, entry: &ActivityEntry) -> anyhow::Result<()> {
+        let path = Self::jsonl_path(thread_path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+        let json = serde_json::to_string(entry)?;
+        writeln!(file, "{json}")?;
+        file.flush()?;
+
+        let metadata = file.metadata()?;
+        let approx_lines = (metadata.len() / 80).max(1);
+        if approx_lines as f64 > DEFAULT_MAX_ENTRIES as f64 * ROTATION_THRESHOLD {
+            drop(file);
+            Self::rotate_if_needed(thread_path)?;
+        }
+        Ok(())
+    }
+
+    pub fn load_recent(
+        thread_path: &Path,
+        max_entries: usize,
+    ) -> anyhow::Result<Vec<ActivityEntry>> {
+        let path = Self::jsonl_path(thread_path);
+        if !path.exists() {
+            return Ok(Vec::new());
+        }
+        let file = File::open(&path)?;
+        let reader = BufReader::new(file);
+        let lines: Vec<String> = reader.lines().filter_map(|l| l.ok()).collect();
+        let start = lines.len().saturating_sub(max_entries);
+        Ok(lines[start..]
+            .iter()
+            .filter_map(|line| serde_json::from_str::<ActivityEntry>(line).ok())
+            .collect())
+    }
+
+    pub fn rotate_if_needed(thread_path: &Path) -> anyhow::Result<()> {
+        Self::rotate_if_needed_with_max(thread_path, DEFAULT_MAX_ENTRIES)
+    }
+
+    fn rotate_if_needed_with_max(thread_path: &Path, max_entries: usize) -> anyhow::Result<()> {
+        let path = Self::jsonl_path(thread_path);
+        if !path.exists() {
+            return Ok(());
+        }
+        let file = File::open(&path)?;
+        let reader = BufReader::new(file);
+        let lines: Vec<String> = reader.lines().filter_map(|l| l.ok()).collect();
+        if lines.len() <= max_entries {
+            return Ok(());
+        }
+        let keep = lines[lines.len().saturating_sub(max_entries)..].join("\n");
+        let mut file = OpenOptions::new().write(true).truncate(true).open(&path)?;
+        writeln!(file, "{keep}")?;
+        file.flush()?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use tempfile::tempdir;
+
+    fn make_entry(text: &str) -> ActivityEntry {
+        ActivityEntry {
+            time: "00:00:00".to_string(),
+            text: text.to_string(),
+            timestamp: Some(Utc::now().to_rfc3339()),
+        }
+    }
+
+    #[test]
+    fn test_append_and_load_recent() {
+        let dir = tempdir().unwrap();
+        let thread_path = dir.path().join("test-thread");
+        std::fs::create_dir_all(thread_path.join(".jyc")).unwrap();
+
+        for i in 0..5 {
+            let entry = make_entry(&format!("entry {i}"));
+            ActivityLogStore::append(&thread_path, &entry).unwrap();
+        }
+
+        let loaded = ActivityLogStore::load_recent(&thread_path, 3).unwrap();
+        assert_eq!(loaded.len(), 3);
+        assert!(loaded[0].text.contains("entry 2"));
+        assert!(loaded[1].text.contains("entry 3"));
+        assert!(loaded[2].text.contains("entry 4"));
+    }
+
+    #[test]
+    fn test_load_empty_file() {
+        let dir = tempdir().unwrap();
+        let thread_path = dir.path().join("no-such-thread");
+        let loaded = ActivityLogStore::load_recent(&thread_path, 10).unwrap();
+        assert!(loaded.is_empty());
+    }
+
+    #[test]
+    fn test_rotation() {
+        let dir = tempdir().unwrap();
+        let thread_path = dir.path().join("rot-test");
+        std::fs::create_dir_all(thread_path.join(".jyc")).unwrap();
+
+        for i in 0..300 {
+            let entry = make_entry(&format!("entry {i}"));
+            ActivityLogStore::append(&thread_path, &entry).unwrap();
+        }
+
+        ActivityLogStore::rotate_if_needed_with_max(&thread_path, 200).unwrap();
+        let loaded = ActivityLogStore::load_recent(&thread_path, 1000).unwrap();
+        assert_eq!(loaded.len(), 200);
+        assert!(loaded[0].text.contains("entry 100"));
+    }
+}

--- a/src/core/activity_log_store.rs
+++ b/src/core/activity_log_store.rs
@@ -7,6 +7,10 @@ use crate::inspect::types::ActivityEntry;
 const DEFAULT_MAX_ENTRIES: usize = 200;
 const ROTATION_THRESHOLD: f64 = 1.5;
 
+/// Persists activity entries to `.jyc/activity.jsonl` per thread.
+///
+/// Each thread's activity log is stored as one JSON line per entry,
+/// enabling efficient append-only writes and bounded history retrieval.
 pub struct ActivityLogStore;
 
 impl ActivityLogStore {
@@ -14,6 +18,10 @@ impl ActivityLogStore {
         thread_path.join(".jyc").join("activity.jsonl")
     }
 
+    /// Append an activity entry to the thread's JSONL log file.
+    ///
+    /// Creates the `.jyc/` directory if it doesn't exist. After writing,
+    /// checks whether lazy rotation is needed (1.5x threshold).
     pub fn append(thread_path: &Path, entry: &ActivityEntry) -> anyhow::Result<()> {
         let path = Self::jsonl_path(thread_path);
         if let Some(parent) = path.parent() {
@@ -33,6 +41,10 @@ impl ActivityLogStore {
         Ok(())
     }
 
+    /// Load the most recent activity entries from the thread's JSONL log.
+    ///
+    /// Returns up to `max_entries` entries in chronological order (oldest first).
+    /// Returns an empty vec if the file doesn't exist or has no valid entries.
     pub fn load_recent(
         thread_path: &Path,
         max_entries: usize,
@@ -51,6 +63,10 @@ impl ActivityLogStore {
             .collect())
     }
 
+    /// Rotate the JSONL file if it exceeds the default max entries.
+    ///
+    /// Keeps only the most recent `DEFAULT_MAX_ENTRIES` lines,
+    /// rewriting the file in place.
     pub fn rotate_if_needed(thread_path: &Path) -> anyhow::Result<()> {
         Self::rotate_if_needed_with_max(thread_path, DEFAULT_MAX_ENTRIES)
     }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod activity_log_store;
 pub mod attachment_storage;
 pub mod chat_log_store;
 pub mod command;

--- a/src/inspect/client.rs
+++ b/src/inspect/client.rs
@@ -161,7 +161,6 @@ mod tests {
             config_path: None,
             config: None,
             workspace_dirs: vec![],
-            channel_names: vec![],
         })
     }
 

--- a/src/inspect/client.rs
+++ b/src/inspect/client.rs
@@ -160,6 +160,8 @@ mod tests {
             start_time: Instant::now(),
             config_path: None,
             config: None,
+            workspace_dirs: vec![],
+            channel_names: vec![],
         })
     }
 

--- a/src/inspect/server.rs
+++ b/src/inspect/server.rs
@@ -9,6 +9,7 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 use crate::config::types::AppConfig;
+use crate::core::activity_log_store::ActivityLogStore;
 use crate::core::metrics::SharedHealthStats;
 use crate::core::thread_event::ThreadEvent;
 use crate::core::thread_manager::ThreadManager;
@@ -46,6 +47,10 @@ pub struct InspectContext {
     pub config_path: Option<PathBuf>,
     /// Swappable application config (for live reload)
     pub config: Option<Arc<ArcSwap<AppConfig>>>,
+    /// Per-channel workspace directories (parallel to thread_managers)
+    pub workspace_dirs: Vec<PathBuf>,
+    /// Per-channel names (parallel to thread_managers)
+    pub channel_names: Vec<String>,
 }
 
 /// TCP-based inspect server.
@@ -232,6 +237,14 @@ impl InspectServer {
             threads.extend(tm_threads);
         }
 
+        // Build channel -> workspace_dir lookup
+        let channel_workspace: std::collections::HashMap<&str, &std::path::Path> = context
+            .channel_names
+            .iter()
+            .zip(context.workspace_dirs.iter())
+            .map(|(name, dir)| (name.as_str(), dir.as_path()))
+            .collect();
+
         // Merge activity logs and status into threads
         let activity_map = context.activity_map.lock().await;
         for thread in &mut threads {
@@ -246,6 +259,23 @@ impl InspectServer {
             }
         }
         drop(activity_map);
+
+        // For threads without in-memory activity, load from disk
+        if !context.workspace_dirs.is_empty() {
+            for thread in &mut threads {
+                if !thread.activity.is_empty() {
+                    continue;
+                }
+                if let Some(workspace_dir) = channel_workspace.get(thread.channel.as_str()) {
+                    let thread_path = workspace_dir.join(&thread.name);
+                    if let Ok(entries) = ActivityLogStore::load_recent(&thread_path, MAX_ACTIVITY_ENTRIES) {
+                        if !entries.is_empty() {
+                            thread.activity = entries;
+                        }
+                    }
+                }
+            }
+        }
 
         // Read metrics
         let health = context.health_stats.lock().await;
@@ -276,12 +306,39 @@ pub struct ActivityTracker;
 impl ActivityTracker {
     /// Start tracking activity for all thread managers.
     /// Periodically discovers new threads and subscribes to their event buses.
+    /// Persists activity entries to `.jyc/activity.jsonl` per thread.
+    /// On startup, loads historical activity from disk.
     pub fn start(
         thread_managers: Vec<Arc<ThreadManager>>,
         activity_map: SharedActivityMap,
+        workspace_dirs: Vec<PathBuf>,
         cancel: CancellationToken,
     ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
+            // Load historical activity from disk for all existing threads
+            for (tm_index, tm) in thread_managers.iter().enumerate() {
+                let workspace_dir = &workspace_dirs[tm_index];
+                let threads = tm.list_threads().await;
+                for thread in &threads {
+                    let thread_path = workspace_dir.join(&thread.name);
+                    if let Ok(entries) = ActivityLogStore::load_recent(&thread_path, MAX_ACTIVITY_ENTRIES) {
+                        if !entries.is_empty() {
+                            let mut map = activity_map.lock().await;
+                            let state = map.entry(thread.name.clone()).or_default();
+                            state.entries = entries.into_iter().collect();
+                            state.is_processing = false;
+                            if let Some(last) = state.entries.back() {
+                                if let Some(ref ts) = last.timestamp {
+                                    if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(ts) {
+                                        state.last_active_at = Some(dt.with_timezone(&chrono::Utc));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             let mut subscribed: HashSet<String> = HashSet::new();
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(2));
 
@@ -289,8 +346,9 @@ impl ActivityTracker {
                 tokio::select! {
                     _ = interval.tick() => {
                         // Discover new threads and subscribe to their event buses
-                        for tm in &thread_managers {
+                        for (tm_index, tm) in thread_managers.iter().enumerate() {
                             let threads = tm.list_threads().await;
+                            let workspace_dir = &workspace_dirs[tm_index];
                             for thread in threads {
                                 if subscribed.contains(&thread.name) {
                                     continue;
@@ -300,6 +358,7 @@ impl ActivityTracker {
                                         subscribed.insert(thread.name.clone());
                                         let map = activity_map.clone();
                                         let name = thread.name.clone();
+                                        let thread_path = workspace_dir.join(&name);
                                         let cancel_inner = cancel.clone();
                                         tokio::spawn(async move {
                                             loop {
@@ -319,6 +378,10 @@ impl ActivityTracker {
                                                                     ThreadEvent::ProcessingCompleted { .. }
                                                                 );
                                                                 let entry = event_to_activity(&event);
+                                                                // Persist to disk
+                                                                if let Err(e) = ActivityLogStore::append(&thread_path, &entry) {
+                                                                    tracing::warn!(error = %e, thread = %name, "Failed to persist activity entry");
+                                                                }
                                                                 let mut map = map.lock().await;
                                                                 let state = map.entry(name.clone()).or_default();
                                                                 state.entries.push_back(entry);
@@ -434,7 +497,11 @@ fn event_to_activity(event: &ThreadEvent) -> ActivityEntry {
             text
         }
     };
-    ActivityEntry { time, text }
+    ActivityEntry {
+        time,
+        text,
+        timestamp: Some(event.timestamp().to_rfc3339()),
+    }
 }
 
 #[cfg(test)]
@@ -462,6 +529,8 @@ mod tests {
             start_time: Instant::now(),
             config_path: None,
             config: None,
+            workspace_dirs: vec![],
+            channel_names: vec![],
         })
     }
 
@@ -674,6 +743,8 @@ mode = "opencode"
             start_time: Instant::now(),
             config_path: Some(config_path.clone()),
             config: Some(config_swap.clone()),
+            workspace_dirs: vec![],
+            channel_names: vec![],
         });
 
         let cancel = CancellationToken::new();

--- a/src/inspect/server.rs
+++ b/src/inspect/server.rs
@@ -47,10 +47,8 @@ pub struct InspectContext {
     pub config_path: Option<PathBuf>,
     /// Swappable application config (for live reload)
     pub config: Option<Arc<ArcSwap<AppConfig>>>,
-    /// Per-channel workspace directories (parallel to thread_managers)
+    /// Per-channel workspace directories (parallel to channels)
     pub workspace_dirs: Vec<PathBuf>,
-    /// Per-channel names (parallel to thread_managers)
-    pub channel_names: Vec<String>,
 }
 
 /// TCP-based inspect server.
@@ -237,14 +235,6 @@ impl InspectServer {
             threads.extend(tm_threads);
         }
 
-        // Build channel -> workspace_dir lookup
-        let channel_workspace: std::collections::HashMap<&str, &std::path::Path> = context
-            .channel_names
-            .iter()
-            .zip(context.workspace_dirs.iter())
-            .map(|(name, dir)| (name.as_str(), dir.as_path()))
-            .collect();
-
         // Merge activity logs and status into threads
         let activity_map = context.activity_map.lock().await;
         for thread in &mut threads {
@@ -259,23 +249,6 @@ impl InspectServer {
             }
         }
         drop(activity_map);
-
-        // For threads without in-memory activity, load from disk
-        if !context.workspace_dirs.is_empty() {
-            for thread in &mut threads {
-                if !thread.activity.is_empty() {
-                    continue;
-                }
-                if let Some(workspace_dir) = channel_workspace.get(thread.channel.as_str()) {
-                    let thread_path = workspace_dir.join(&thread.name);
-                    if let Ok(entries) = ActivityLogStore::load_recent(&thread_path, MAX_ACTIVITY_ENTRIES) {
-                        if !entries.is_empty() {
-                            thread.activity = entries;
-                        }
-                    }
-                }
-            }
-        }
 
         // Read metrics
         let health = context.health_stats.lock().await;
@@ -314,6 +287,11 @@ impl ActivityTracker {
         workspace_dirs: Vec<PathBuf>,
         cancel: CancellationToken,
     ) -> tokio::task::JoinHandle<()> {
+        assert_eq!(
+            thread_managers.len(),
+            workspace_dirs.len(),
+            "thread_managers and workspace_dirs must have the same length"
+        );
         tokio::spawn(async move {
             // Load historical activity from disk for all existing threads
             for (tm_index, tm) in thread_managers.iter().enumerate() {
@@ -347,8 +325,8 @@ impl ActivityTracker {
                     _ = interval.tick() => {
                         // Discover new threads and subscribe to their event buses
                         for (tm_index, tm) in thread_managers.iter().enumerate() {
+                            let workspace_dir = workspace_dirs.get(tm_index);
                             let threads = tm.list_threads().await;
-                            let workspace_dir = &workspace_dirs[tm_index];
                             for thread in threads {
                                 if subscribed.contains(&thread.name) {
                                     continue;
@@ -358,7 +336,7 @@ impl ActivityTracker {
                                         subscribed.insert(thread.name.clone());
                                         let map = activity_map.clone();
                                         let name = thread.name.clone();
-                                        let thread_path = workspace_dir.join(&name);
+                                        let thread_path = workspace_dir.map(|d| d.join(&name));
                                         let cancel_inner = cancel.clone();
                                         tokio::spawn(async move {
                                             loop {
@@ -379,8 +357,10 @@ impl ActivityTracker {
                                                                 );
                                                                 let entry = event_to_activity(&event);
                                                                 // Persist to disk
-                                                                if let Err(e) = ActivityLogStore::append(&thread_path, &entry) {
-                                                                    tracing::warn!(error = %e, thread = %name, "Failed to persist activity entry");
+                                                                if let Some(ref path) = thread_path {
+                                                                    if let Err(e) = ActivityLogStore::append(path, &entry) {
+                                                                        tracing::warn!(error = %e, thread = %name, "Failed to persist activity entry");
+                                                                    }
                                                                 }
                                                                 let mut map = map.lock().await;
                                                                 let state = map.entry(name.clone()).or_default();
@@ -530,7 +510,6 @@ mod tests {
             config_path: None,
             config: None,
             workspace_dirs: vec![],
-            channel_names: vec![],
         })
     }
 
@@ -744,7 +723,6 @@ mode = "opencode"
             config_path: Some(config_path.clone()),
             config: Some(config_swap.clone()),
             workspace_dirs: vec![],
-            channel_names: vec![],
         });
 
         let cancel = CancellationToken::new();

--- a/src/inspect/types.rs
+++ b/src/inspect/types.rs
@@ -16,9 +16,14 @@ pub struct InspectRequest {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum InspectResponse {
     State(InspectState),
-    Error { error: String },
+    Error {
+        error: String,
+    },
     /// Result of a `reload_config` request.
-    ReloadResult { success: bool, message: String },
+    ReloadResult {
+        success: bool,
+        message: String,
+    },
 }
 
 // ── State snapshot ──
@@ -81,6 +86,9 @@ pub struct ActivityEntry {
     pub time: String,
     /// Human-readable description
     pub text: String,
+    /// RFC 3339 timestamp for ordering and cross-day sorting
+    #[serde(default)]
+    pub timestamp: Option<String>,
 }
 
 /// Thread processing status.


### PR DESCRIPTION
## Spec

Persist the dashboard Activity panel data (processing events, tool calls, heartbeats, retries, etc.) to `.jyc/activity.jsonl` per thread so that activity history survives JYC restarts. Currently, activity data only exists in memory (`SharedActivityMap`) and is lost on restart.

Fixes #137

## Implementation Plan

### Step 1: Add `timestamp` field to `ActivityEntry`
**What:** In `src/inspect/types.rs`, add an optional `timestamp` field (`Option<String>`, RFC 3339) to `ActivityEntry`. This is needed for proper ordering when loading from disk. The existing `time` field (HH:MM:SS) is insufficient for cross-day sorting. Add `#[serde(default)]` for backward compat with entries that lack it.
**Why:** Without a full timestamp, entries loaded from disk cannot be reliably sorted or correlated with chat history.
**Verify:** `cargo check` passes; existing `ActivityEntry` serialization tests still pass.

### Step 2: Create `ActivityLogStore` module
**What:** Create `src/core/activity_log_store.rs` with a struct that can:
- `append(thread_path: &Path, entry: &ActivityEntry)` — serialize entry as one JSON line and append to `{thread_path}/.jyc/activity.jsonl`
- `load_recent(thread_path: &Path, max_entries: usize) -> Vec<ActivityEntry>` — read the last N lines from the file, parse each as `ActivityEntry`, return in chronological order (oldest first)
- `rotate_if_needed(thread_path: &Path, max_entries: usize)` — if file exceeds max_entries lines, truncate to keep only the most recent entries
Use `std::fs::OpenOptions` with append for writes. For reads, use `std::io::BufRead::lines` and seek to near the end for efficiency. Max entries default: 200 (more generous than the in-memory 60, since disk is cheap).
**Why:** Separate store module follows the existing pattern of `ChatLogStore` and keeps I/O logic isolated.
**Verify:** `cargo check` passes. Write a unit test: create a temp dir, append 5 entries, load_recent(3) returns last 3 in order.

### Step 3: Add `ActivityLogStore` to `core/mod.rs`
**What:** Add `pub mod activity_log_store;` to `src/core/mod.rs`.
**Why:** Make the module accessible to the activity tracker.
**Verify:** `cargo check` passes.

### Step 4: Add `workspace_dirs` to `InspectContext`
**What:** In `src/inspect/server.rs`, add a field `pub workspace_dirs: Vec<PathBuf>` to `InspectContext`. This maps 1:1 with `thread_managers` — each thread manager's workspace dir. Also add a `pub channel_names: Vec<String>` field (parallel to thread_managers) so the tracker can resolve thread paths as `workspace_dir / thread_name / .jyc / activity.jsonl`.
**Why:** The `ActivityTracker` currently has no way to resolve a thread name to its filesystem path. It needs workspace directories to find `.jyc/activity.jsonl`.
**Verify:** `cargo check` passes. Existing inspect server tests need to be updated to include `workspace_dirs: vec![]` and `channel_names: vec![]`.

### Step 5: Wire `workspace_dirs` in `cli/monitor.rs`
**What:** In `src/cli/monitor.rs`, when building `InspectContext`, add `workspace_dirs` and `channel_names` from the thread managers' configuration. Each `ThreadManagerBuilder` has a `workspace_dir` field; collect these into a vec.
**Why:** Connect the new context fields to actual data.
**Verify:** `cargo check` passes.

### Step 6: Modify `ActivityTracker` to persist events on arrival
**What:** In `src/inspect/server.rs` `ActivityTracker::start()`, when an event is received and converted to an `ActivityEntry`:
- Determine the thread's workspace dir by finding the matching index in `workspace_dirs` / `channel_names`
- Construct thread_path as `workspace_dir / thread_name`
- Call `ActivityLogStore::append(&thread_path, &entry)`
Also add `workspace_dirs` and `channel_names` as parameters to `ActivityTracker::start()`.
**Why:** This is the core persistence — every event is written to disk as it arrives.
**Verify:** `cargo check` passes. Manual test: start monitor, send a message, check `.jyc/activity.jsonl` is created with entries.

### Step 7: Load historical activity on startup in `ActivityTracker`
**What:** In `ActivityTracker::start()`, before entering the main loop, scan all workspace_dirs for existing thread directories with `.jyc/activity.jsonl` files. For each, call `ActivityLogStore::load_recent()` and populate the `activity_map` with the results. Also set `is_processing = false` and `last_active_at` from the last entry's timestamp.
**Why:** This is the key feature — restoring activity history from disk after restart.
**Verify:** `cargo check` passes. Integration test: create a temp workspace with a thread dir containing `.jyc/activity.jsonl` with some entries, start the tracker, verify the activity_map is populated.

### Step 8: Add `timestamp` population in `event_to_activity()`
**What:** In `src/inspect/server.rs` `event_to_activity()`, populate the new `timestamp` field on `ActivityEntry` from `event.timestamp().to_rfc3339()`. This ensures persisted entries have full timestamps.
**Why:** Without this, persisted entries would lack the timestamp needed for ordering on reload.
**Verify:** `cargo check` passes.

### Step 9: Update `build_state()` to include loaded activity for dormant threads
**What:** In `InspectServer::build_state()`, after merging activity from the in-memory `activity_map`, also check threads that have no in-memory activity. For those, load recent activity from disk via `ActivityLogStore::load_recent()`. This ensures threads that were active before restart show their history even if no new events have arrived.
**Why:** The `list_threads()` method returns all threads (including dormant ones), but the activity_map only contains entries for threads that have received events since startup. Dormant threads need their history loaded from disk.
**Verify:** `cargo check` passes. Manual test: restart JYC, open dashboard, select a previously active thread — activity panel should show historical entries.

### Step 10: Add rotation to prevent unbounded growth
**What:** In the `append()` method of `ActivityLogStore`, after writing, check line count. If it exceeds `max_entries * 1.5` (lazy rotation), call the rotation function to truncate. Also add a `rotate_if_needed()` that reads the file, keeps only the last `max_entries` lines, and rewrites.
**Why:** Prevent `.jyc/activity.jsonl` from growing indefinitely over months/years of operation.
**Verify:** Unit test: write 300 entries with max_entries=200, verify file is rotated to 200 lines.

### Step 11: Update existing tests
**What:** Update all tests that construct `InspectContext` to include the new `workspace_dirs` and `channel_names` fields. Add unit tests for `ActivityLogStore` (append, load_recent, rotation). Add integration tests for the tracker startup loading.
**Why:** Ensure no regressions and verify new functionality.
**Verify:** `cargo test` passes.

## Design Decisions
- **JSONL format** over SQLite/other: simplest, append-friendly, no extra dependencies, matches the project's file-per-thread convention
- **200 max entries on disk** vs 60 in memory: disk is cheap, more history is useful for debugging; the dashboard will still display only what fits the panel
- **Lazy rotation** (1.5x threshold): avoids rotation on every write, reduces I/O overhead
- **`workspace_dirs` in `InspectContext`**: thread managers don't expose their workspace_dir publicly, so we pass it explicitly at construction time