### PR TITLE
feat: close session and kill LSP after worker idle

### DIFF
--- a/src/cli/monitor.rs
+++ b/src/cli/monitor.rs
@@ -542,12 +542,16 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
     };
 
     // 6. Start idle shutdown monitor (auto-stop OpenCode server when idle)
+    let idle_enabled = config_snapshot.agent.opencode.as_ref()
+        .map(|oc| oc.idle_shutdown_enabled)
+        .unwrap_or(true);
+
     let idle_timeout = config_snapshot.agent.opencode.as_ref()
         .and_then(|oc| oc.idle_shutdown_timeout_secs)
         .map(std::time::Duration::from_secs)
         .unwrap_or(OPENCODE_IDLE_SHUTDOWN_TIMEOUT);
 
-    let idle_monitor_task = {
+    let idle_monitor_task = if idle_enabled {
         let idle_tms = thread_managers_for_idle;
         let idle_server: Arc<dyn IdleStopServer> = opencode_server.clone();
         let idle_cancel = cancel.clone();
@@ -577,6 +581,9 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                 idle_cancel,
             ).await;
         }))
+    } else {
+        tracing::info!("Idle shutdown monitor disabled (idle_shutdown_enabled = false)");
+        None
     };
 
     tracing::info!(

--- a/src/cli/monitor.rs
+++ b/src/cli/monitor.rs
@@ -64,26 +64,17 @@ pub async fn run_idle_monitor(
                 let total_active = active_count();
 
                 if total_active == 0 {
-                    match idle_since {
-                        None => {
-                            idle_since = Some(std::time::Instant::now());
-                            tracing::info!(
-                                "All workers idle — idle timer started"
-                            );
-                        }
-                        Some(since) => {
-                            let elapsed = since.elapsed();
-                            if elapsed >= idle_timeout {
-                                tracing::info!(
-                                    elapsed_secs = elapsed.as_secs(),
-                                    timeout_secs = idle_timeout.as_secs(),
-                                    "Idle timeout reached — stopping OpenCode server"
-                                );
-                                on_stop_server.stop_server().await;
-                                tracing::info!("OpenCode server stopped due to idle timeout");
-                                idle_since = None;
-                            }
-                        }
+                    let since = idle_since.get_or_insert(std::time::Instant::now());
+                    let elapsed = since.elapsed();
+                    if elapsed >= idle_timeout {
+                        tracing::info!(
+                            elapsed_secs = elapsed.as_secs(),
+                            timeout_secs = idle_timeout.as_secs(),
+                            "Idle timeout reached — stopping OpenCode server"
+                        );
+                        on_stop_server.stop_server().await;
+                        tracing::info!("OpenCode server stopped due to idle timeout");
+                        idle_since = None;
                     }
                 } else if idle_since.is_some() {
                     tracing::info!(
@@ -556,14 +547,20 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
         .map(std::time::Duration::from_secs)
         .unwrap_or(OPENCODE_IDLE_SHUTDOWN_TIMEOUT);
 
-    let idle_monitor_task = if !idle_timeout.is_zero() {
+    let idle_monitor_task = {
         let idle_tms = thread_managers_for_idle;
         let idle_server: Arc<dyn IdleStopServer> = opencode_server.clone();
         let idle_cancel = cancel.clone();
 
+        let check_interval = if idle_timeout.as_secs() <= 10 {
+            std::time::Duration::from_secs(5)
+        } else {
+            OPENCODE_IDLE_CHECK_INTERVAL
+        };
+
         tracing::info!(
             timeout_secs = idle_timeout.as_secs(),
-            check_interval_secs = OPENCODE_IDLE_CHECK_INTERVAL.as_secs(),
+            check_interval_secs = check_interval.as_secs(),
             "Idle shutdown monitor enabled"
         );
 
@@ -576,13 +573,10 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                 active_count,
                 idle_server,
                 idle_timeout,
-                OPENCODE_IDLE_CHECK_INTERVAL,
+                check_interval,
                 idle_cancel,
             ).await;
         }))
-    } else {
-        tracing::info!("Idle shutdown monitor disabled (timeout = 0)");
-        None
     };
 
     tracing::info!(

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -229,6 +229,12 @@ pub struct OpenCodeConfig {
     /// Defaults to 0 (immediate shutdown) when None. Set to `None` explicitly
     /// in config (via omitting or using a sentinel) to disable idle shutdown.
     pub idle_shutdown_timeout_secs: Option<u64>,
+
+    /// Kill LSP server processes after each prompt completes to free memory.
+    /// Default is `false` (no behavior change). When `true`, LSP processes
+    /// are killed after each prompt completes.
+    #[serde(default)]
+    pub kill_lsp_after_prompt: Option<bool>,
 }
 
 /// Inspect server configuration — exposes runtime state via TCP for the dashboard.

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -225,9 +225,15 @@ pub struct OpenCodeConfig {
     /// If not set, uses 95% of the model's context window, or 120K as fallback.
     pub max_input_tokens: Option<u64>,
 
+    /// Whether idle shutdown is enabled. Defaults to `true` (the idle monitor
+    /// will auto-stop the OpenCode server when all workers are idle).
+    /// Set to `false` to disable idle shutdown entirely.
+    #[serde(default = "default_true")]
+    pub idle_shutdown_enabled: bool,
+
     /// Idle timeout in seconds before auto-shutting down the OpenCode server.
-    /// Defaults to 0 (immediate shutdown) when None. Set to `None` explicitly
-    /// in config (via omitting or using a sentinel) to disable idle shutdown.
+    /// Defaults to 0 (immediate shutdown) when None. Only effective when
+    /// `idle_shutdown_enabled` is `true`.
     pub idle_shutdown_timeout_secs: Option<u64>,
 
     /// Kill LSP server processes after each prompt completes to free memory.

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -226,7 +226,8 @@ pub struct OpenCodeConfig {
     pub max_input_tokens: Option<u64>,
 
     /// Idle timeout in seconds before auto-shutting down the OpenCode server.
-    /// Set to 0 to disable. Defaults to 60 (1 minute) when None.
+    /// Defaults to 0 (immediate shutdown) when None. Set to `None` explicitly
+    /// in config (via omitting or using a sentinel) to disable idle shutdown.
     pub idle_shutdown_timeout_secs: Option<u64>,
 }
 

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -289,6 +289,19 @@ pub fn validate_config(config: &AppConfig) -> Vec<ValidationError> {
         }
     }
 
+    // OpenCode config
+    if let Some(ref opencode) = config.agent.opencode {
+        if opencode.kill_lsp_after_prompt.unwrap_or(false)
+            && opencode.idle_shutdown_timeout_secs.map_or(true, |s| s == 0)
+        {
+            tracing::warn!(
+                "kill_lsp_after_prompt = true with idle_shutdown_timeout_secs = 0 (immediate idle \
+                 shutdown) is redundant — idle shutdown already kills all LSP processes. \
+                 Consider removing kill_lsp_after_prompt."
+            );
+        }
+    }
+
     errors
 }
 fn validate_pattern(

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -292,13 +292,16 @@ pub fn validate_config(config: &AppConfig) -> Vec<ValidationError> {
     // OpenCode config
     if let Some(ref opencode) = config.agent.opencode {
         if opencode.kill_lsp_after_prompt.unwrap_or(false)
+            && opencode.idle_shutdown_enabled
             && opencode.idle_shutdown_timeout_secs.map_or(true, |s| s == 0)
         {
-            tracing::warn!(
-                "kill_lsp_after_prompt = true with idle_shutdown_timeout_secs = 0 (immediate idle \
-                 shutdown) is redundant — idle shutdown already kills all LSP processes. \
-                 Consider removing kill_lsp_after_prompt."
-            );
+            errors.push(ValidationError {
+                path: "agent.opencode.kill_lsp_after_prompt".into(),
+                message: "redundant with idle_shutdown_timeout_secs = 0 (immediate idle \
+                          shutdown already kills all LSP processes). Consider removing \
+                          kill_lsp_after_prompt."
+                    .into(),
+            });
         }
     }
 

--- a/src/services/opencode/client.rs
+++ b/src/services/opencode/client.rs
@@ -216,6 +216,30 @@ impl OpenCodeClient {
         Ok(providers)
     }
 
+    /// Get LSP server status for a project directory.
+    pub async fn get_lsp_status(&self, directory: &Path) -> Result<Vec<LspStatus>> {
+        let url = format!("{}/lsp", self.base_url);
+        let (hdr_name, hdr_val) = Self::directory_header(directory);
+
+        let resp = self
+            .http
+            .get(&url)
+            .header(hdr_name, &hdr_val)
+            .timeout(OPENCODE_HEALTH_CHECK_TIMEOUT)
+            .send()
+            .await
+            .context("get_lsp_status request failed")?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("get_lsp_status failed ({}): {}", status, body);
+        }
+
+        let lsp_status: Vec<LspStatus> = resp.json().await.context("parse lsp status response")?;
+        Ok(lsp_status)
+    }
+
     /// Look up the context window limit for a specific model.
     ///
     /// Returns the context token limit if found, or None.

--- a/src/services/opencode/service.rs
+++ b/src/services/opencode/service.rs
@@ -675,6 +675,17 @@ impl AgentService for OpenCodeService {
     ) -> Result<AgentResult> {
         let result = self.generate_reply(message, thread_name, thread_path, message_dir, pending_rx, thread_cancel).await?;
 
+        let kill_lsp = self.app_config.load()
+            .agent.opencode.as_ref()
+            .and_then(|oc| oc.kill_lsp_after_prompt)
+            .unwrap_or(false);
+
+        if kill_lsp {
+            if let Err(e) = self.kill_lsp_processes(thread_path).await {
+                tracing::warn!(error = %e, "Failed to kill LSP processes after prompt");
+            }
+        }
+
         Ok(AgentResult {
             reply_sent_by_tool: result.reply_sent_by_tool,
             reply_text: result.reply_text,

--- a/src/services/opencode/service.rs
+++ b/src/services/opencode/service.rs
@@ -211,6 +211,44 @@ impl OpenCodeService {
         }
     }
 
+    /// Kill LSP server processes for the given project directory.
+    ///
+    /// Queries the OpenCode `/lsp` endpoint to discover running LSP servers
+    /// and sends SIGTERM to each process by PID. Frees memory occupied by
+    /// LSP servers (especially rust-analyzer at ~2GB) after a prompt completes.
+    async fn kill_lsp_processes(&self, directory: &Path) -> Result<()> {
+        let base_url = self.server.base_url().await?;
+        let client = OpenCodeClient::with_http_client(&base_url, self.http_client.clone());
+
+        let lsp_servers = client.get_lsp_status(directory).await?;
+
+        if lsp_servers.is_empty() {
+            tracing::debug!("No LSP servers found to kill");
+            return Ok(());
+        }
+
+        for lsp in &lsp_servers {
+            if let Some(pid) = lsp.pid {
+                tracing::info!(
+                    lsp_name = %lsp.name,
+                    pid = pid,
+                    "Killing LSP server process"
+                );
+                let ret = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
+                if ret != 0 {
+                    tracing::warn!(
+                        lsp_name = %lsp.name,
+                        pid = pid,
+                        errno = ret,
+                        "Failed to send SIGTERM to LSP process"
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Internal: generate AI reply via OpenCode SSE streaming.
     async fn generate_reply(
         &self,

--- a/src/services/opencode/service.rs
+++ b/src/services/opencode/service.rs
@@ -236,10 +236,11 @@ impl OpenCodeService {
                 );
                 let ret = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
                 if ret != 0 {
+                    let err = std::io::Error::last_os_error();
                     tracing::warn!(
                         lsp_name = %lsp.name,
                         pid = pid,
-                        errno = ret,
+                        error = %err,
                         "Failed to send SIGTERM to LSP process"
                     );
                 }

--- a/src/services/opencode/types.rs
+++ b/src/services/opencode/types.rs
@@ -268,6 +268,21 @@ pub struct CacheTokenInfo {
     pub write: u64,
 }
 
+/// LSP server status from the OpenCode `/lsp` endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct LspStatus {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub pid: Option<u32>,
+    #[serde(default)]
+    pub directory: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -34,8 +34,8 @@ pub const OPENCODE_PORT_RANGE_START: u16 = 49152;
 pub const OPENCODE_PORT_RANGE_END: u16 = 49252;
 pub const OPENCODE_STARTUP_TIMEOUT: Duration = Duration::from_secs(15);
 pub const OPENCODE_HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(3);
-/// Default idle timeout before auto-shutting down the OpenCode server (60 seconds).
-pub const OPENCODE_IDLE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(60);
+/// Default idle timeout before auto-shutting down the OpenCode server (0 = immediate).
+pub const OPENCODE_IDLE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(0);
 /// How often the idle monitor checks active worker counts (60 seconds).
 pub const OPENCODE_IDLE_CHECK_INTERVAL: Duration = Duration::from_secs(60);
 


### PR DESCRIPTION
## Spec

When a worker finishes processing a prompt, the OpenCode session and its associated LSP servers (e.g., rust-analyzer) remain running, consuming significant memory. This is especially problematic in cloud-worker deployments where multiple threads share the same host. This PR changes the default `idle_shutdown_timeout_secs` to `0` (immediate server shutdown when all workers idle) and adds a `kill_lsp_after_prompt` feature that kills LSP server processes after each prompt completes to free memory between prompts.

Fixes #146

## Implementation Plan

### Step 1: Change `idle_shutdown_timeout_secs` default to 0
**What:** In `src/utils/constants.rs`, change `OPENCODE_IDLE_SHUTDOWN_TIMEOUT` from `Duration::from_secs(60)` to `Duration::from_secs(0)`. In `src/cli/monitor.rs`, update the idle monitor logic so that `0` means "immediate shutdown when all workers idle" instead of "disabled." Change the `if !idle_timeout.is_zero()` check to use a separate `enabled` flag or `Option<Duration>` where `None` = disabled and `Some(0)` = immediate.
**Why:** The current default of 60s keeps the server alive unnecessarily in cloud-worker deployments. Setting default to 0 frees all resources (LSP, MCP, everything) immediately when no workers are active. Sessions persist on disk across server restarts.
**Verify:** Set `idle_shutdown_timeout_secs = None` explicitly in config → server should NOT auto-shutdown (disabled). Set `idle_shutdown_timeout_secs = 0` (or omit it for default) → server should shutdown immediately when all workers idle. Set `idle_shutdown_timeout_secs = 60` → server should shutdown after 60s idle (old behavior). Run `cargo check`.

### Step 2: Add `kill_lsp_after_prompt` config option
**What:** In `src/config/types.rs`, add `pub kill_lsp_after_prompt: Option<bool>` field to `OpenCodeConfig`. Default is `false` (no behavior change). When `true`, LSP processes are killed after each prompt completes.
**Why:** Allows cloud-worker deployments to opt into aggressive LSP cleanup between prompts, freeing memory even when other threads may be using the same server.
**Verify:** Parse a config file with `kill_lsp_after_prompt = true` and verify the field is read correctly. Run `cargo check`.

### Step 3: Add `get_lsp_status()` to `OpenCodeClient`
**What:** In `src/services/opencode/client.rs`, add a `pub async fn get_lsp_status(&self, directory: &Path) -> Result<Vec<LspStatus>>` method that calls `GET /lsp` with the `x-opencode-directory` header. Add `LspStatus` struct to `src/services/opencode/types.rs` with fields: `id: String`, `name: String`, `status: String`, `pid: Option<u32>`, `directory: Option<String>`.
**Why:** Needed to discover running LSP server processes and their PIDs for targeted killing.
**Verify:** Call `get_lsp_status()` against a running OpenCode server and verify response parsing. Run `cargo check`.

### Step 4: Add `kill_lsp_processes()` method
**What:** In `src/services/opencode/service.rs`, add a `async fn kill_lsp_processes(&self, directory: &Path)` method that: (1) calls `client.get_lsp_status(directory)` to list LSP servers, (2) kills each LSP process by PID using `libc::kill(pid, SIGTERM)`, (3) logs the action. This kills ALL LSP servers for the project directory regardless of whether other threads might need them (5-10s restart delay is acceptable per user).
**Why:** Frees memory occupied by LSP servers (especially rust-analyzer at ~2GB) after a prompt completes.
**Verify:** Run a prompt in a Rust project, verify rust-analyzer is running via `GET /lsp`, then call `kill_lsp_processes()` and verify the process is gone. Run `cargo check`.

### Step 5: Call `kill_lsp_processes()` after prompt completes
**What:** In `src/services/opencode/service.rs`, in the `process()` method (the `AgentService` trait implementation), after `generate_reply()` returns successfully, check if `kill_lsp_after_prompt` is enabled in config. If so, call `self.kill_lsp_processes(thread_path)`. Add the config read (via `self.app_config`) to check the option.
**Why:** This is the integration point that triggers LSP cleanup after each prompt.
**Verify:** Enable `kill_lsp_after_prompt = true` in config, send a message to a Rust project thread, verify rust-analyzer is killed after the prompt completes and is restarted on the next prompt. Run `cargo check` and `cargo test`.

### Step 6: Update config validation
**What:** In `src/config/validation.rs`, add validation for the new `kill_lsp_after_prompt` option if needed (e.g., warn if both `kill_lsp_after_prompt = true` and `idle_shutdown_timeout_secs = 0` since idle shutdown already kills everything).
**Why:** Prevent confusing config combinations.
**Verify:** Run config validation with conflicting options. Run `cargo test`.

## Design Decisions
- `idle_shutdown_timeout_secs = 0` now means "immediate shutdown" (not "disabled"). `None` means "disabled". This is a behavioral change but acceptable since the old default (60s) kept servers alive unnecessarily.
- LSP killing is aggressive (kills regardless of other threads using same project). 5-10s restart delay is acceptable per user feedback.
- Session data is NOT deleted — OpenCode persists sessions on disk, surviving server restarts. This preserves AI conversation quality.
- `kill_lsp_after_prompt` is opt-in (default `false`) to avoid surprising behavior changes for non-cloud deployments.