### PR TITLE
fix: replace /lsp API with pkill for killing rust-analyzer

### DIFF
--- a/src/services/opencode/client.rs
+++ b/src/services/opencode/client.rs
@@ -216,28 +216,6 @@ impl OpenCodeClient {
         Ok(providers)
     }
 
-    /// Get LSP server status across all directories (no directory filter).
-    pub async fn get_lsp_status_all(&self) -> Result<Vec<LspStatus>> {
-        let url = format!("{}/lsp", self.base_url);
-
-        let resp = self
-            .http
-            .get(&url)
-            .timeout(OPENCODE_HEALTH_CHECK_TIMEOUT)
-            .send()
-            .await
-            .context("get_lsp_status_all request failed")?;
-
-        let status = resp.status();
-        if !status.is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            anyhow::bail!("get_lsp_status_all failed ({}): {}", status, body);
-        }
-
-        let lsp_status: Vec<LspStatus> = resp.json().await.context("parse lsp status response")?;
-        Ok(lsp_status)
-    }
-
     /// Look up the context window limit for a specific model.
     ///
     /// Returns the context token limit if found, or None.

--- a/src/services/opencode/mod.rs
+++ b/src/services/opencode/mod.rs
@@ -186,6 +186,14 @@ impl OpenCodeServer {
         anyhow::bail!("OpenCode server API not ready after 5s")
     }
 
+    /// Get the PID of the running OpenCode server process.
+    ///
+    /// Returns `Some(pid)` when the server is running and `None` when stopped.
+    pub async fn server_pid(&self) -> Option<u32> {
+        let guard = self.process.lock().await;
+        guard.as_ref().and_then(|child| child.id())
+    }
+
     /// Get the current port (if running).
     #[allow(dead_code)]
     pub async fn port(&self) -> Option<u16> {

--- a/src/services/opencode/service.rs
+++ b/src/services/opencode/service.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use chrono::Utc;
@@ -211,42 +211,36 @@ impl OpenCodeService {
         }
     }
 
-    /// Kill LSP server processes for the given project directory.
+    /// Kill LSP server processes spawned by the OpenCode server.
     ///
-    /// Queries the OpenCode `/lsp` endpoint to discover running LSP servers
-    /// and sends SIGTERM to each process by PID. Frees memory occupied by
-    /// LSP servers (especially rust-analyzer at ~2GB) after a prompt completes.
+    /// Uses `pkill -P <opencode_pid> -f rust-analyzer` to kill
+    /// rust-analyzer child processes of the known OpenCode server PID.
+    /// Frees memory occupied by LSP servers (especially rust-analyzer
+    /// at ~2GB) after a prompt completes.
     async fn kill_lsp_processes(&self) -> Result<()> {
-        let base_url = self.server.base_url().await?;
-        let client = OpenCodeClient::with_http_client(&base_url, self.http_client.clone());
-
-        let lsp_servers = client.get_lsp_status_all().await?;
-
-        if lsp_servers.is_empty() {
-            tracing::debug!("No LSP servers found to kill");
-            return Ok(());
-        }
-
-        for lsp in &lsp_servers {
-            if lsp.name.to_lowercase().contains("rust") {
-                if let Some(pid) = lsp.pid {
-                    tracing::info!(
-                        lsp_name = %lsp.name,
-                        pid = pid,
-                        "Killing LSP server process"
-                    );
-                    let ret = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
-                    if ret != 0 {
-                        let err = std::io::Error::last_os_error();
-                        tracing::warn!(
-                            lsp_name = %lsp.name,
-                            pid = pid,
-                            error = %err,
-                            "Failed to send SIGTERM to LSP process"
-                        );
-                    }
-                }
+        let pid = match self.server.server_pid().await {
+            Some(pid) => pid,
+            None => {
+                tracing::debug!("OpenCode server not running, skipping LSP kill");
+                return Ok(());
             }
+        };
+
+        tracing::info!(
+            pid = pid,
+            "Killing rust-analyzer child processes of OpenCode server"
+        );
+
+        let status = tokio::process::Command::new("pkill")
+            .args(["-P", &pid.to_string(), "-f", "rust-analyzer"])
+            .status()
+            .await
+            .context("failed to execute pkill")?;
+
+        if status.success() {
+            tracing::info!("rust-analyzer processes killed via pkill");
+        } else {
+            tracing::debug!("pkill found no matching processes (exit code non-zero)");
         }
 
         Ok(())

--- a/src/services/opencode/types.rs
+++ b/src/services/opencode/types.rs
@@ -268,21 +268,6 @@ pub struct CacheTokenInfo {
     pub write: u64,
 }
 
-/// LSP server status from the OpenCode `/lsp` endpoint.
-#[derive(Debug, Clone, Deserialize)]
-pub struct LspStatus {
-    #[serde(default)]
-    pub id: String,
-    #[serde(default)]
-    pub name: String,
-    #[serde(default)]
-    pub status: String,
-    #[serde(default)]
-    pub pid: Option<u32>,
-    #[serde(default)]
-    pub directory: Option<String>,
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Spec

Replace the broken `/lsp` API approach for killing rust-analyzer processes with a `pkill -P <opencode_pid> -f rust-analyzer` approach that uses the already-known OpenCode server PID, which is more reliable and doesn't depend on the non-functional `/lsp` endpoint.

Fixes #157

## Implementation Plan

### Step 1: Add `server_pid()` method to `OpenCodeServer`
**What:** Add a `pub async fn server_pid(&self) -> Option<u32>` method in `src/services/opencode/mod.rs` that returns the PID of the running OpenCode server process by locking `self.process` and calling `child.id()`.
**Why:** The new kill approach needs the OpenCode server PID to target its child processes. The PID is already available from the `Child` stored in `self.process`.
**Verify:** `cargo check` passes. The method returns `Some(pid)` when the server is running and `None` when stopped.

### Step 2: Rewrite `kill_lsp_processes()` to use `pkill -P <pid>`
**What:** In `src/services/opencode/service.rs`, rewrite `kill_lsp_processes()` to: (1) call `self.server.server_pid()` to get the PID, (2) if a PID exists, run `tokio::process::Command::new("pkill").args(["-P", &pid.to_string(), "-f", "rust-analyzer"]).status()` to kill rust-analyzer children of the opencode process. Remove the old `/lsp` API call logic entirely.
**Why:** The `/lsp` endpoint returns empty results, so the current approach never kills anything. `pkill -P <pid>` directly targets child processes of the known OpenCode server PID.
**Verify:** `cargo check` passes. After a prompt completes with `kill_lsp_after_prompt = true`, rust-analyzer child processes of the opencode server are killed.

### Step 3: Remove `get_lsp_status_all()` from `OpenCodeClient`
**What:** In `src/services/opencode/client.rs`, delete the `get_lsp_status_all()` method entirely. Remove the `"/lsp"` URL construction and the associated HTTP GET logic.
**Why:** This method is no longer used after replacing `kill_lsp_processes()`. The `/lsp` endpoint is broken and should not be relied upon.
**Verify:** `cargo check` passes with no unused code warnings for the removed method.

### Step 4: Remove `LspStatus` struct from types
**What:** In `src/services/opencode/types.rs`, delete the `LspStatus` struct and its `#[derive(...)]` attributes.
**Why:** `LspStatus` was only used by `get_lsp_status_all()` which is being removed. No other code references it.
**Verify:** `cargo check` passes. `grep -r "LspStatus" src/` returns no results.

### Step 5: Run tests and final verification
**What:** Run `cargo test` and `cargo clippy` to ensure all changes compile correctly, no regressions are introduced, and no dead code warnings remain.
**Why:** Ensures the refactoring is complete and the codebase is clean.
**Verify:** `cargo test` passes. `cargo clippy` reports no new warnings.

## Design Decisions
- Using `pkill -P <pid> -f rust-analyzer` instead of libc signals because: (1) it's simpler, (2) it's cross-platform (Linux + macOS), (3) it directly targets rust-analyzer children without needing to discover PIDs via an API
- Keeping the `kill_lsp_after_prompt` config flag name for backward compatibility — the behavior is the same (kill memory-hungry LSP processes), just the mechanism changes
- The `LspStatus` type and `get_lsp_status_all()` client method are fully removed since they have no other consumers