### PR TITLE
fix: correct dashboard free worker count

### DIFF
--- a/src/cli/monitor.rs
+++ b/src/cli/monitor.rs
@@ -449,7 +449,6 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
             channels: all_channels,
             health_stats: shared_stats,
             activity_map: activity_map.clone(),
-            max_concurrent: config_snapshot.general.max_concurrent_threads,
             start_time: std::time::Instant::now(),
             config_path: Some(config_path.clone()),
             config: Some(config.clone()),

--- a/src/core/thread_manager.rs
+++ b/src/core/thread_manager.rs
@@ -615,9 +615,9 @@ impl ThreadManager {
     pub async fn get_stats(&self) -> QueueStats {
         let queues = self.thread_queues.lock().await;
         let total_threads = queues.len();
-        let active_workers = self.semaphore.available_permits();
+        let active_workers = self.active_worker_count();
         QueueStats {
-            active_workers: total_threads.saturating_sub(active_workers),
+            active_workers,
             total_threads,
             pending_messages: 0,
         }

--- a/src/inspect/client.rs
+++ b/src/inspect/client.rs
@@ -156,7 +156,6 @@ mod tests {
                 crate::core::metrics::HealthStats::default(),
             )),
             activity_map: Arc::new(Mutex::new(HashMap::new())),
-            max_concurrent: 5,
             start_time: Instant::now(),
             config_path: None,
             config: None,
@@ -182,7 +181,7 @@ mod tests {
 
         assert_eq!(state.channels.len(), 1);
         assert_eq!(state.channels[0].name, "test-ch");
-        assert_eq!(state.stats.max_concurrent, 5);
+        assert_eq!(state.stats.max_concurrent, 0);
 
         cancel.cancel();
     }

--- a/src/inspect/server.rs
+++ b/src/inspect/server.rs
@@ -255,11 +255,12 @@ impl InspectServer {
 
         // Read metrics
         let health = context.health_stats.lock().await;
+        let max_concurrent: usize = context.thread_managers.iter().map(|tm| tm.max_concurrent()).sum();
         let stats = GlobalStats {
             active_workers,
             total_threads,
-            max_concurrent: context.max_concurrent,
-            available_workers: context.max_concurrent.saturating_sub(active_workers),
+            max_concurrent,
+            available_workers: max_concurrent.saturating_sub(active_workers),
             messages_received: health.messages_received,
             messages_processed: health.messages_processed,
             errors: health.errors,

--- a/src/inspect/server.rs
+++ b/src/inspect/server.rs
@@ -40,8 +40,6 @@ pub struct InspectContext {
     pub health_stats: SharedHealthStats,
     /// Per-thread activity logs from SSE events
     pub activity_map: SharedActivityMap,
-    /// Max concurrent threads per channel
-    pub max_concurrent: usize,
     /// When the monitor started
     pub start_time: Instant,
     /// Path to the config file (for reload)
@@ -524,7 +522,6 @@ mod tests {
                 crate::core::metrics::HealthStats::default(),
             )),
             activity_map: Arc::new(Mutex::new(HashMap::new())),
-            max_concurrent: 3,
             start_time: Instant::now(),
             config_path: None,
             config: None,
@@ -738,7 +735,6 @@ mode = "opencode"
             channels: vec![],
             health_stats: Arc::new(Mutex::new(crate::core::metrics::HealthStats::default())),
             activity_map: Arc::new(Mutex::new(HashMap::new())),
-            max_concurrent: 3,
             start_time: Instant::now(),
             config_path: Some(config_path.clone()),
             config: Some(config_swap.clone()),

--- a/src/inspect/server.rs
+++ b/src/inspect/server.rs
@@ -565,8 +565,9 @@ mod tests {
             InspectResponse::State(state) => {
                 assert_eq!(state.channels.len(), 1);
                 assert_eq!(state.channels[0].name, "emf");
-                assert_eq!(state.stats.max_concurrent, 3);
-                assert_eq!(state.stats.available_workers, 3);
+                assert_eq!(state.stats.active_workers, 0);
+                assert_eq!(state.stats.max_concurrent, 0);
+                assert_eq!(state.stats.available_workers, 0);
                 assert!(!state.version.is_empty());
             }
             other => panic!("expected State, got {:?}", other),


### PR DESCRIPTION
## Spec

Fix the dashboard showing incorrect free worker counts — e.g., "3/3 free, 0 active" when a thread is actually processing. The root cause is a wrong formula in `ThreadManager::get_stats()` that uses `total_threads` instead of `max_concurrent` to compute `active_workers`.

Fixes #159

## Implementation Plan

### Step 1: Fix `active_workers` calculation in `get_stats()`
**What:** In `src/core/thread_manager.rs:618-620`, replace the buggy formula:
```rust
let active_workers = self.semaphore.available_permits();
QueueStats {
    active_workers: total_threads.saturating_sub(active_workers),
```
with the correct one using the existing `active_worker_count()` method:
```rust
let active_workers = self.active_worker_count();
QueueStats {
    active_workers,
```
**Why:** The current formula `total_threads - available_permits` is wrong. When 1 of 3 workers is busy: `available_permits=2`, `total_threads=1`, so `1-2=0` (saturating) → shows 0 active. The correct formula is `max_concurrent - available_permits = 3-2 = 1`.
**Verify:** `cargo check` compiles. Run `cargo test -- thread_manager` if relevant tests exist.

### Step 2: Fix `max_concurrent` and `available_workers` in inspect server for multi-channel
**What:** In `src/inspect/server.rs:258-262`, change `build_state()` to compute `max_concurrent` by summing each TM's `max_concurrent()` instead of using `context.max_concurrent`:
```rust
let max_concurrent: usize = context.thread_managers.iter().map(|tm| tm.max_concurrent()).sum();
let stats = GlobalStats {
    active_workers,
    total_threads,
    max_concurrent,
    available_workers: max_concurrent.saturating_sub(active_workers),
    ...
};
```
**Why:** Each `ThreadManager` has its own semaphore of size `max_concurrent_threads`. With multiple channels, the total capacity is the sum of all TMs' capacities, not the per-channel config value.
**Verify:** `cargo check` compiles. Existing test `test_inspect_server_state` at `src/inspect/server.rs:526` should still pass.

### Step 3: Remove redundant `context.max_concurrent` field
**What:** In `src/inspect/server.rs:44`, remove the `max_concurrent: usize` field from `InspectContext`. Update `src/cli/monitor.rs:452` to remove the field from the struct literal. All usages in `build_state()` now derive from TMs (done in Step 2).
**Why:** The field is now unused — `max_concurrent` is computed dynamically from TMs, keeping the source of truth in one place.
**Verify:** `cargo check` compiles with no warnings about unused fields. `cargo test` passes.

### Step 4: Update `build_state()` test to verify active_workers correctness
**What:** In `src/inspect/server.rs`, review/update the existing test `test_inspect_server_state` (around line 526) to ensure it validates `active_workers` and `available_workers` correctly after the fix. Add assertions like:
```rust
assert_eq!(state.stats.active_workers, 0); // No threads processing in test
assert_eq!(state.stats.available_workers, state.stats.max_concurrent);
```
**Why:** Ensures the fix is covered by tests and prevents regression.
**Verify:** `cargo test test_inspect_server_state` passes.

## Design Decisions
- Used the existing `active_worker_count()` method instead of duplicating the formula — single source of truth
- Derived `max_concurrent` from TMs dynamically instead of caching a static config value — handles config reload correctly
- Kept `QueueStats.active_workers` field unchanged to avoid unnecessary API churn