### PR TITLE
feat: poll PR CI check-run results and trigger developer on failure

### DIFF
--- a/GITHUB_CHANNEL.md
+++ b/GITHUB_CHANNEL.md
@@ -181,6 +181,7 @@ InboundMessage {
 | pr.labeled | New labels match pattern | `pr-{N}` | Trigger agent (re-route) |
 | pr.review_submitted | — | `pr-{N}` | Trigger developer agent |
 | pr.review_comment | — | `pr-{N}` | Trigger developer agent (inline feedback) |
+| pr.ci_failure | Check run conclusion = "failure" | `pr-{N}` | Trigger developer agent (auto-fix CI failures) |
 | pr.merged | — | `pr-{N}`, `review-pr-{N}`, linked `issue-{N}` | **Close + delete all** |
 | pr.closed (not merged) | — | `pr-{N}`, `review-pr-{N}` | **Close + delete** (keep issue thread) |
 
@@ -260,6 +261,7 @@ owner = "kingye"
 repo = "jyc"
 token = "${GITHUB_TOKEN}"
 poll_interval_secs = 60
+poll_ci_status = true
 
 # Pattern 1: Issues with jyc:plan label → Planner
 [[channels.my_repo.patterns]]
@@ -496,7 +498,28 @@ Every poll_interval_secs:
 4. For each open PR: fetch reviews and review comments
    GET /repos/{o}/{r}/pulls/{n}/reviews?per_page=100
    GET /repos/{o}/{r}/pulls/{n}/comments?sort=updated&direction=asc&per_page=100
+
+5. For each open PR: poll CI check-run status (if poll_ci_status = true)
+   GET /repos/{o}/{r}/pulls/{n}  (get head SHA)
+   GET /repos/{o}/{r}/commits/{sha}/check-runs?per_page=100
 ```
+
+### CI Check-Run Polling
+
+When `poll_ci_status = true` (default), the adapter monitors CI check-run results
+for all open PRs on each poll cycle. It detects **transitions** to "failure" status
+and triggers the developer agent to fix the issue.
+
+**Behavior**:
+- Only triggers on status **change** to "failure" (not on every poll if still failing)
+- When a new commit is pushed (head SHA changes), tracking resets automatically
+- CI status is persisted to `<channel>/.github/ci-status.txt` across restarts
+- CI events use `github_event: "check_run"` and `actor: "github-actions"` — they
+  pass through self-loop prevention since they're not prefixed with `[Developer]`
+- Failing check names and conclusions are included in metadata (`ci_failed_checks`)
+  and in the message body
+
+**Dedup key**: `ci-{pr_number}-{head_sha_prefix}-failure`
 
 ### Deduplication
 
@@ -513,8 +536,9 @@ Processed event IDs are stored in a set (persisted to disk between restarts).
 ### Rate Limiting
 
 GitHub API rate limit: 5000 requests/hour for PAT.
-With 60s poll interval, ~4 base API calls per cycle, plus 2 per open PR (reviews + review comments):
-~240 base requests/hour + ~2400 for 20 open PRs = well within limits.
+With 60s poll interval, ~4 base API calls per cycle, plus 2 per open PR (reviews + review comments),
+plus 2 per open PR for CI polling (get_pr_head_sha + list_check_runs) when `poll_ci_status = true`:
+~240 base requests/hour + ~2400 for 20 open PRs (reviews) + ~2400 for CI polling = well within limits.
 
 ## Bot Identity
 

--- a/src/channels/github/client.rs
+++ b/src/channels/github/client.rs
@@ -120,6 +120,38 @@ pub struct GithubReviewComment {
     pub in_reply_to_id: Option<u64>,
 }
 
+/// GitHub check run (from /commits/{ref}/check-runs endpoint).
+#[derive(Debug, Clone, Deserialize)]
+pub struct GithubCheckRun {
+    pub id: u64,
+    pub name: String,
+    /// "queued", "in_progress", "completed"
+    pub status: String,
+    /// "success", "failure", "cancelled", "timed_out", etc. (None if not completed)
+    pub conclusion: Option<String>,
+    pub head_sha: String,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+}
+
+/// Response wrapper for the check runs API.
+#[derive(Debug, Deserialize)]
+pub struct GithubCheckRunsResponse {
+    pub total_count: u64,
+    pub check_runs: Vec<GithubCheckRun>,
+}
+
+/// Response wrapper for the PR detail API (minimal fields for head SHA).
+#[derive(Debug, Deserialize)]
+struct GithubPullRequestDetail {
+    head: GithubPullRequestHead,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubPullRequestHead {
+    sha: String,
+}
+
 impl GithubClient {
     /// Create a new GitHub API client.
     pub fn new(config: &GithubConfig) -> Result<Self> {
@@ -370,6 +402,81 @@ impl GithubClient {
 
         Ok(comment.id)
     }
+
+    /// Get the head SHA for a PR.
+    ///
+    /// Calls `GET /repos/{owner}/{repo}/pulls/{pr_number}` and extracts `head.sha`.
+    pub async fn get_pr_head_sha(&self, pr_number: u64) -> Result<String> {
+        let url = format!(
+            "{}/repos/{}/{}/pulls/{}",
+            self.api_url, self.owner, self.repo, pr_number
+        );
+
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context("Failed to fetch PR detail")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "GET PR detail failed: {} — {}",
+                status,
+                truncate_str(&body, 200)
+            );
+        }
+
+        let pr: GithubPullRequestDetail = resp
+            .json()
+            .await
+            .context("Failed to parse PR detail response")?;
+
+        Ok(pr.head.sha)
+    }
+
+    /// List check runs for a given commit ref.
+    ///
+    /// Calls `GET /repos/{owner}/{repo}/commits/{ref}/check-runs?per_page=100`.
+    pub async fn list_check_runs(&self, ref_sha: &str) -> Result<Vec<GithubCheckRun>> {
+        let url = format!(
+            "{}/repos/{}/{}/commits/{}/check-runs?per_page=100",
+            self.api_url, self.owner, self.repo, ref_sha
+        );
+
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context("Failed to fetch check runs")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "GET check runs failed: {} — {}",
+                status,
+                truncate_str(&body, 200)
+            );
+        }
+
+        let response: GithubCheckRunsResponse = resp
+            .json()
+            .await
+            .context("Failed to parse check runs response")?;
+
+        tracing::trace!(
+            ref_sha = %ref_sha,
+            total_count = response.total_count,
+            returned = response.check_runs.len(),
+            "Fetched check runs"
+        );
+
+        Ok(response.check_runs)
+    }
 }
 
 #[cfg(test)]
@@ -463,5 +570,40 @@ mod tests {
         assert_eq!(comment.path.as_deref(), Some("src/main.rs"));
         assert_eq!(comment.line, Some(42));
         assert!(comment.in_reply_to_id.is_none());
+    }
+
+    #[test]
+    fn test_check_run_deserialization() {
+        let json = r#"{
+            "id": 789,
+            "name": "CI",
+            "status": "completed",
+            "conclusion": "failure",
+            "head_sha": "abc123",
+            "started_at": "2026-04-15T10:00:00Z",
+            "completed_at": "2026-04-15T10:05:00Z"
+        }"#;
+        let check_run: GithubCheckRun = serde_json::from_str(json).unwrap();
+        assert_eq!(check_run.id, 789);
+        assert_eq!(check_run.name, "CI");
+        assert_eq!(check_run.status, "completed");
+        assert_eq!(check_run.conclusion.as_deref(), Some("failure"));
+        assert_eq!(check_run.head_sha, "abc123");
+    }
+
+    #[test]
+    fn test_check_run_deserialization_pending() {
+        let json = r#"{
+            "id": 790,
+            "name": "Lint",
+            "status": "in_progress",
+            "conclusion": null,
+            "head_sha": "def456",
+            "started_at": "2026-04-15T10:00:00Z",
+            "completed_at": null
+        }"#;
+        let check_run: GithubCheckRun = serde_json::from_str(json).unwrap();
+        assert_eq!(check_run.status, "in_progress");
+        assert!(check_run.conclusion.is_none());
     }
 }

--- a/src/channels/github/config.rs
+++ b/src/channels/github/config.rs
@@ -10,6 +10,10 @@ fn default_poll_interval() -> u64 {
     60
 }
 
+fn default_true() -> bool {
+    true
+}
+
 /// GitHub-specific configuration for a channel.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct GithubConfig {
@@ -30,6 +34,10 @@ pub struct GithubConfig {
     /// Polling interval in seconds (default: 60)
     #[serde(default = "default_poll_interval")]
     pub poll_interval_secs: u64,
+
+    /// Whether to poll CI check-run status on open PRs (default: true)
+    #[serde(default = "default_true")]
+    pub poll_ci_status: bool,
 }
 
 impl Default for GithubConfig {
@@ -40,6 +48,7 @@ impl Default for GithubConfig {
             token: String::new(),
             api_url: default_api_url(),
             poll_interval_secs: default_poll_interval(),
+            poll_ci_status: true,
         }
     }
 }
@@ -99,5 +108,30 @@ mod tests {
         assert_eq!(config.owner, "myorg");
         assert_eq!(config.repo, "myrepo");
         assert_eq!(config.api_url, "https://github.example.com/api/v3");
+    }
+
+    #[test]
+    fn test_config_deserialize_poll_ci_status_default() {
+        let toml_str = r#"
+            owner = "kingye"
+            repo = "jyc"
+            token = "ghp_test123"
+        "#;
+
+        let config: GithubConfig = toml::from_str(toml_str).unwrap();
+        assert!(config.poll_ci_status);
+    }
+
+    #[test]
+    fn test_config_deserialize_poll_ci_status_disabled() {
+        let toml_str = r#"
+            owner = "kingye"
+            repo = "jyc"
+            token = "ghp_test123"
+            poll_ci_status = false
+        "#;
+
+        let config: GithubConfig = toml::from_str(toml_str).unwrap();
+        assert!(!config.poll_ci_status);
     }
 }

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -2564,4 +2564,182 @@ mod tests {
         assert_ne!(key1, key2, "Same review ID with different submitted_at should be different keys");
         assert_ne!(key1, key3, "Review and review comment keys should be different");
     }
+
+    // --- CI status tracking tests ---
+
+    fn make_ci_test_config() -> GithubConfig {
+        GithubConfig {
+            owner: "test".to_string(),
+            repo: "test".to_string(),
+            token: "test".to_string(),
+            api_url: "https://api.github.com".to_string(),
+            poll_interval_secs: 60,
+            poll_ci_status: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_ci_status_load_and_track() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let config = make_ci_test_config();
+        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
+
+        let mut ci_status: HashMap<u64, (String, String)> = HashMap::new();
+
+        adapter.track_ci_status(42, "abc123", "pending", &mut ci_status).await;
+        adapter.track_ci_status(43, "def456", "failure", &mut ci_status).await;
+
+        assert_eq!(ci_status.len(), 2);
+        assert_eq!(ci_status.get(&42), Some(&("abc123".to_string(), "pending".to_string())));
+        assert_eq!(ci_status.get(&43), Some(&("def456".to_string(), "failure".to_string())));
+
+        let reloaded = adapter.load_ci_status().await;
+        assert_eq!(reloaded.len(), 2);
+        assert_eq!(reloaded.get(&42), Some(&("abc123".to_string(), "pending".to_string())));
+        assert_eq!(reloaded.get(&43), Some(&("def456".to_string(), "failure".to_string())));
+    }
+
+    #[tokio::test]
+    async fn test_ci_status_transition_triggers_message() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let config = make_ci_test_config();
+        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
+
+        let mut ci_status: HashMap<u64, (String, String)> = HashMap::new();
+
+        // PR 42 was previously tracked as "pending"
+        adapter.track_ci_status(42, "abc123", "pending", &mut ci_status).await;
+
+        // Simulate transition: same head_sha, status changes to "failure"
+        let (tracked_sha, previous_status) = ci_status.get(&42).cloned().unwrap();
+        assert_eq!(tracked_sha, "abc123");
+        assert_eq!(previous_status, "pending");
+
+        // The polling logic would detect: overall_status="failure" && previous_status != "failure"
+        // → trigger message. We test the state management part here.
+        let should_trigger = previous_status != "failure";
+        assert!(should_trigger, "Transition from pending to failure should trigger message");
+
+        // Update to failure
+        adapter.track_ci_status(42, "abc123", "failure", &mut ci_status).await;
+        assert_eq!(ci_status.get(&42), Some(&("abc123".to_string(), "failure".to_string())));
+    }
+
+    #[tokio::test]
+    async fn test_ci_status_no_retrigger_on_same_failure() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let config = make_ci_test_config();
+        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
+
+        let mut ci_status: HashMap<u64, (String, String)> = HashMap::new();
+
+        // PR 42 is already tracked as "failure"
+        adapter.track_ci_status(42, "abc123", "failure", &mut ci_status).await;
+
+        // On next poll, same failure status — should NOT re-trigger
+        let (_, previous_status) = ci_status.get(&42).cloned().unwrap();
+        let should_trigger = previous_status != "failure";
+        assert!(!should_trigger, "Same failure status should not re-trigger");
+    }
+
+    #[tokio::test]
+    async fn test_ci_status_resets_on_new_commit() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let config = make_ci_test_config();
+        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
+
+        let mut ci_status: HashMap<u64, (String, String)> = HashMap::new();
+
+        // PR 42 tracked with old head_sha in "failure" status
+        adapter.track_ci_status(42, "abc123", "failure", &mut ci_status).await;
+
+        // Developer pushes a fix — new head_sha
+        let new_head_sha = "def456";
+        let (tracked_sha, _) = ci_status.get(&42).cloned().unwrap();
+
+        // head_sha changed → tracking should reset
+        let should_reset = tracked_sha != new_head_sha;
+        assert!(should_reset, "New commit should reset CI status tracking");
+
+        // After reset, previous_status would be None → transition to any status triggers
+        // Simulate: new commit's CI is still pending
+        adapter.track_ci_status(42, new_head_sha, "pending", &mut ci_status).await;
+        assert_eq!(
+            ci_status.get(&42),
+            Some(&("def456".to_string(), "pending".to_string()))
+        );
+
+        // Now CI fails on new commit → should trigger (because we reset)
+        let (_, previous_status) = ci_status.get(&42).cloned().unwrap();
+        let should_trigger = previous_status != "failure";
+        assert!(should_trigger, "Failure on new commit should trigger after reset");
+    }
+
+    #[tokio::test]
+    async fn test_ci_status_empty_load() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let config = make_ci_test_config();
+        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
+
+        let ci_status = adapter.load_ci_status().await;
+        assert!(ci_status.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_ci_status_compact() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let config = make_ci_test_config();
+        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
+
+        let mut ci_status: HashMap<u64, (String, String)> = HashMap::new();
+
+        // Add entries
+        for i in 1..=100u64 {
+            adapter
+                .track_ci_status(i, &format!("sha{}", i), "success", &mut ci_status)
+                .await;
+        }
+
+        assert_eq!(ci_status.len(), 100);
+
+        // Compact should rewrite the file (no size reduction since under threshold)
+        adapter.compact_ci_status(&mut ci_status).await;
+        assert_eq!(ci_status.len(), 100);
+
+        // Verify persistence
+        let reloaded = adapter.load_ci_status().await;
+        assert_eq!(reloaded.len(), 100);
+    }
+
+    #[test]
+    fn test_ci_failure_message_routing() {
+        // CI failure messages with github_type=pull_request should route to pr-{N}
+        let mut msg = make_message("pull_request", 43);
+        msg.metadata.insert(
+            "github_event".to_string(),
+            serde_json::Value::String("check_run".to_string()),
+        );
+        msg.metadata.insert(
+            "github_action".to_string(),
+            serde_json::Value::String("completed".to_string()),
+        );
+
+        let name = GithubMatcher.derive_thread_name(&msg, &[], None);
+        assert_eq!(name, "pr-43");
+
+        // CI failure with developer pattern match should also route to pr-{N}
+        let pm = PatternMatch {
+            pattern_name: "developer".to_string(),
+            channel: "github".to_string(),
+            matches: HashMap::new(),
+        };
+        let name_with_pattern = GithubMatcher.derive_thread_name(&msg, &[], Some(&pm));
+        assert_eq!(name_with_pattern, "pr-43");
+    }
 }

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -1638,6 +1638,7 @@ mod tests {
             token: "test".to_string(),
             api_url: "https://api.github.com".to_string(),
             poll_interval_secs: 60,
+            poll_ci_status: true,
         };
         let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
         tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
@@ -1655,6 +1656,7 @@ mod tests {
             token: "test".to_string(),
             api_url: "https://api.github.com".to_string(),
             poll_interval_secs: 60,
+            poll_ci_status: true,
         };
         let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
         tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
@@ -1686,6 +1688,7 @@ mod tests {
             token: "test".to_string(),
             api_url: "https://api.github.com".to_string(),
             poll_interval_secs: 60,
+            poll_ci_status: true,
         };
         let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
         tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
@@ -1717,6 +1720,7 @@ mod tests {
             token: "test".to_string(),
             api_url: "https://api.github.com".to_string(),
             poll_interval_secs: 60,
+            poll_ci_status: true,
         };
         let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
         tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
@@ -1752,6 +1756,7 @@ mod tests {
             token: "test".to_string(),
             api_url: "https://api.github.com".to_string(),
             poll_interval_secs: 60,
+            poll_ci_status: true,
         };
         let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
         tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
@@ -1774,6 +1779,7 @@ mod tests {
             token: "test".to_string(),
             api_url: "https://api.github.com".to_string(),
             poll_interval_secs: 60,
+            poll_ci_status: true,
         };
         let tmpdir = tempfile::tempdir().unwrap();
         let adapter = GithubInboundAdapter::new(&config, "test_github".to_string(), tmpdir.path());
@@ -1812,6 +1818,7 @@ mod tests {
             token: "test".to_string(),
             api_url: "https://api.github.com".to_string(),
             poll_interval_secs: 60,
+            poll_ci_status: true,
         };
         let tmpdir = tempfile::tempdir().unwrap();
         let adapter = GithubInboundAdapter::new(&config, "test_github".to_string(), tmpdir.path());

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -428,22 +428,14 @@ impl GithubInboundAdapter {
         status: &str,
         tracked: &mut HashMap<u64, (String, String)>,
     ) {
+        let changed = tracked
+            .get(&pr_number)
+            .map(|(sha, s)| sha != head_sha || s != status)
+            .unwrap_or(true);
+
         tracked.insert(pr_number, (head_sha.to_string(), status.to_string()));
 
-        let file = self.state_dir.join("ci-status.txt");
-        use tokio::io::AsyncWriteExt;
-        if let Ok(mut f) = tokio::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&file)
-            .await
-        {
-            let _ = f
-                .write_all(format!("{}:{}:{}\n", pr_number, head_sha, status).as_bytes())
-                .await;
-        }
-
-        if tracked.len() > 5000 {
+        if changed {
             self.compact_ci_status(tracked).await;
         }
     }
@@ -1135,7 +1127,7 @@ impl GithubInboundAdapter {
 
                 let has_failure = check_runs
                     .iter()
-                    .any(|cr| cr.conclusion.as_deref() == Some("failure"));
+                    .any(|cr| cr.conclusion.as_deref() == Some("failure") || cr.conclusion.as_deref() == Some("timed_out"));
                 let all_completed = check_runs
                     .iter()
                     .all(|cr| cr.status == "completed");
@@ -1168,7 +1160,7 @@ impl GithubInboundAdapter {
                 if overall_status == "failure" && previous_status.as_deref() != Some("failure") {
                     let failed_checks: Vec<&super::client::GithubCheckRun> = check_runs
                         .iter()
-                        .filter(|cr| cr.conclusion.as_deref() == Some("failure"))
+                        .filter(|cr| cr.conclusion.as_deref() == Some("failure") || cr.conclusion.as_deref() == Some("timed_out"))
                         .collect();
 
                     let (title, github_type, labels, assignees) = issue_cache
@@ -1183,7 +1175,7 @@ impl GithubInboundAdapter {
                             )
                         });
 
-                    let event_uid = format!("ci-{}-{}-failure", pr_number, &head_sha[..8]);
+                    let event_uid = format!("ci-{}-{}-failure", pr_number, head_sha.get(..12).unwrap_or(&head_sha));
 
                     let mut message = self.build_trigger_message(
                         "check_run",
@@ -1229,7 +1221,7 @@ impl GithubInboundAdapter {
 
                     let ci_section = format!(
                         "\n\n---\nCI check-run failure detected on commit {}:\n\n{}\n\nDiagnose:\n  gh pr checks {}",
-                        &head_sha[..8],
+                        head_sha.get(..8).unwrap_or(&head_sha),
                         failed_names.join("\n"),
                         pr_number
                     );
@@ -1242,7 +1234,7 @@ impl GithubInboundAdapter {
                         channel = %self.channel_name,
                         event = "ci_failure",
                         pr_number = pr_number,
-                        head_sha = %&head_sha[..8],
+                        head_sha = %head_sha.get(..8).unwrap_or(&head_sha),
                         failed_count = failed_checks.len(),
                         "CI failure detected → routing to developer agent"
                     );
@@ -2741,5 +2733,69 @@ mod tests {
         };
         let name_with_pattern = GithubMatcher.derive_thread_name(&msg, &[], Some(&pm));
         assert_eq!(name_with_pattern, "pr-43");
+    }
+
+    #[tokio::test]
+    async fn test_ci_status_no_file_growth_on_unchanged() {
+        let tmpdir = tempfile::tempdir().unwrap();
+        let config = make_ci_test_config();
+        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
+
+        let mut ci_status: HashMap<u64, (String, String)> = HashMap::new();
+
+        adapter.track_ci_status(42, "abc123", "failure", &mut ci_status).await;
+        let file = adapter.state_dir.join("ci-status.txt");
+        let lines_after_first = tokio::fs::read_to_string(&file).await.unwrap().lines().count();
+
+        // Track same entry again — file should be rewritten (same content), not grow
+        adapter.track_ci_status(42, "abc123", "failure", &mut ci_status).await;
+        let lines_after_second = tokio::fs::read_to_string(&file).await.unwrap().lines().count();
+
+        assert_eq!(lines_after_first, lines_after_second, "File should not grow when status is unchanged");
+    }
+
+    #[test]
+    fn test_ci_timed_out_triggers_failure() {
+        let check_runs = vec![
+            super::super::client::GithubCheckRun {
+                id: 1,
+                name: "CI".to_string(),
+                status: "completed".to_string(),
+                conclusion: Some("timed_out".to_string()),
+                head_sha: "abc123def456".to_string(),
+                started_at: None,
+                completed_at: None,
+            },
+        ];
+
+        let has_failure = check_runs
+            .iter()
+            .any(|cr| cr.conclusion.as_deref() == Some("failure") || cr.conclusion.as_deref() == Some("timed_out"));
+
+        assert!(has_failure, "timed_out should be treated as failure");
+
+        let failed_checks: Vec<_> = check_runs
+            .iter()
+            .filter(|cr| cr.conclusion.as_deref() == Some("failure") || cr.conclusion.as_deref() == Some("timed_out"))
+            .collect();
+
+        assert_eq!(failed_checks.len(), 1);
+        assert_eq!(failed_checks[0].name, "CI");
+    }
+
+    #[test]
+    fn test_safe_head_sha_truncation() {
+        let short_sha = "abc".to_string();
+        let result = short_sha.get(..8).unwrap_or(&short_sha);
+        assert_eq!(result, "abc");
+
+        let normal_sha = "abc123def456".to_string();
+        let result2 = normal_sha.get(..8).unwrap_or(&normal_sha);
+        assert_eq!(result2, "abc123de");
+
+        let empty_sha = "".to_string();
+        let result3 = empty_sha.get(..8).unwrap_or(&empty_sha);
+        assert_eq!(result3, "");
     }
 }

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -378,6 +378,88 @@ impl GithubInboundAdapter {
         }
     }
 
+    /// Load CI status tracking from persistent storage.
+    /// File format: `{pr_number}:{head_sha}:{overall_status}` per line.
+    /// Returns map of pr_number → (head_sha, overall_status).
+    async fn load_ci_status(&self) -> HashMap<u64, (String, String)> {
+        let file = self.state_dir.join("ci-status.txt");
+        if !file.exists() {
+            return HashMap::new();
+        }
+        match tokio::fs::read_to_string(&file).await {
+            Ok(content) => {
+                let map: HashMap<u64, (String, String)> = content
+                    .lines()
+                    .filter_map(|line| {
+                        let line = line.trim();
+                        if line.is_empty() {
+                            return None;
+                        }
+                        let mut parts = line.splitn(3, ':');
+                        let number: u64 = parts.next()?.parse().ok()?;
+                        let head_sha = parts.next()?.to_string();
+                        let status = parts.next()?.to_string();
+                        Some((number, (head_sha, status)))
+                    })
+                    .collect();
+                tracing::debug!(
+                    channel = %self.channel_name,
+                    count = map.len(),
+                    "Loaded CI status tracking"
+                );
+                map
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "Failed to load CI status, starting fresh"
+                );
+                HashMap::new()
+            }
+        }
+    }
+
+    /// Track CI status for a PR (append to file).
+    /// Key format: `{pr_number}:{head_sha}:{overall_status}`
+    async fn track_ci_status(
+        &self,
+        pr_number: u64,
+        head_sha: &str,
+        status: &str,
+        tracked: &mut HashMap<u64, (String, String)>,
+    ) {
+        tracked.insert(pr_number, (head_sha.to_string(), status.to_string()));
+
+        let file = self.state_dir.join("ci-status.txt");
+        use tokio::io::AsyncWriteExt;
+        if let Ok(mut f) = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&file)
+            .await
+        {
+            let _ = f
+                .write_all(format!("{}:{}:{}\n", pr_number, head_sha, status).as_bytes())
+                .await;
+        }
+
+        if tracked.len() > 5000 {
+            self.compact_ci_status(tracked).await;
+        }
+    }
+
+    /// Rewrite CI status file from in-memory map.
+    async fn compact_ci_status(&self, tracked: &mut HashMap<u64, (String, String)>) {
+        let file = self.state_dir.join("ci-status.txt");
+        let content: String = tracked
+            .iter()
+            .map(|(number, (sha, status))| format!("{}:{}:{}\n", number, sha, status))
+            .collect();
+        if let Err(e) = tokio::fs::write(&file, content).await {
+            tracing::warn!(error = %e, "Failed to compact CI status file");
+        }
+    }
+
     /// Build a minimal InboundMessage from a GitHub event.
     /// Contains only trigger metadata — agent uses `gh` CLI for actual content.
     fn build_trigger_message(

--- a/src/channels/github/inbound.rs
+++ b/src/channels/github/inbound.rs
@@ -607,6 +607,9 @@ impl InboundAdapter for GithubInboundAdapter {
         // Cache issue info for comment routing (number → title, type, labels, assignees)
         let mut issue_cache: HashMap<u64, (String, String, Vec<String>, Vec<String>)> = HashMap::new();
 
+        // Load CI status tracking for check-run polling
+        let mut ci_status: HashMap<u64, (String, String)> = self.load_ci_status().await;
+
         // Determine poll start time:
         // - Fresh start (no processed-comments.txt): start from "now" to avoid
         //   replaying old comments that already have @j:<role> mentions.
@@ -650,6 +653,7 @@ impl InboundAdapter for GithubInboundAdapter {
                         &mut seen_issues,
                         &mut issue_cache,
                         &mut last_poll,
+                        &mut ci_status,
                     ).await {
                         tracing::error!(
                             channel = %self.channel_name,
@@ -679,6 +683,7 @@ impl GithubInboundAdapter {
         seen_issues: &mut HashSet<String>,
         issue_cache: &mut HashMap<u64, (String, String, Vec<String>, Vec<String>)>, // number → (title, type, labels, assignees)
         last_poll: &mut String,
+        ci_status: &mut HashMap<u64, (String, String)>, // pr_number → (head_sha, overall_status)
     ) -> Result<()> {
         let poll_start = last_poll.clone();
 
@@ -1096,6 +1101,159 @@ impl GithubInboundAdapter {
                         "Failed to fetch review comments for PR"
                     );
                 }
+            }
+        }
+
+        // 2c. Poll CI check-run status for open PRs (if enabled).
+        if self.config.poll_ci_status {
+            for pr_number in &open_pr_numbers {
+                let head_sha = match client.get_pr_head_sha(*pr_number).await {
+                    Ok(sha) => sha,
+                    Err(e) => {
+                        tracing::warn!(
+                            channel = %self.channel_name,
+                            pr_number = pr_number,
+                            error = %e,
+                            "Failed to get PR head SHA for CI polling"
+                        );
+                        continue;
+                    }
+                };
+
+                let check_runs = match client.list_check_runs(&head_sha).await {
+                    Ok(runs) => runs,
+                    Err(e) => {
+                        tracing::warn!(
+                            channel = %self.channel_name,
+                            pr_number = pr_number,
+                            error = %e,
+                            "Failed to list check runs for CI polling"
+                        );
+                        continue;
+                    }
+                };
+
+                let has_failure = check_runs
+                    .iter()
+                    .any(|cr| cr.conclusion.as_deref() == Some("failure"));
+                let all_completed = check_runs
+                    .iter()
+                    .all(|cr| cr.status == "completed");
+
+                let overall_status = if has_failure {
+                    "failure"
+                } else if !all_completed {
+                    "pending"
+                } else {
+                    "success"
+                };
+
+                let tracked_status = ci_status
+                    .get(pr_number)
+                    .map(|(sha, status)| (sha.clone(), status.clone()));
+
+                // Reset tracking if head_sha changed (new commit pushed)
+                let should_reset = tracked_status
+                    .as_ref()
+                    .map(|(tracked_sha, _)| tracked_sha != &head_sha)
+                    .unwrap_or(true);
+
+                let previous_status = if should_reset {
+                    None
+                } else {
+                    tracked_status.as_ref().map(|(_, s)| s.clone())
+                };
+
+                // Only trigger on transition TO "failure"
+                if overall_status == "failure" && previous_status.as_deref() != Some("failure") {
+                    let failed_checks: Vec<&super::client::GithubCheckRun> = check_runs
+                        .iter()
+                        .filter(|cr| cr.conclusion.as_deref() == Some("failure"))
+                        .collect();
+
+                    let (title, github_type, labels, assignees) = issue_cache
+                        .get(pr_number)
+                        .cloned()
+                        .unwrap_or_else(|| {
+                            (
+                                format!("#{}", pr_number),
+                                "pull_request".to_string(),
+                                vec![],
+                                vec![],
+                            )
+                        });
+
+                    let event_uid = format!("ci-{}-{}-failure", pr_number, &head_sha[..8]);
+
+                    let mut message = self.build_trigger_message(
+                        "check_run",
+                        *pr_number,
+                        &title,
+                        &github_type,
+                        "completed",
+                        "github-actions",
+                        &labels,
+                        &assignees,
+                        &event_uid,
+                    );
+
+                    message.metadata.insert(
+                        "ci_head_sha".to_string(),
+                        serde_json::Value::String(head_sha.clone()),
+                    );
+
+                    let failed_checks_json: Vec<serde_json::Value> = failed_checks
+                        .iter()
+                        .map(|cr| {
+                            serde_json::json!({
+                                "name": cr.name,
+                                "conclusion": cr.conclusion.clone().unwrap_or_default(),
+                            })
+                        })
+                        .collect();
+                    message.metadata.insert(
+                        "ci_failed_checks".to_string(),
+                        serde_json::Value::Array(failed_checks_json),
+                    );
+
+                    let failed_names: Vec<String> = failed_checks
+                        .iter()
+                        .map(|cr| {
+                            format!(
+                                "- {} ({})",
+                                cr.name,
+                                cr.conclusion.as_deref().unwrap_or("unknown")
+                            )
+                        })
+                        .collect();
+
+                    let ci_section = format!(
+                        "\n\n---\nCI check-run failure detected on commit {}:\n\n{}\n\nDiagnose:\n  gh pr checks {}",
+                        &head_sha[..8],
+                        failed_names.join("\n"),
+                        pr_number
+                    );
+                    match &mut message.content.text {
+                        Some(text) => text.push_str(&ci_section),
+                        None => message.content.text = Some(ci_section),
+                    }
+
+                    tracing::info!(
+                        channel = %self.channel_name,
+                        event = "ci_failure",
+                        pr_number = pr_number,
+                        head_sha = %&head_sha[..8],
+                        failed_count = failed_checks.len(),
+                        "CI failure detected → routing to developer agent"
+                    );
+
+                    if let Err(e) = (options.on_message)(message) {
+                        tracing::error!(error = %e, pr_number = pr_number, "Failed to route CI failure event");
+                    }
+                }
+
+                self.track_ci_status(*pr_number, &head_sha, overall_status, ci_status)
+                    .await;
             }
         }
 

--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -92,6 +92,7 @@ Read the triggering comment at the bottom of the incoming message.
 
 1. **Analyze the task**: Determine what the comment asks for
    - If it's implementing the full implementation plan → treat as planner task
+   - If `github_event: "check_run"` → CI failure on the PR → fix the failing checks
    - Otherwise → treat as specific task (fix, add comments, refactor, etc.)
 
 2. **Execute the task**:
@@ -156,6 +157,19 @@ Read the triggering comment at the bottom of the incoming message.
 
 - **After full plan**: Hand off → add `ready-for-review` label + `gh pr ready`
 - **After reviewer feedback fix**: Hand off → add `ready-for-review` label (reviewer needs the label to be re-triggered)
+- **After CI failure fix**: Hand off → add `ready-for-review` label + `gh pr ready`
+
+## CI Failure Handling
+
+When `github_event: "check_run"` appears in the triggering message, CI checks have failed on the PR.
+
+1. **Read the failing checks**: The message body lists which checks failed and their conclusions. The `ci_failed_checks` metadata contains a JSON array of `{name, conclusion}` objects. The `ci_head_sha` metadata contains the failing commit SHA.
+
+2. **Diagnose**: Run `gh pr checks <number>` to see the current status of all checks.
+
+3. **Fix**: Checkout the PR branch, fix the failing tests/lint issues, commit, push.
+
+4. **Hand off to Reviewer**: After pushing fixes, hand off to reviewer as usual.
 
 ## Rules
 - **#1 RULE: Do what the triggering comment says.** This overrides everything else.


### PR DESCRIPTION
## Spec

Add CI check-run polling to the GitHub inbound adapter so that when CI fails on a PR, the developer agent is automatically triggered to fix the issue — eliminating the need for manual user comments.

Fixes #144

## Implementation Plan

### Step 1: Add `poll_ci_status` config field to `GithubConfig`
**What:** Add `pub poll_ci_status: bool` field with default `true` to `src/channels/github/config.rs`. Use `serde(default = "default_true")` for backward compatibility. Add deserialization test.
**Why:** Makes CI polling opt-out without breaking existing configs.
**Verify:** `cargo check` passes. Existing tests pass.

### Step 2: Add `GithubCheckRun` struct and `list_check_runs()` method to `GithubClient`
**What:** In `src/channels/github/client.rs`, add:
- `GithubCheckRun` struct with fields: `id: u64`, `name: String`, `status: String` (queued/in_progress/completed), `conclusion: Option<String>` (success/failure/cancelled/timed_out/...), `head_sha: String`, `started_at: Option<String>`, `completed_at: Option<String>`
- `GithubCheckRunsResponse` struct (wrapping `total_count` + `check_runs`)
- `async fn list_check_runs(&self, ref_sha: &str) -> Result<Vec<GithubCheckRun>>` — calls `GET /repos/{owner}/{repo}/commits/{ref}/check-runs?per_page=100`
- `async fn get_pr_head_sha(&self, pr_number: u64) -> Result<String>` — calls `GET /repos/{owner}/{repo}/pulls/{pr_number}` and extracts `head.sha`
**Why:** The `/issues` endpoint doesn't return PR head SHA. Need the `/pulls/{n}` endpoint for that. The Check Runs API needs a commit SHA as the ref parameter.
**Verify:** `cargo check` passes. Add unit test for `GithubCheckRun` deserialization.

### Step 3: Add CI status tracking persistence methods to `GithubInboundAdapter`
**What:** In `src/channels/github/inbound.rs`, add:
- `async fn load_ci_status(&self) -> HashMap<u64, (String, String)>` — loads from `<state_dir>/ci-status.txt`. Format: `{pr_number}:{head_sha}:{overall_status}` per line. Returns map of pr_number → (head_sha, overall_status).
- `async fn track_ci_status(&self, pr_number: u64, head_sha: &str, status: &str, tracked: &mut HashMap<u64, (String, String)>)` — appends/updates entry, persists to file
- `async fn compact_ci_status(&self, tracked: &mut HashMap<u64, (String, String)>)` — same compaction pattern as existing `compact_processed_comments`
**Why:** Need persistent CI state tracking across restarts to detect status transitions (not just current status) and avoid re-triggering on already-known failures.
**Verify:** `cargo check` passes.

### Step 4: Add CI polling logic in `poll_once()`
**What:** In `src/channels/github/inbound.rs`, after the review comment processing block (after the `for pr_number in &open_pr_numbers` loop), add a new block gated by `self.config.poll_ci_status`:
- Load `ci_status` from persistent storage (add `ci_status: HashMap<u64, (String, String)>` as a parameter to `poll_once`)
- For each open PR, call `client.get_pr_head_sha(*pr_number)` then `client.list_check_runs(&head_sha)`
- Compute `overall_status`: if any check has `conclusion: "failure"` → "failure"; if any check has `status` not "completed" → "pending"; else "success"
- Compare with tracked status: only trigger if overall_status transitions TO "failure" (i.e., previously was "success"/"pending"/absent, now is "failure")
- On transition to failure: build `InboundMessage` with `github_event: "check_run"`, `github_action: "completed"`, include failing check names in metadata (`ci_failed_checks`) and in message body. Dedup key: `ci-{pr_number}-{head_sha}-failure`
- Update `ci_status` tracking with new status
- Persist updated ci_status to file
**Why:** This is the core feature — detecting CI failures and routing them to the developer agent. Transition-based triggering avoids re-notifying on already-known failures.
**Verify:** `cargo check` passes. `cargo test` passes. Manual test: push a commit that fails CI, verify developer agent is triggered.

### Step 5: Add `ci_status` map to `start()` and pass to `poll_once()`
**What:** In `src/channels/github/inbound.rs`, in the `start()` method:
- Add `let mut ci_status: HashMap<u64, (String, String)> = self.load_ci_status().await;` after loading `seen_issues`
- Pass `&mut ci_status` to `self.poll_once(...)` call
- Update `poll_once()` signature to accept the new parameter
**Why:** Wire up the CI status tracking into the polling lifecycle.
**Verify:** `cargo check` passes. `cargo test` passes.

### Step 6: Update `build_trigger_message` and add CI-specific message formatting
**What:** In `src/channels/github/inbound.rs`, in the CI polling block (Step 4), when building the trigger message for a CI failure:
- Use `self.build_trigger_message("check_run", pr_number, &title, "pull_request", "completed", "github-actions", &labels, &assignees, &event_uid)`
- Add metadata: `ci_failed_checks` (JSON array of `{name, conclusion}` objects), `ci_head_sha` (the failing commit SHA)
- Append to message body: formatted list of failing checks with their conclusions, and the head_sha prefix
- Add `gh pr checks <number>` command suggestion
**Why:** The developer agent needs to know which specific checks failed and the commit SHA to diagnose the issue.
**Verify:** `cargo check` passes.

### Step 7: Update developer agent template to handle CI events
**What:** In `templates/github-developer/AGENTS.md`, add a new section after "### 3. Do What The Triggering Comment Says":
- Add CI handling: when `github_event: "check_run"`, read the failed checks from the message, checkout the PR, fix the failing tests/lint issues, commit, push, hand off to reviewer
- Add `gh pr checks <number>` as a useful command for diagnosing CI failures
**Why:** The developer agent needs instructions on how to respond to CI failure triggers.
**Verify:** Template file is syntactically correct (no Rust verification needed — it's a markdown template).

### Step 8: Update GITHUB_CHANNEL.md documentation
**What:** In `GITHUB_CHANNEL.md`:
- Add `check_run` / `ci_failure` to the Event → Thread Routing table
- Add `pr.ci_failure` row: routes to `pr-{N}` thread, triggers developer agent
- Document the CI polling behavior in the Polling Strategy section
- Add `poll_ci_status` config field documentation
**Why:** Keep documentation in sync with the implementation.
**Verify:** No code verification needed — documentation only.

### Step 9: Add integration tests
**What:** In `src/channels/github/inbound.rs`, add tests:
- `test_ci_status_transition_triggers_message`: mock a PR going from "pending" to "failure" → verify InboundMessage is generated
- `test_ci_status_no_retrigger_on_same_failure`: mock a PR already in "failure" status → verify no new message
- `test_ci_status_resets_on_new_commit`: mock a PR with new head_sha → verify status tracking resets
- `test_check_run_deserialization`: test `GithubCheckRun` struct parsing in `client.rs`
**Why:** Ensure CI polling logic is correct and doesn't cause infinite re-triggering.
**Verify:** `cargo test` passes with all new tests.

## Design Decisions
- **Check Runs API** over Statuses API: modern, covers GitHub Actions and all CI integrations
- **Transition-based triggering**: only notify on status change to "failure", not on every poll if still failing
- **Per-PR head_sha tracking**: when developer pushes a fix (new commit), head_sha changes → CI status tracking resets → no stale failure notifications
- **`poll_ci_status: bool` default true**: opt-out rather than opt-in since CI polling is broadly useful
- **`actor: "github-actions"`**: CI events come from the CI system, not a human — this ensures they pass through self-loop prevention (no `[Developer]` prefix)
- **Rate limit**: +1 API call per open PR per cycle (get_pr_head_sha could be batched later if needed)