### PR TITLE
feat: add severity to ActivityEntry and Error status to threads

### DIFF
--- a/src/cli/dashboard.rs
+++ b/src/cli/dashboard.rs
@@ -17,7 +17,7 @@ use std::io::stdout;
 use std::time::Duration;
 
 use crate::inspect::client::InspectClient;
-use crate::inspect::types::{InspectState, ThreadStatus};
+use crate::inspect::types::{InspectState, Severity, ThreadStatus};
 
 #[derive(Args, Debug)]
 pub struct DashboardArgs {
@@ -284,6 +284,7 @@ fn render_threads(frame: &mut Frame, area: Rect, app: &mut App) {
                 ThreadStatus::Queued => Style::default().fg(Color::Yellow),
                 ThreadStatus::WaitingForAnswer => Style::default().fg(Color::Cyan),
                 ThreadStatus::Idle => Style::default().fg(Color::DarkGray),
+                ThreadStatus::Error => Style::default().fg(Color::Red),
             };
 
             let tokens = match (t.input_tokens, t.max_tokens) {
@@ -397,6 +398,7 @@ fn render_details(frame: &mut Frame, area: Rect, app: &App) {
                 ThreadStatus::Queued => Style::default().fg(Color::Yellow),
                 ThreadStatus::WaitingForAnswer => Style::default().fg(Color::Cyan),
                 ThreadStatus::Idle => Style::default().fg(Color::DarkGray),
+                ThreadStatus::Error => Style::default().fg(Color::Red),
             },
         ),
     ];
@@ -439,12 +441,22 @@ fn render_details(frame: &mut Frame, area: Rect, app: &App) {
             .iter()
             .skip(skip)
             .map(|entry| {
+                let time_str = entry.timestamp.as_deref().and_then(|ts| {
+                    chrono::DateTime::parse_from_rfc3339(ts)
+                        .ok()
+                        .map(|dt| dt.format("%H:%M:%S").to_string())
+                }).unwrap_or_else(|| "-".to_string());
+                let text_style = match entry.severity {
+                    Severity::Error => Style::default().fg(Color::Red),
+                    Severity::Warning => Style::default().fg(Color::Yellow),
+                    Severity::Info => Style::default(),
+                };
                 Line::from(vec![
                     Span::styled(
-                        format!("  {} ", entry.time),
+                        format!("  {time_str} "),
                         Style::default().fg(Color::DarkGray),
                     ),
-                    Span::raw(&entry.text),
+                    Span::styled(&entry.text, text_style),
                 ])
             })
             .collect();

--- a/src/core/activity_log_store.rs
+++ b/src/core/activity_log_store.rs
@@ -98,9 +98,9 @@ mod tests {
 
     fn make_entry(text: &str) -> ActivityEntry {
         ActivityEntry {
-            time: "00:00:00".to_string(),
             text: text.to_string(),
             timestamp: Some(Utc::now().to_rfc3339()),
+            severity: crate::inspect::types::Severity::Info,
         }
     }
 

--- a/src/inspect/server.rs
+++ b/src/inspect/server.rs
@@ -396,6 +396,17 @@ impl ActivityTracker {
 
 /// Convert a ThreadEvent into a human-readable ActivityEntry.
 fn event_to_activity(event: &ThreadEvent) -> ActivityEntry {
+    let severity = match event {
+        ThreadEvent::SessionStatus { status_type, .. } => match status_type.as_str() {
+            "error" | "timeout" => Severity::Error,
+            "retry" | "rate_limit" => Severity::Warning,
+            _ => Severity::Info,
+        },
+        ThreadEvent::ToolCompleted { success: false, .. } => Severity::Error,
+        ThreadEvent::ProcessingCompleted { success: false, .. } => Severity::Error,
+        _ => Severity::Info,
+    };
+
     let text = match event {
         ThreadEvent::ProcessingStarted { .. } => "Processing started".to_string(),
         ThreadEvent::ProcessingProgress {
@@ -479,7 +490,7 @@ fn event_to_activity(event: &ThreadEvent) -> ActivityEntry {
     ActivityEntry {
         text,
         timestamp: Some(event.timestamp().to_rfc3339()),
-        severity: Severity::Info,
+        severity,
     }
 }
 

--- a/src/inspect/server.rs
+++ b/src/inspect/server.rs
@@ -26,6 +26,7 @@ pub type SharedActivityMap = Arc<Mutex<HashMap<String, ThreadActivityState>>>;
 pub struct ThreadActivityState {
     pub entries: VecDeque<ActivityEntry>,
     pub is_processing: bool,
+    pub has_error: bool,
     pub last_active_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
@@ -355,25 +356,30 @@ impl ActivityTracker {
                                                                     &event,
                                                                     ThreadEvent::ProcessingCompleted { .. }
                                                                 );
-                                                                let entry = event_to_activity(&event);
-                                                                // Persist to disk
-                                                                if let Some(ref path) = thread_path {
-                                                                    if let Err(e) = ActivityLogStore::append(path, &entry) {
-                                                                        tracing::warn!(error = %e, thread = %name, "Failed to persist activity entry");
-                                                                    }
-                                                                }
-                                                                let mut map = map.lock().await;
-                                                                let state = map.entry(name.clone()).or_default();
-                                                                state.entries.push_back(entry);
-                                                                state.last_active_at = Some(event.timestamp());
-                                                                if state.entries.len() > MAX_ACTIVITY_ENTRIES {
-                                                                    state.entries.pop_front();
-                                                                }
-                                                                if is_processing {
-                                                                    state.is_processing = true;
-                                                                } else if is_completed {
-                                                                    state.is_processing = false;
-                                                                }
+                                                                 let entry = event_to_activity(&event);
+                                                                 let is_error = entry.severity == Severity::Error;
+                                                                 // Persist to disk
+                                                                 if let Some(ref path) = thread_path {
+                                                                     if let Err(e) = ActivityLogStore::append(path, &entry) {
+                                                                         tracing::warn!(error = %e, thread = %name, "Failed to persist activity entry");
+                                                                     }
+                                                                 }
+                                                                 let mut map = map.lock().await;
+                                                                 let state = map.entry(name.clone()).or_default();
+                                                                 state.entries.push_back(entry);
+                                                                 state.last_active_at = Some(event.timestamp());
+                                                                 if state.entries.len() > MAX_ACTIVITY_ENTRIES {
+                                                                     state.entries.pop_front();
+                                                                 }
+                                                                 if is_processing {
+                                                                     state.is_processing = true;
+                                                                     state.has_error = false;
+                                                                 } else if is_completed {
+                                                                     state.is_processing = false;
+                                                                 }
+                                                                 if is_error {
+                                                                     state.has_error = true;
+                                                                 }
                                                             }
                                                             None => break,
                                                         }

--- a/src/inspect/server.rs
+++ b/src/inspect/server.rs
@@ -396,7 +396,6 @@ impl ActivityTracker {
 
 /// Convert a ThreadEvent into a human-readable ActivityEntry.
 fn event_to_activity(event: &ThreadEvent) -> ActivityEntry {
-    let time = event.timestamp().format("%H:%M:%S").to_string();
     let text = match event {
         ThreadEvent::ProcessingStarted { .. } => "Processing started".to_string(),
         ThreadEvent::ProcessingProgress {
@@ -478,9 +477,9 @@ fn event_to_activity(event: &ThreadEvent) -> ActivityEntry {
         }
     };
     ActivityEntry {
-        time,
         text,
         timestamp: Some(event.timestamp().to_rfc3339()),
+        severity: Severity::Info,
     }
 }
 

--- a/src/inspect/server.rs
+++ b/src/inspect/server.rs
@@ -243,6 +243,8 @@ impl InspectServer {
                 thread.activity = state.entries.iter().cloned().collect();
                 if state.is_processing {
                     thread.status = ThreadStatus::Processing;
+                } else if state.has_error {
+                    thread.status = ThreadStatus::Error;
                 }
                 if let Some(last_active) = state.last_active_at {
                     thread.last_active_at = Some(last_active.to_rfc3339());

--- a/src/inspect/server.rs
+++ b/src/inspect/server.rs
@@ -360,7 +360,6 @@ impl ActivityTracker {
                                                                 );
                                                                  let entry = event_to_activity(&event);
                                                                  let is_error = entry.severity == Severity::Error;
-                                                                 // Persist to disk
                                                                  if let Some(ref path) = thread_path {
                                                                      if let Err(e) = ActivityLogStore::append(path, &entry) {
                                                                          tracing::warn!(error = %e, thread = %name, "Failed to persist activity entry");

--- a/src/inspect/types.rs
+++ b/src/inspect/types.rs
@@ -79,16 +79,32 @@ pub struct ThreadInfo {
     pub last_active_at: Option<String>,
 }
 
+/// Severity level for an activity entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Severity {
+    Info,
+    Warning,
+    Error,
+}
+
+impl Default for Severity {
+    fn default() -> Self {
+        Self::Info
+    }
+}
+
 /// A single activity event from the thread's SSE stream.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ActivityEntry {
-    /// Timestamp (HH:MM:SS)
-    pub time: String,
     /// Human-readable description
     pub text: String,
     /// RFC 3339 timestamp for ordering and cross-day sorting
     #[serde(default)]
     pub timestamp: Option<String>,
+    /// Severity level (defaults to Info for backward compat)
+    #[serde(default)]
+    pub severity: Severity,
 }
 
 /// Thread processing status.
@@ -103,6 +119,8 @@ pub enum ThreadStatus {
     Idle,
     /// Question tool waiting for user reply
     WaitingForAnswer,
+    /// Thread encountered an error
+    Error,
 }
 
 impl Default for ThreadStatus {
@@ -118,6 +136,7 @@ impl std::fmt::Display for ThreadStatus {
             Self::Processing => write!(f, "Processing"),
             Self::Idle => write!(f, "Idle"),
             Self::WaitingForAnswer => write!(f, "Waiting"),
+            Self::Error => write!(f, "Error"),
         }
     }
 }
@@ -248,6 +267,7 @@ mod tests {
         assert_eq!(format!("{}", ThreadStatus::Processing), "Processing");
         assert_eq!(format!("{}", ThreadStatus::Idle), "Idle");
         assert_eq!(format!("{}", ThreadStatus::WaitingForAnswer), "Waiting");
+        assert_eq!(format!("{}", ThreadStatus::Error), "Error");
     }
 
     #[test]

--- a/src/inspect/types.rs
+++ b/src/inspect/types.rs
@@ -287,5 +287,58 @@ mod tests {
 
         let parsed: ThreadStatus = serde_json::from_str(r#""processing""#).unwrap();
         assert_eq!(parsed, ThreadStatus::Processing);
+
+        let json = serde_json::to_string(&ThreadStatus::Error).unwrap();
+        assert_eq!(json, r#""error""#);
+
+        let parsed: ThreadStatus = serde_json::from_str(r#""error""#).unwrap();
+        assert_eq!(parsed, ThreadStatus::Error);
+    }
+
+    #[test]
+    fn test_severity_serde_roundtrip() {
+        let json = serde_json::to_string(&Severity::Info).unwrap();
+        assert_eq!(json, r#""info""#);
+        let parsed: Severity = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, Severity::Info);
+
+        let json = serde_json::to_string(&Severity::Warning).unwrap();
+        assert_eq!(json, r#""warning""#);
+        let parsed: Severity = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, Severity::Warning);
+
+        let json = serde_json::to_string(&Severity::Error).unwrap();
+        assert_eq!(json, r#""error""#);
+        let parsed: Severity = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, Severity::Error);
+    }
+
+    #[test]
+    fn test_severity_default_is_info() {
+        assert_eq!(Severity::default(), Severity::Info);
+    }
+
+    #[test]
+    fn test_activity_entry_backward_compat_old_jsonl() {
+        // Old JSONL entries have `time` field but no `severity` — should deserialize fine
+        let old_json =
+            r#"{"time":"12:34:56","text":"Processing started","timestamp":"2025-01-15T12:34:56Z"}"#;
+        let entry: ActivityEntry = serde_json::from_str(old_json).unwrap();
+        assert_eq!(entry.text, "Processing started");
+        assert_eq!(entry.severity, Severity::Info);
+        assert_eq!(entry.timestamp.as_deref(), Some("2025-01-15T12:34:56Z"));
+    }
+
+    #[test]
+    fn test_activity_entry_with_severity() {
+        let entry = ActivityEntry {
+            text: "Failed (5s)".to_string(),
+            timestamp: Some("2025-01-15T12:34:56Z".to_string()),
+            severity: Severity::Error,
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        assert!(json.contains(r#""severity":"error""#));
+        let parsed: ActivityEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.severity, Severity::Error);
     }
 }


### PR DESCRIPTION
## Spec

Add `Severity` enum to `ActivityEntry` and `Error` variant to `ThreadStatus`, enabling the dashboard to display error/warning states on threads and color-code activity entries by severity. Also remove the redundant `time` field from `ActivityEntry`, keeping only `timestamp`.

Fixes #139

## Implementation Plan

### Step 1: Add `Severity` enum and update `ActivityEntry` in `src/inspect/types.rs`
**What:** Add `Severity` enum (`Info`, `Warning`, `Error`) with `serde(rename_all = "snake_case")` and `Default = Info`. Remove `time` field from `ActivityEntry`. Add `severity: Severity` field with `#[serde(default)]` for backward compat with old JSONL data. Add `ThreadStatus::Error` variant. Update `Display` impl for `ThreadStatus`. Update all test constructions of `ActivityEntry` and `ThreadStatus`.
**Why:** Core type changes needed before any consumer can be updated.
**Verify:** `cargo check`

### Step 2: Update `event_to_activity` in `src/inspect/server.rs`
**What:** Modify `event_to_activity()` to return `ActivityEntry` without `time` (derive HH:MM:SS display from `timestamp` only internally if needed). Set `severity` based on event type:
- `SessionStatus { status_type: "error" | "timeout" }` → `Severity::Error`
- `SessionStatus { status_type: "retry" | "rate_limit" }` → `Severity::Warning`
- `ToolCompleted { success: false }` → `Severity::Error`
- `ProcessingCompleted { success: false }` → `Severity::Error`
- Everything else → `Severity::Info`
**Why:** This is where event semantics are translated to activity entries — severity must be set here.
**Verify:** `cargo test -- --test-threads=1` (specifically `test_event_to_activity_session_status_error` and related tests)

### Step 3: Track error state in `ActivityTracker` in `src/inspect/server.rs`
**What:** In the `ActivityTracker::start()` event loop, when receiving `SessionStatus { status_type: "error" | "timeout" }` or `ProcessingCompleted { success: false }`, set `state.is_processing = false` and also set a new `has_error: bool` flag on `ThreadActivityState`. When receiving `ProcessingStarted`, clear the `has_error` flag. Add `has_error: bool` field to `ThreadActivityState` (default `false`).
**Why:** The thread-level error status needs to be tracked so `build_state` can set `ThreadStatus::Error`.
**Verify:** `cargo check`

### Step 4: Use `has_error` in `build_state` in `src/inspect/server.rs`
**What:** In `InspectServer::build_state()`, after merging activity logs, check `state.has_error` — if true and status is `Idle`, set `thread.status = ThreadStatus::Error`.
**Why:** Threads in error state should show as `Error` rather than `Idle` in the dashboard.
**Verify:** `cargo test`

### Step 5: Update dashboard rendering in `src/cli/dashboard.rs`
**What:** 
- In `render_threads()`: add `ThreadStatus::Error => Style::default().fg(Color::Red)` for the status column coloring.
- In `render_details()`: same for the detail status line.
- In activity log rendering: color activity entries by `severity` — `Error` → `Color::Red`, `Warning` → `Color::Yellow`, `Info` → default. Parse HH:MM:SS from `entry.timestamp` (RFC 3339) instead of using `entry.time`.
**Why:** This is the user-facing change — dashboard must display the new error state and color-coded activity.
**Verify:** `cargo build --release` and manually run `jyc dashboard` to verify rendering

### Step 6: Update `ActivityLogStore` tests in `src/core/activity_log_store.rs`
**What:** Update `make_entry()` helper to construct `ActivityEntry` without `time` field, using only `timestamp` and `severity`. Ensure JSONL round-trip still works.
**Why:** Tests must compile with the new `ActivityEntry` shape.
**Verify:** `cargo test -- activity_log`

### Step 7: Add `Severity` serde and display tests in `src/inspect/types.rs`
**What:** Add unit tests for `Severity` serde round-trip (snake_case), `Severity::default() == Info`, and `ThreadStatus::Error` display/serde. Test that old JSONL entries with `time` field but no `severity` deserialize correctly (ignoring `time`, defaulting `severity` to `Info`).
**Why:** Ensure backward compatibility with existing JSONL data and correct serialization.
**Verify:** `cargo test -- inspect::types`

## Design Decisions
- **Remove `time` field from `ActivityEntry`**: Only `timestamp` (RFC 3339) is kept. Dashboard formats display time from `timestamp`. Old JSONL data with `time` but no `severity` will deserialize fine — `time` is silently ignored by serde, `severity` defaults to `Info`.
- **`ThreadStatus::Error`**: A thread shows as `Error` (not `Idle`) when the last significant event was a failure. It resets to `Processing`/`Idle` when a new `ProcessingStarted` event arrives.
- **`Severity` default is `Info`**: Ensures backward compatibility — old activity entries without severity are treated as informational.