### PR TITLE
feat: show free workers per channel in dashboard

### DIFF
--- a/src/cli/dashboard.rs
+++ b/src/cli/dashboard.rs
@@ -239,11 +239,19 @@ fn render_channels(frame: &mut Frame, area: Rect, app: &App) {
             if i > 0 {
                 parts.push(Span::raw("  "));
             }
-            parts.push(Span::styled(
-                "●",
-                Style::default().fg(Color::Green),
-            ));
-            parts.push(Span::raw(format!(" {} ({})", ch.name, ch.channel_type)));
+            let free = ch.max_concurrent.saturating_sub(ch.active_workers);
+            let dot_color = if free == 0 {
+                Color::Red
+            } else if free < ch.max_concurrent {
+                Color::Yellow
+            } else {
+                Color::Green
+            };
+            parts.push(Span::styled("●", Style::default().fg(dot_color)));
+            parts.push(Span::raw(format!(
+                " {} ({} {}/{})",
+                ch.name, ch.channel_type, free, ch.max_concurrent
+            )));
             parts
         })
         .collect();
@@ -253,23 +261,6 @@ fn render_channels(frame: &mut Frame, area: Rect, app: &App) {
 
     let channels_para = Paragraph::new(Line::from(spans));
     frame.render_widget(channels_para, inner);
-
-    let available = state.stats.available_workers;
-    let max = state.stats.max_concurrent;
-    let color = if available == 0 {
-        Color::Red
-    } else if available < max {
-        Color::Yellow
-    } else {
-        Color::Green
-    };
-    let worker_span = Span::styled(
-        format!("Workers: {}/{} free ", available, max),
-        Style::default().fg(color),
-    );
-    let worker_para = Paragraph::new(Line::from(worker_span))
-        .alignment(ratatui::layout::Alignment::Right);
-    frame.render_widget(worker_para, inner);
 }
 
 fn render_threads(frame: &mut Frame, area: Rect, app: &mut App) {

--- a/src/cli/monitor.rs
+++ b/src/cli/monitor.rs
@@ -210,6 +210,8 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
         all_channels.push(crate::inspect::types::ChannelInfo {
             name: channel_name.clone(),
             channel_type: channel_type.to_string(),
+            active_workers: 0,
+            max_concurrent: 0,
         });
         all_workspace_dirs.push(workspace_dir);
 

--- a/src/inspect/client.rs
+++ b/src/inspect/client.rs
@@ -151,6 +151,8 @@ mod tests {
             channels: vec![ChannelInfo {
                 name: "test-ch".to_string(),
                 channel_type: "email".to_string(),
+                active_workers: 0,
+                max_concurrent: 0,
             }],
             health_stats: Arc::new(Mutex::new(
                 crate::core::metrics::HealthStats::default(),

--- a/src/inspect/server.rs
+++ b/src/inspect/server.rs
@@ -221,16 +221,20 @@ impl InspectServer {
     async fn build_state(context: &InspectContext) -> InspectState {
         let uptime = context.start_time.elapsed().as_secs();
 
-        // Collect threads from all thread managers
         let mut threads = Vec::new();
         let mut total_threads = 0;
         let mut active_workers = 0;
+        let mut per_channel_workers: HashMap<String, (usize, usize)> = HashMap::new();
 
         for tm in &context.thread_managers {
             let tm_threads = tm.list_threads().await;
             total_threads += tm_threads.len();
             let stats = tm.get_stats().await;
             active_workers += stats.active_workers;
+            per_channel_workers.insert(
+                tm.channel_name().to_string(),
+                (stats.active_workers, tm.max_concurrent()),
+            );
             threads.extend(tm_threads);
         }
 
@@ -265,10 +269,18 @@ impl InspectServer {
         };
         drop(health);
 
+        let mut channels = context.channels.clone();
+        for ch in &mut channels {
+            if let Some((aw, mc)) = per_channel_workers.get(&ch.name) {
+                ch.active_workers = *aw;
+                ch.max_concurrent = *mc;
+            }
+        }
+
         InspectState {
             uptime_secs: uptime,
             version: env!("CARGO_PKG_VERSION").to_string(),
-            channels: context.channels.clone(),
+            channels,
             threads,
             stats,
         }

--- a/src/inspect/server.rs
+++ b/src/inspect/server.rs
@@ -516,6 +516,8 @@ mod tests {
                 ChannelInfo {
                     name: "emf".to_string(),
                     channel_type: "github".to_string(),
+                    active_workers: 0,
+                    max_concurrent: 0,
                 },
             ],
             health_stats: Arc::new(Mutex::new(

--- a/src/inspect/types.rs
+++ b/src/inspect/types.rs
@@ -50,6 +50,12 @@ pub struct ChannelInfo {
     pub name: String,
     /// Channel type: "email", "feishu", "github"
     pub channel_type: String,
+    /// Number of active workers holding semaphore permits in this channel.
+    #[serde(default)]
+    pub active_workers: usize,
+    /// Max concurrent workers allowed for this channel.
+    #[serde(default)]
+    pub max_concurrent: usize,
 }
 
 /// Information about an active thread.
@@ -199,6 +205,8 @@ mod tests {
             channels: vec![ChannelInfo {
                 name: "emf".to_string(),
                 channel_type: "github".to_string(),
+                active_workers: 2,
+                max_concurrent: 3,
             }],
             threads: vec![ThreadInfo {
                 name: "issue-42".to_string(),
@@ -229,6 +237,8 @@ mod tests {
         assert_eq!(parsed.uptime_secs, 3600);
         assert_eq!(parsed.channels.len(), 1);
         assert_eq!(parsed.channels[0].name, "emf");
+        assert_eq!(parsed.channels[0].active_workers, 2);
+        assert_eq!(parsed.channels[0].max_concurrent, 3);
         assert_eq!(parsed.threads.len(), 1);
         assert_eq!(parsed.threads[0].status, ThreadStatus::Processing);
         assert_eq!(parsed.stats.active_workers, 2);
@@ -343,5 +353,14 @@ mod tests {
         assert!(json.contains(r#""severity":"error""#));
         let parsed: ActivityEntry = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.severity, Severity::Error);
+    }
+
+    #[test]
+    fn test_channel_info_backward_compat() {
+        let old_json = r#"{"name":"emf","channel_type":"github"}"#;
+        let ch: ChannelInfo = serde_json::from_str(old_json).unwrap();
+        assert_eq!(ch.name, "emf");
+        assert_eq!(ch.active_workers, 0);
+        assert_eq!(ch.max_concurrent, 0);
     }
 }


### PR DESCRIPTION
## Spec

Show per-channel worker stats in the dashboard channels bar instead of the misleading global sum. Currently with 4 channels × max_concurrent_threads=3, the dashboard shows "Workers: 12/12 free" — but each ThreadManager has its own semaphore, so workers are per-channel. The fix makes the dashboard show e.g. `● jyc_repo (github 2/3 free)` for each channel.

Fixes #161

## Implementation Plan

### Step 1: Add worker stats fields to `ChannelInfo`
**What:** In `src/inspect/types.rs`, add `active_workers: usize` and `max_concurrent: usize` fields to the `ChannelInfo` struct, both with `#[serde(default)]` for backward compatibility. Update the test in `test_inspect_state_serialize_roundtrip` to include the new fields.
**Why:** The inspect protocol needs to carry per-channel worker data to the dashboard client.
**Verify:** `cargo check`

### Step 2: Populate per-channel worker stats in `InspectServer::build_state`
**What:** In `src/inspect/server.rs`, in the `build_state` method, after collecting threads from each `ThreadManager`, populate the `active_workers` and `max_concurrent` fields on the corresponding `ChannelInfo` by matching `tm.channel_name()` against `context.channels`. Keep the existing `GlobalStats` aggregation as-is (the status bar still uses it).
**Why:** The server is the source of truth for runtime state — it already has access to all `ThreadManager`s and their stats.
**Verify:** `cargo check`

### Step 3: Update dashboard `render_channels` to show per-channel worker stats
**What:** In `src/cli/dashboard.rs`, modify `render_channels` to display worker stats inline with each channel name, e.g. `● jyc_repo (github 2/3 free)`. Remove the global "Workers: X/Y free" text that is currently right-aligned in the channels bar (it's misleading and redundant — aggregate stats remain in the status bar).
**Why:** This directly addresses the bug — users will see per-channel concurrency instead of a misleading global sum.
**Verify:** `cargo check` and manual visual verification with `cargo run -- dashboard`

### Step 4: Run full test suite
**What:** Run `cargo test` to ensure all existing tests pass, especially the inspect types serde roundtrip tests and the inspect server integration tests.
**Why:** The changes affect the inspect protocol types and server — need to verify no regressions.
**Verify:** `cargo test`

## Design Decisions
- Per-channel fields use `#[serde(default)]` so older dashboard clients or recorded JSON still works
- Global `GlobalStats` is kept unchanged — the status bar at the bottom still shows aggregate numbers
- Each channel's worker display uses the same color logic (red=0 free, yellow=some, green=all free) as the current global display