### PR TITLE
feat: change kill_lsp_after_prompt and idle_shutdown defaults

### DIFF
--- a/src/cli/monitor.rs
+++ b/src/cli/monitor.rs
@@ -542,28 +542,24 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
     };
 
     // 6. Start idle shutdown monitor (auto-stop OpenCode server when idle)
-    let idle_enabled = config_snapshot.agent.opencode.as_ref()
-        .map(|oc| oc.idle_shutdown_enabled)
-        .unwrap_or(true);
+    let idle_timeout_secs = config_snapshot.agent.opencode.as_ref()
+        .map(|oc| oc.idle_shutdown_timeout_secs)
+        .unwrap_or(OPENCODE_IDLE_SHUTDOWN_TIMEOUT.as_secs());
 
-    let idle_timeout = config_snapshot.agent.opencode.as_ref()
-        .and_then(|oc| oc.idle_shutdown_timeout_secs)
-        .map(std::time::Duration::from_secs)
-        .unwrap_or(OPENCODE_IDLE_SHUTDOWN_TIMEOUT);
-
-    let idle_monitor_task = if idle_enabled {
+    let idle_monitor_task = if idle_timeout_secs > 0 {
+        let idle_timeout = std::time::Duration::from_secs(idle_timeout_secs);
         let idle_tms = thread_managers_for_idle;
         let idle_server: Arc<dyn IdleStopServer> = opencode_server.clone();
         let idle_cancel = cancel.clone();
 
-        let check_interval = if idle_timeout.as_secs() <= 10 {
+        let check_interval = if idle_timeout_secs <= 10 {
             std::time::Duration::from_secs(5)
         } else {
             OPENCODE_IDLE_CHECK_INTERVAL
         };
 
         tracing::info!(
-            timeout_secs = idle_timeout.as_secs(),
+            timeout_secs = idle_timeout_secs,
             check_interval_secs = check_interval.as_secs(),
             "Idle shutdown monitor enabled"
         );
@@ -582,7 +578,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
             ).await;
         }))
     } else {
-        tracing::info!("Idle shutdown monitor disabled (idle_shutdown_enabled = false)");
+        tracing::info!("Idle shutdown monitor disabled (idle_shutdown_timeout_secs = 0)");
         None
     };
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -225,22 +225,16 @@ pub struct OpenCodeConfig {
     /// If not set, uses 95% of the model's context window, or 120K as fallback.
     pub max_input_tokens: Option<u64>,
 
-    /// Whether idle shutdown is enabled. Defaults to `true` (the idle monitor
-    /// will auto-stop the OpenCode server when all workers are idle).
-    /// Set to `false` to disable idle shutdown entirely.
-    #[serde(default = "default_true")]
-    pub idle_shutdown_enabled: bool,
-
     /// Idle timeout in seconds before auto-shutting down the OpenCode server.
-    /// Defaults to 0 (immediate shutdown) when None. Only effective when
-    /// `idle_shutdown_enabled` is `true`.
-    pub idle_shutdown_timeout_secs: Option<u64>,
+    /// Defaults to `5`. Set to `0` to disable idle shutdown entirely.
+    #[serde(default = "default_5_u64")]
+    pub idle_shutdown_timeout_secs: u64,
 
-    /// Kill LSP server processes after each prompt completes to free memory.
-    /// Default is `false` (no behavior change). When `true`, LSP processes
-    /// are killed after each prompt completes.
-    #[serde(default)]
-    pub kill_lsp_after_prompt: Option<bool>,
+    /// Kill LSP server processes after each prompt completed to free memory.
+    /// Default is `true`. When `true`, LSP processes are killed after each
+    /// prompt completes.
+    #[serde(default = "default_true")]
+    pub kill_lsp_after_prompt: bool,
 }
 
 /// Inspect server configuration — exposes runtime state via TCP for the dashboard.
@@ -342,6 +336,9 @@ fn default_3() -> usize {
     3
 }
 fn default_5() -> usize {
+    5
+}
+fn default_5_u64() -> u64 {
     5
 }
 fn default_10() -> usize {

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -289,21 +289,8 @@ pub fn validate_config(config: &AppConfig) -> Vec<ValidationError> {
         }
     }
 
-    // OpenCode config
-    if let Some(ref opencode) = config.agent.opencode {
-        if opencode.kill_lsp_after_prompt.unwrap_or(false)
-            && opencode.idle_shutdown_enabled
-            && opencode.idle_shutdown_timeout_secs.map_or(true, |s| s == 0)
-        {
-            errors.push(ValidationError {
-                path: "agent.opencode.kill_lsp_after_prompt".into(),
-                message: "redundant with idle_shutdown_timeout_secs = 0 (immediate idle \
-                          shutdown already kills all LSP processes). Consider removing \
-                          kill_lsp_after_prompt."
-                    .into(),
-            });
-        }
-    }
+    // OpenCode config — no additional validation needed
+    // (idle_shutdown_timeout_secs = 0 means "disabled", which is valid)
 
     errors
 }
@@ -679,5 +666,86 @@ max_per_message = 5
         assert!(errors.iter().any(|e| e.path.contains("allowed_extensions")));
         assert!(errors.iter().any(|e| e.path.contains("max_file_size")));
         assert!(errors.iter().any(|e| e.path.contains("max_per_message")));
+    }
+
+    #[test]
+    fn test_opencode_defaults() {
+        let toml = r#"
+[general]
+max_concurrent_threads = 3
+
+[channels.work]
+type = "email"
+
+[channels.work.inbound]
+host = "imap.example.com"
+port = 993
+username = "user"
+password = "pass"
+
+[channels.work.outbound]
+host = "smtp.example.com"
+port = 465
+username = "user"
+password = "pass"
+
+[agent]
+enabled = true
+mode = "opencode"
+
+[agent.opencode]
+"#;
+        let config = load_config_from_str(toml).unwrap();
+        let oc = config.agent.opencode.as_ref().unwrap();
+        assert!(
+            oc.kill_lsp_after_prompt,
+            "kill_lsp_after_prompt should default to true"
+        );
+        assert_eq!(
+            oc.idle_shutdown_timeout_secs, 5,
+            "idle_shutdown_timeout_secs should default to 5"
+        );
+    }
+
+    #[test]
+    fn test_opencode_idle_disabled_with_zero() {
+        let toml = r#"
+[general]
+max_concurrent_threads = 3
+
+[channels.work]
+type = "email"
+
+[channels.work.inbound]
+host = "imap.example.com"
+port = 993
+username = "user"
+password = "pass"
+
+[channels.work.outbound]
+host = "smtp.example.com"
+port = 465
+username = "user"
+password = "pass"
+
+[agent]
+enabled = true
+mode = "opencode"
+
+[agent.opencode]
+idle_shutdown_timeout_secs = 0
+"#;
+        let config = load_config_from_str(toml).unwrap();
+        let oc = config.agent.opencode.as_ref().unwrap();
+        assert_eq!(
+            oc.idle_shutdown_timeout_secs, 0,
+            "idle_shutdown_timeout_secs = 0 means disabled"
+        );
+        let errors = validate_config(&config);
+        assert!(
+            errors.is_empty(),
+            "idle_shutdown_timeout_secs = 0 should be valid, got: {:?}",
+            errors
+        );
     }
 }

--- a/src/services/opencode/service.rs
+++ b/src/services/opencode/service.rs
@@ -678,8 +678,8 @@ impl AgentService for OpenCodeService {
 
         let kill_lsp = self.app_config.load()
             .agent.opencode.as_ref()
-            .and_then(|oc| oc.kill_lsp_after_prompt)
-            .unwrap_or(false);
+            .map(|oc| oc.kill_lsp_after_prompt)
+            .unwrap_or(true);
 
         if kill_lsp {
             if let Err(e) = self.kill_lsp_processes(thread_path).await {

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -34,8 +34,8 @@ pub const OPENCODE_PORT_RANGE_START: u16 = 49152;
 pub const OPENCODE_PORT_RANGE_END: u16 = 49252;
 pub const OPENCODE_STARTUP_TIMEOUT: Duration = Duration::from_secs(15);
 pub const OPENCODE_HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(3);
-/// Default idle timeout before auto-shutting down the OpenCode server (0 = immediate).
-pub const OPENCODE_IDLE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(0);
+/// Default idle timeout before auto-shutting down the OpenCode server (5 seconds).
+pub const OPENCODE_IDLE_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 /// How often the idle monitor checks active worker counts (60 seconds).
 pub const OPENCODE_IDLE_CHECK_INTERVAL: Duration = Duration::from_secs(60);
 


### PR DESCRIPTION
## Spec

Change `kill_lsp_after_prompt` default to `true` and `idle_shutdown_timeout_secs` default to `5`. Remove `idle_shutdown_enabled` field — use `idle_shutdown_timeout_secs = 0` to disable idle shutdown instead.

Fixes #151

## Implementation Plan

### Step 1: Update `OpenCodeConfig` in `src/config/types.rs`
**What:**
- Change `kill_lsp_after_prompt` from `Option<bool>` with `#[serde(default)]` to `bool` with `#[serde(default = "default_true")]` (default: `true`)
- Change `idle_shutdown_timeout_secs` from `Option<u64>` to `u64` with `#[serde(default = "default_5")]` (default: `5`)
- Remove `idle_shutdown_enabled` field entirely
- Update doc comments: `idle_shutdown_timeout_secs = 0` means disabled (not "immediate shutdown")
**Why:** These are the core type changes that all other files depend on.
**Verify:** `cargo check`

### Step 2: Update `src/utils/constants.rs`
**What:** Change `OPENCODE_IDLE_SHUTDOWN_TIMEOUT` from `Duration::from_secs(0)` to `Duration::from_secs(5)`.
**Why:** The constant should match the new default value.
**Verify:** `cargo check`

### Step 3: Update idle monitor logic in `src/cli/monitor.rs`
**What:**
- Remove the `idle_enabled` check based on `idle_shutdown_enabled` (~line 134)
- Change idle_timeout resolution: use `idle_shutdown_timeout_secs` directly as `u64` (no longer `Option`). Treat `0` as "disabled" — skip spawning the idle monitor task when `timeout_secs == 0`
- Remove `idle_shutdown_enabled` references
**Why:** The idle monitor needs to use the new field types and semantics.
**Verify:** `cargo check`

### Step 4: Update `src/services/opencode/service.rs`
**What:** Change `kill_lsp_after_prompt` resolution from `and_then(|oc| oc.kill_lsp_after_prompt).unwrap_or(false)` to `oc.kill_lsp_after_prompt` (now a plain `bool`, no unwrap needed).
**Why:** Field type changed from `Option<bool>` to `bool`.
**Verify:** `cargo check`

### Step 5: Update validation in `src/config/validation.rs`
**What:**
- Remove the `idle_shutdown_enabled` reference in the OpenCode validation block (~line 139-149)
- Remove the warning about `kill_lsp_after_prompt` being redundant with `idle_shutdown_timeout_secs = 0` — now `0` means disabled, so `kill_lsp_after_prompt = true` with `idle_shutdown_timeout_secs = 0` is a valid and meaningful combination
**Why:** Validation must match the new semantics.
**Verify:** `cargo check`

### Step 6: Update tests in `src/config/validation.rs`
**What:** Update any existing tests that reference `idle_shutdown_enabled` or the old default values. Add a test that verifies `kill_lsp_after_prompt` defaults to `true` and `idle_shutdown_timeout_secs` defaults to `5`.
**Why:** Tests must reflect the new defaults.
**Verify:** `cargo test`

## Design Decisions
- `idle_shutdown_enabled` removed: `idle_shutdown_timeout_secs = 0` now means "disabled" instead of "immediate shutdown"
- `kill_lsp_after_prompt` changed from `Option<bool>` to `bool` with serde default — configs without this field will now get `true`
- `idle_shutdown_timeout_secs` changed from `Option<u64>` to `u64` with serde default `5` — configs without this field will now get 5-second idle timeout