### PR TITLE
feat: make footer display configurable per channel

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -31,6 +31,11 @@ poll_interval_secs = 30
 max_retries = 5
 folder = "INBOX"
 
+# Footer configuration: controls whether model/mode/tokens footer is appended to replies.
+# Default is enabled = true when omitted. Set enabled = false to disable the footer.
+# [channels.jiny283.footer]
+# enabled = true
+
 [[channels.jiny283.patterns]]
 name = "sap"
 enabled = true
@@ -259,6 +264,10 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # token = "${GITHUB_TOKEN}"           # PAT scopes: repo, read:user
 # poll_interval_secs = 60
 # # api_url = "https://api.github.com"  # Default. For GitHub Enterprise, use: https://github.example.com/api/v3
+#
+# # Disable footer for GitHub channel (comments don't need model info)
+# [channels.my_repo.footer]
+# enabled = false
 #
 # # Pattern: Issues with 'feature-plan' label → High-Level Planner (product manager perspective)
 # [[channels.my_repo.patterns]]

--- a/src/channels/email/outbound.rs
+++ b/src/channels/email/outbound.rs
@@ -170,6 +170,7 @@ impl OutboundAdapter for EmailOutboundAdapter {
             mode,
             input_tokens,
             max_tokens,
+            true,
         )
         .await;
 

--- a/src/channels/email/outbound.rs
+++ b/src/channels/email/outbound.rs
@@ -27,18 +27,20 @@ pub struct EmailOutboundAdapter {
     from_address: String,
     from_name: Option<String>,
     attachment_config: Option<OutboundAttachmentConfig>,
+    footer_enabled: bool,
 }
 
 impl EmailOutboundAdapter {
     #[allow(dead_code)]
     pub fn new(config: &SmtpConfig, storage: Arc<MessageStorage>) -> Self {
-        Self::new_with_attachments(config, storage, None)
+        Self::new_with_attachments(config, storage, None, true)
     }
     
     pub fn new_with_attachments(
         config: &SmtpConfig,
         storage: Arc<MessageStorage>,
         attachment_config: Option<OutboundAttachmentConfig>,
+        footer_enabled: bool,
     ) -> Self {
         let from_address = config
             .from_address
@@ -52,6 +54,7 @@ impl EmailOutboundAdapter {
             from_address,
             from_name,
             attachment_config,
+            footer_enabled,
         }
     }
 
@@ -170,7 +173,7 @@ impl OutboundAdapter for EmailOutboundAdapter {
             mode,
             input_tokens,
             max_tokens,
-            true,
+            self.footer_enabled,
         )
         .await;
 

--- a/src/channels/feishu/outbound.rs
+++ b/src/channels/feishu/outbound.rs
@@ -21,13 +21,14 @@ pub struct FeishuOutboundAdapter {
     client: FeishuClient,
     storage: Arc<MessageStorage>,
     attachment_config: Option<OutboundAttachmentConfig>,
+    footer_enabled: bool,
 }
 
 impl FeishuOutboundAdapter {
     /// Create a new Feishu outbound adapter.
     #[allow(dead_code)]
     pub fn new(config: FeishuConfig, storage: Arc<MessageStorage>) -> Self {
-        Self::new_with_attachments(config, storage, None)
+        Self::new_with_attachments(config, storage, None, true)
     }
     
     /// Create a new Feishu outbound adapter with attachment configuration.
@@ -35,11 +36,13 @@ impl FeishuOutboundAdapter {
         config: FeishuConfig,
         storage: Arc<MessageStorage>,
         attachment_config: Option<OutboundAttachmentConfig>,
+        footer_enabled: bool,
     ) -> Self {
         Self {
             client: FeishuClient::new(config),
             storage,
             attachment_config,
+            footer_enabled,
         }
     }
 }
@@ -95,7 +98,7 @@ impl crate::channels::types::OutboundAdapter for FeishuOutboundAdapter {
         let (input_tokens, max_tokens) = crate::services::opencode::session::read_input_tokens(thread_path).await;
         
         // 2. Build footer with model/mode/tokens information
-        let footer = email_parser::build_footer(model, mode, input_tokens, max_tokens, true);
+        let footer = email_parser::build_footer(model, mode, input_tokens, max_tokens, self.footer_enabled);
         
         // 3. Clean reply text to remove any trailing `---` separators
         let clean_reply = email_parser::strip_trailing_separators(reply_text);

--- a/src/channels/feishu/outbound.rs
+++ b/src/channels/feishu/outbound.rs
@@ -95,7 +95,7 @@ impl crate::channels::types::OutboundAdapter for FeishuOutboundAdapter {
         let (input_tokens, max_tokens) = crate::services::opencode::session::read_input_tokens(thread_path).await;
         
         // 2. Build footer with model/mode/tokens information
-        let footer = email_parser::build_footer(model, mode, input_tokens, max_tokens);
+        let footer = email_parser::build_footer(model, mode, input_tokens, max_tokens, true);
         
         // 3. Clean reply text to remove any trailing `---` separators
         let clean_reply = email_parser::strip_trailing_separators(reply_text);

--- a/src/channels/github/outbound.rs
+++ b/src/channels/github/outbound.rs
@@ -77,7 +77,7 @@ impl OutboundAdapter for GithubOutboundAdapter {
         let (input_tokens, max_tokens) = crate::services::opencode::session::read_input_tokens(thread_path).await;
 
         // Build footer with model/mode/tokens information
-        let footer = crate::core::email_parser::build_footer(model, mode, input_tokens, max_tokens);
+        let footer = crate::core::email_parser::build_footer(model, mode, input_tokens, max_tokens, true);
 
         // Clean reply text
         let clean_reply = crate::core::email_parser::strip_trailing_separators(reply_text);

--- a/src/channels/github/outbound.rs
+++ b/src/channels/github/outbound.rs
@@ -13,13 +13,18 @@ pub struct GithubOutboundAdapter {
     config: GithubConfig,
     storage: Arc<MessageStorage>,
     client: GithubClient,
+    footer_enabled: bool,
 }
 
 impl GithubOutboundAdapter {
     pub fn new(config: GithubConfig, storage: Arc<MessageStorage>) -> Result<Self> {
+        Self::with_footer_enabled(config, storage, true)
+    }
+
+    pub fn with_footer_enabled(config: GithubConfig, storage: Arc<MessageStorage>, footer_enabled: bool) -> Result<Self> {
         let client = GithubClient::new(&config)
             .context("Failed to create GitHub client for outbound")?;
-        Ok(Self { config, storage, client })
+        Ok(Self { config, storage, client, footer_enabled })
     }
 }
 
@@ -77,7 +82,7 @@ impl OutboundAdapter for GithubOutboundAdapter {
         let (input_tokens, max_tokens) = crate::services::opencode::session::read_input_tokens(thread_path).await;
 
         // Build footer with model/mode/tokens information
-        let footer = crate::core::email_parser::build_footer(model, mode, input_tokens, max_tokens, true);
+        let footer = crate::core::email_parser::build_footer(model, mode, input_tokens, max_tokens, self.footer_enabled);
 
         // Clean reply text
         let clean_reply = crate::core::email_parser::strip_trailing_separators(reply_text);

--- a/src/cli/monitor.rs
+++ b/src/cli/monitor.rs
@@ -129,6 +129,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     feishu_config,
                     storage.clone(),
                     outbound_attachment_config,
+                    true,
                 ))
             }
             "github" => {

--- a/src/cli/monitor.rs
+++ b/src/cli/monitor.rs
@@ -101,6 +101,11 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
             .as_ref()
             .and_then(|att| att.inbound.clone());
 
+        let footer_enabled = channel_config
+            .footer
+            .as_ref()
+            .map_or(true, |f| f.enabled);
+
         // Create the outbound adapter based on channel type
         let outbound: Arc<dyn OutboundAdapter> = match channel_type {
             "email" => {
@@ -114,7 +119,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     outbound_config,
                     storage.clone(),
                     outbound_attachment_config,
-                    true,
+                    footer_enabled,
                 ))
             }
             "feishu" => {
@@ -129,7 +134,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     feishu_config,
                     storage.clone(),
                     outbound_attachment_config,
-                    true,
+                    footer_enabled,
                 ))
             }
             "github" => {
@@ -140,9 +145,10 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                         anyhow::anyhow!("channel '{channel_name}': missing github config")
                     })?
                     .clone();
-                Arc::new(GithubOutboundAdapter::new(
+                Arc::new(GithubOutboundAdapter::with_footer_enabled(
                     github_config,
                     storage.clone(),
+                    footer_enabled,
                 )?)
             }
             other => {

--- a/src/cli/monitor.rs
+++ b/src/cli/monitor.rs
@@ -114,6 +114,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     outbound_config,
                     storage.clone(),
                     outbound_attachment_config,
+                    true,
                 ))
             }
             "feishu" => {

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -94,6 +94,17 @@ impl Default for GeneralConfig {
     }
 }
 
+/// Footer display configuration for a channel.
+///
+/// Controls whether the model/mode/tokens footer is appended to AI replies.
+/// Default is `enabled = true` for backward compatibility.
+#[derive(Debug, Clone, Deserialize)]
+pub struct FooterConfig {
+    /// Whether the footer is appended to replies (default: true)
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
 /// Configuration for a single channel (e.g., one email account).
 #[derive(Debug, Deserialize)]
 pub struct ChannelConfig {
@@ -126,6 +137,9 @@ pub struct ChannelConfig {
 
     /// Channel-specific agent config override
     pub agent: Option<AgentConfig>,
+
+    /// Footer display configuration (omit for default: footer enabled)
+    pub footer: Option<FooterConfig>,
 }
 
 /// IMAP server configuration.

--- a/src/core/email_parser.rs
+++ b/src/core/email_parser.rs
@@ -356,7 +356,13 @@ pub fn parse_stored_reply(content: &str) -> String {
 }
 
 /// Build a footer with model, mode, and token information.
-pub fn build_footer(model: Option<&str>, mode: Option<&str>, input_tokens: Option<u64>, max_tokens: Option<u64>) -> String {
+///
+/// When `footer_enabled` is `false`, returns an empty string immediately.
+pub fn build_footer(model: Option<&str>, mode: Option<&str>, input_tokens: Option<u64>, max_tokens: Option<u64>, footer_enabled: bool) -> String {
+    if !footer_enabled {
+        return String::new();
+    }
+
     let mut parts = Vec::new();
 
     if let Some(m) = model {
@@ -406,8 +412,9 @@ pub async fn build_full_reply_text(
     mode: Option<&str>,
     input_tokens: Option<u64>,
     max_tokens: Option<u64>,
+    footer_enabled: bool,
 ) -> String {
-    let footer = build_footer(model, mode, input_tokens, max_tokens);
+    let footer = build_footer(model, mode, input_tokens, max_tokens, footer_enabled);
     
     // Clean reply text to remove any trailing `---` separators
     let clean_reply = strip_trailing_separators(reply_text);

--- a/src/core/email_parser.rs
+++ b/src/core/email_parser.rs
@@ -697,4 +697,77 @@ Hello, I need help with X.
         let text2 = "   ";
         assert_eq!(strip_trailing_separators(text2), "");
     }
+
+    // --- build_footer tests ---
+
+    #[test]
+    fn test_build_footer_enabled_with_model() {
+        let footer = build_footer(Some("test-model"), None, None, None, true);
+        assert!(footer.contains("Model: test-model"));
+        assert!(footer.starts_with("---\n\n"));
+    }
+
+    #[test]
+    fn test_build_footer_disabled_returns_empty() {
+        let footer = build_footer(Some("test-model"), Some("opencode"), Some(5000), Some(120000), false);
+        assert!(footer.is_empty());
+    }
+
+    #[test]
+    fn test_build_footer_disabled_no_model_returns_empty() {
+        let footer = build_footer(None, None, None, None, false);
+        assert!(footer.is_empty());
+    }
+
+    #[test]
+    fn test_build_footer_enabled_all_fields() {
+        let footer = build_footer(Some("gpt-4"), Some("opencode"), Some(10240), Some(122880), true);
+        assert!(footer.contains("Model: gpt-4"));
+        assert!(footer.contains("Mode: opencode"));
+        assert!(footer.contains("Tokens:"));
+    }
+
+    // --- build_full_reply_text footer tests ---
+
+    #[tokio::test]
+    async fn test_build_full_reply_text_footer_disabled() {
+        let reply = build_full_reply_text(
+            "Hello world",
+            std::path::Path::new("/tmp"),
+            "sender",
+            "2026-01-01T00:00:00Z",
+            "topic",
+            "body",
+            "msg",
+            Some("model"),
+            Some("opencode"),
+            Some(5000),
+            Some(120000),
+            false,
+        )
+        .await;
+        assert_eq!(reply, "Hello world");
+        assert!(!reply.contains("Model:"));
+    }
+
+    #[tokio::test]
+    async fn test_build_full_reply_text_footer_enabled() {
+        let reply = build_full_reply_text(
+            "Hello world",
+            std::path::Path::new("/tmp"),
+            "sender",
+            "2026-01-01T00:00:00Z",
+            "topic",
+            "body",
+            "msg",
+            Some("model"),
+            Some("opencode"),
+            Some(5000),
+            Some(120000),
+            true,
+        )
+        .await;
+        assert!(reply.contains("Hello world"));
+        assert!(reply.contains("Model: model"));
+    }
 }


### PR DESCRIPTION
## Spec

Add per-channel `footer` configuration to `config.toml`, allowing users to enable/disable the model/mode/tokens footer on replies for each channel independently. Default is `enabled = true` for backward compatibility.

Fixes #166

## Implementation Plan

### Step 1: Add `FooterConfig` struct to config types
**What:** Add `FooterConfig { enabled: bool }` (default `true`) to `src/config/types.rs`. Add `footer: Option<FooterConfig>` field to `ChannelConfig`. Add `default_true()` helper if not already available for the `enabled` field.
**Why:** Provides the config structure for per-channel footer settings. Default `true` ensures backward compatibility.
**Verify:** `cargo check` compiles without errors.

### Step 2: Pass `footer_enabled` through `build_footer()` and `build_full_reply_text()`
**What:** In `src/core/email_parser.rs`, add `footer_enabled: bool` parameter to `build_footer()` (return empty string early when `false`) and `build_full_reply_text()` (pass it through to `build_footer()`).
**Why:** Core logic change — when footer is disabled, the footer string is empty, so no `---\n\nModel: ...` is appended to replies.
**Verify:** `cargo test -p jyc -- email_parser` — existing tests still pass (they pass `true` for the new param).

### Step 3: Add `footer_enabled` field to `EmailOutboundAdapter`
**What:** In `src/channels/email/outbound.rs`, add `footer_enabled: bool` field to `EmailOutboundAdapter`. Update `new()` and `new_with_attachments()` constructors to accept it. Pass `self.footer_enabled` to `build_full_reply_text()` in `send_reply()`.
**Why:** Email channel needs to know the footer setting from config.
**Verify:** `cargo check` compiles. Email replies respect the footer config.

### Step 4: Add `footer_enabled` field to `FeishuOutboundAdapter`
**What:** In `src/channels/feishu/outbound.rs`, add `footer_enabled: bool` field to `FeishuOutboundAdapter`. Update `new()` and `new_with_attachments()` constructors. Pass `self.footer_enabled` to `build_footer()` in `send_reply()`.
**Why:** Feishu channel needs to know the footer setting from config.
**Verify:** `cargo check` compiles. Feishu replies respect the footer config.

### Step 5: Add `footer_enabled` field to `GithubOutboundAdapter`
**What:** In `src/channels/github/outbound.rs`, add `footer_enabled: bool` field to `GithubOutboundAdapter`. Update `new()` constructor. Pass `self.footer_enabled` to `build_footer()` in `send_reply()`.
**Why:** GitHub channel needs to know the footer setting from config.
**Verify:** `cargo check` compiles. GitHub comments respect the footer config.

### Step 6: Wire footer config in `monitor.rs`
**What:** In `src/cli/monitor.rs`, extract `footer_enabled` from `channel_config.footer` (default `true` when not set) and pass it to each outbound adapter constructor (`EmailOutboundAdapter::new_with_attachments(...)`, `FeishuOutboundAdapter::new_with_attachments(...)`, `GithubOutboundAdapter::new(...)`).
**Why:** Connects the config to the adapters at runtime.
**Verify:** `cargo check` compiles. Running `jyc monitor` with `[channels.X.footer] enabled = false` produces replies without footer.

### Step 7: Update test files for new constructor signatures
**What:** Update adapter construction calls in `src/core/thread_manager_tests.rs` and `src/core/command/close_handler.rs` to pass `true` for `footer_enabled` (maintaining existing behavior).
**Why:** Tests must compile with the updated constructor signatures.
**Verify:** `cargo test` passes.

### Step 8: Add unit tests for `footer_enabled = false`
**What:** In `src/core/email_parser.rs` tests, add test cases verifying `build_footer()` returns empty string when `footer_enabled = false`, and that `build_full_reply_text()` returns just the reply text without footer.
**Why:** Ensures the new feature works correctly.
**Verify:** `cargo test -p jyc -- email_parser::tests` passes all new tests.

### Step 9: Update `config.example.toml` with footer documentation
**What:** Add `[channels.jiny283.footer]` section with `enabled = true` and a comment explaining the feature. Add `[channels.my_repo.footer]` example with `enabled = false` in the GitHub channel section.
**Why:** Documents the new config option for users.
**Verify:** Config file is valid TOML.

## Design Decisions
- Per-channel config (not global) — user explicitly requested this
- `enabled = true` default — backward compatible, existing deployments unaffected
- `Option<FooterConfig>` on `ChannelConfig` — omitting the section entirely means footer stays on
- Footer config stored on outbound adapter structs — keeps the `send_reply()` method signature unchanged, no need to thread config through `ThreadManager`