### PR TITLE
feat: show available workers in dashboard channels bar

### DIFF
--- a/src/cli/dashboard.rs
+++ b/src/cli/dashboard.rs
@@ -248,8 +248,28 @@ fn render_channels(frame: &mut Frame, area: Rect, app: &App) {
         })
         .collect();
 
-    let text = Paragraph::new(Line::from(spans)).block(block);
-    frame.render_widget(text, area);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let channels_para = Paragraph::new(Line::from(spans));
+    frame.render_widget(channels_para, inner);
+
+    let available = state.stats.available_workers;
+    let max = state.stats.max_concurrent;
+    let color = if available == 0 {
+        Color::Red
+    } else if available < max {
+        Color::Yellow
+    } else {
+        Color::Green
+    };
+    let worker_span = Span::styled(
+        format!("Workers: {}/{} free ", available, max),
+        Style::default().fg(color),
+    );
+    let worker_para = Paragraph::new(Line::from(worker_span))
+        .alignment(ratatui::layout::Alignment::Right);
+    frame.render_widget(worker_para, inner);
 }
 
 fn render_threads(frame: &mut Frame, area: Rect, app: &mut App) {

--- a/src/inspect/server.rs
+++ b/src/inspect/server.rs
@@ -259,6 +259,7 @@ impl InspectServer {
             active_workers,
             total_threads,
             max_concurrent: context.max_concurrent,
+            available_workers: context.max_concurrent.saturating_sub(active_workers),
             messages_received: health.messages_received,
             messages_processed: health.messages_processed,
             errors: health.errors,

--- a/src/inspect/server.rs
+++ b/src/inspect/server.rs
@@ -568,6 +568,7 @@ mod tests {
                 assert_eq!(state.channels.len(), 1);
                 assert_eq!(state.channels[0].name, "emf");
                 assert_eq!(state.stats.max_concurrent, 3);
+                assert_eq!(state.stats.available_workers, 3);
                 assert!(!state.version.is_empty());
             }
             other => panic!("expected State, got {:?}", other),

--- a/src/inspect/types.rs
+++ b/src/inspect/types.rs
@@ -150,6 +150,8 @@ pub struct GlobalStats {
     pub total_threads: usize,
     /// Max concurrent workers allowed
     pub max_concurrent: usize,
+    /// Number of available worker slots (max_concurrent - active_workers)
+    pub available_workers: usize,
     /// Total messages received since startup
     pub messages_received: u64,
     /// Total messages processed since startup
@@ -214,6 +216,7 @@ mod tests {
                 active_workers: 2,
                 total_threads: 3,
                 max_concurrent: 3,
+                available_workers: 1,
                 messages_received: 156,
                 messages_processed: 150,
                 errors: 2,


### PR DESCRIPTION
## Spec

Add a right-aligned worker capacity indicator (`Workers: 1/3 free`) to the Channels bar in the TUI dashboard, so users can see at a glance how many worker slots are available without scrolling or switching panels.

Fixes #155

## Implementation Plan

### Step 1: Add `available_workers` field to `GlobalStats`
**What:** In `src/inspect/types.rs`, add a field `available_workers: usize` to `GlobalStats`. This is computed as `max_concurrent - active_workers`.
**Why:** Makes the data available to the dashboard client via the inspect protocol, rather than requiring the dashboard to compute it. This keeps the inspect API self-documenting.
**Verify:** `cargo check` passes. Run existing tests: `cargo test -- inspect::types`.

### Step 2: Populate `available_workers` in `InspectServer::build_state`
**What:** In `src/inspect/server.rs`, in the `build_state` method, compute `available_workers = max_concurrent.saturating_sub(active_workers)` and set it on the `GlobalStats` struct.
**Why:** The inspect server already computes `active_workers` and `max_concurrent` (from `context.max_concurrent`), so this is a one-line addition.
**Verify:** `cargo check` passes. Run existing tests: `cargo test -- inspect::server`.

### Step 3: Update `render_channels` to show worker capacity
**What:** In `src/cli/dashboard.rs`, modify `render_channels()` to:
1. Accept the full `InspectState` (or add `stats` to what's accessible) — currently it only accesses `state.channels`
2. After rendering channel spans, compute right-padding so the worker indicator is right-aligned
3. Append a `Span` like `Workers: 1/3 free` with color coding:
   - Green when all workers are free (available == max)
   - Yellow when some are free
   - Red when no workers are free (available == 0)
**Why:** This is the core UI change. Right-alignment keeps channel info on the left and worker status on the right, making efficient use of the bar's horizontal space.
**Verify:** `cargo build --release` succeeds. Run the dashboard with `./target/release/jyc dashboard` and verify the worker indicator appears in the channels bar, right-aligned, with correct color.

### Step 4: Update existing tests for the new `GlobalStats` field
**What:** In `src/inspect/types.rs` tests, update the `test_inspect_state_serialize_roundtrip` test to include `available_workers: 1` in the `GlobalStats` struct. In `src/inspect/server.rs` tests, update the `test_inspect_server_responds_to_get_state` test to assert `stats.available_workers` matches the expected value (`max_concurrent - active_workers`).
**Why:** Tests must compile and pass with the new field.
**Verify:** `cargo test` — all tests pass.

## Design Decisions
- **Channels bar placement** (over status bar): Workers are a global pool resource shared across channels, so placing them alongside channel info is semantically natural. The channels bar is always visible and has horizontal space to spare.
- **Right-aligned**: Keeps channel indicators on the left (their natural position) and uses otherwise empty space on the right.
- **Color coding**: Provides instant visual feedback — green (all free), yellow (some busy), red (fully saturated).
- **New field in `GlobalStats`** (over computing in dashboard): Makes the inspect API self-documenting; the dashboard stays a pure view layer.