### PR TITLE
feat: reset session from dashboard

### DIFF
--- a/src/cli/dashboard.rs
+++ b/src/cli/dashboard.rs
@@ -32,8 +32,8 @@ struct App {
     error: Option<String>,
     table_state: TableState,
     should_quit: bool,
-    /// Transient status message (e.g., config reload result).
     status_message: Option<(String, std::time::Instant)>,
+    pending_reset: Option<(String, std::time::Instant)>,
 }
 
 impl App {
@@ -44,6 +44,7 @@ impl App {
             table_state: TableState::default(),
             should_quit: false,
             status_message: None,
+            pending_reset: None,
         }
     }
 
@@ -51,11 +52,19 @@ impl App {
         self.status_message = Some((msg, std::time::Instant::now()));
     }
 
-    /// Clear status message after 5 seconds.
+    fn clear_pending_reset(&mut self) {
+        self.pending_reset = None;
+    }
+
     fn tick_status(&mut self) {
         if let Some((_, at)) = &self.status_message {
             if at.elapsed() > Duration::from_secs(5) {
                 self.status_message = None;
+            }
+        }
+        if let Some((_, at)) = &self.pending_reset {
+            if at.elapsed() > Duration::from_secs(3) {
+                self.pending_reset = None;
             }
         }
     }
@@ -157,7 +166,6 @@ pub async fn run(args: &DashboardArgs) -> Result<()> {
                             match client.reload_config().await {
                                 Ok((true, msg)) => {
                                     app.set_status(format!("Config reloaded: {msg}"));
-                                    // Force refresh to show updated state
                                     last_poll = std::time::Instant::now() - poll_interval;
                                 }
                                 Ok((false, msg)) => {
@@ -168,7 +176,49 @@ pub async fn run(args: &DashboardArgs) -> Result<()> {
                                 }
                             }
                         }
-                        _ => {}
+                        KeyCode::Char('s') => {
+                            if let Some((ref thread_name, at)) = app.pending_reset {
+                                if at.elapsed() <= Duration::from_secs(3) {
+                                    let name = thread_name.clone();
+                                    app.clear_pending_reset();
+                                    match client.reset_session(&name).await {
+                                        Ok((true, msg)) => {
+                                            app.set_status(format!("Session reset: {msg}"));
+                                            last_poll = std::time::Instant::now() - poll_interval;
+                                        }
+                                        Ok((false, msg)) => {
+                                            app.set_status(format!("Reset failed: {msg}"));
+                                        }
+                                        Err(e) => {
+                                            app.set_status(format!("Reset error: {e:#}"));
+                                        }
+                                    }
+                                } else {
+                                    app.clear_pending_reset();
+                                }
+                            } else {
+                                let thread_name = app
+                                    .state
+                                    .as_ref()
+                                    .and_then(|s| {
+                                        app.table_state
+                                            .selected()
+                                            .and_then(|i| s.threads.get(i).map(|t| t.name.clone()))
+                                    });
+                                match thread_name {
+                                    Some(name) => {
+                                        app.pending_reset = Some((name.clone(), std::time::Instant::now()));
+                                        app.set_status(format!("Press `s` again to confirm reset session for {name}"));
+                                    }
+                                    None => {
+                                        app.set_status("No thread selected".to_string());
+                                    }
+                                }
+                            }
+                        }
+                        _ => {
+                            app.clear_pending_reset();
+                        }
                     }
                 }
             }
@@ -478,7 +528,7 @@ fn render_details(frame: &mut Frame, area: Rect, app: &App) {
 }
 
 fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
-    let help_text = "[q]quit [↑↓]select [r]refresh [R]reload";
+    let help_text = "[q]quit [↑↓]select [r]refresh [R]reload [s]reset session";
 
     let state = match &app.state {
         Some(s) => s,

--- a/src/inspect/client.rs
+++ b/src/inspect/client.rs
@@ -133,6 +133,45 @@ impl InspectClient {
             InspectResponse::ResetSessionResult { .. } => anyhow::bail!("unexpected reset_session_result for reload_config"),
         }
     }
+
+    /// Send a `reset_session` command to the inspect server.
+    pub async fn reset_session(&mut self, thread_name: &str) -> Result<(bool, String)> {
+        if self.conn.is_none() {
+            self.connect().await?;
+        }
+
+        let conn = self.conn.as_mut().context("not connected")?;
+
+        let request = InspectRequest {
+            method: "reset_session".to_string(),
+            params: Some(serde_json::json!({ "thread_name": thread_name })),
+        };
+        let mut json = serde_json::to_string(&request)?;
+        json.push('\n');
+        conn.writer.write_all(json.as_bytes()).await?;
+        conn.writer.flush().await?;
+
+        let mut response_line = String::new();
+        let bytes = conn
+            .reader
+            .read_line(&mut response_line)
+            .await
+            .context("failed to read response")?;
+
+        if bytes == 0 {
+            anyhow::bail!("server closed connection");
+        }
+
+        let resp: InspectResponse =
+            serde_json::from_str(response_line.trim()).context("failed to parse inspect response")?;
+
+        match resp {
+            InspectResponse::ResetSessionResult { success, message } => Ok((success, message)),
+            InspectResponse::Error { error } => Ok((false, error)),
+            InspectResponse::State(_) => anyhow::bail!("unexpected state for reset_session"),
+            InspectResponse::ReloadResult { .. } => anyhow::bail!("unexpected reload_result for reset_session"),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -260,5 +299,56 @@ mod tests {
         let mut client = InspectClient::new("127.0.0.1:1");
         let result = client.get_state().await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_inspect_client_reset_session() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace_dir = tmp.path().to_path_buf();
+        let thread_name = "test-thread";
+        let jyc_dir = workspace_dir.join(thread_name).join(".jyc");
+        tokio::fs::create_dir_all(&jyc_dir).await.unwrap();
+        tokio::fs::write(
+            jyc_dir.join("opencode-session.json"),
+            r#"{"sessionId":"test-id"}"#,
+        )
+        .await
+        .unwrap();
+
+        let context = Arc::new(InspectContext {
+            thread_managers: vec![],
+            channels: vec![ChannelInfo {
+                name: "test-ch".to_string(),
+                channel_type: "email".to_string(),
+                active_workers: 0,
+                max_concurrent: 0,
+            }],
+            health_stats: Arc::new(Mutex::new(
+                crate::core::metrics::HealthStats::default(),
+            )),
+            activity_map: Arc::new(Mutex::new(HashMap::new())),
+            start_time: Instant::now(),
+            config_path: None,
+            config: None,
+            workspace_dirs: vec![workspace_dir],
+        });
+
+        let cancel = CancellationToken::new();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let server = InspectServer::new(addr.to_string(), context, cancel.clone());
+        let _handle = server.start();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let mut client = InspectClient::new(&addr.to_string());
+        let (success, message) = client.reset_session("test-thread").await.unwrap();
+
+        assert!(success, "reset should succeed: {message}");
+        assert!(message.contains("session deleted"));
+        assert!(!jyc_dir.join("opencode-session.json").exists());
+
+        cancel.cancel();
     }
 }

--- a/src/inspect/client.rs
+++ b/src/inspect/client.rs
@@ -90,6 +90,7 @@ impl InspectClient {
             InspectResponse::State(state) => Ok(state),
             InspectResponse::Error { error } => anyhow::bail!("server error: {error}"),
             InspectResponse::ReloadResult { .. } => anyhow::bail!("unexpected reload_result for get_state"),
+            InspectResponse::ResetSessionResult { .. } => anyhow::bail!("unexpected reset_session_result for get_state"),
         }
     }
 
@@ -129,6 +130,7 @@ impl InspectClient {
             InspectResponse::ReloadResult { success, message } => Ok((success, message)),
             InspectResponse::Error { error } => Ok((false, error)),
             InspectResponse::State(_) => anyhow::bail!("unexpected state for reload_config"),
+            InspectResponse::ResetSessionResult { .. } => anyhow::bail!("unexpected reset_session_result for reload_config"),
         }
     }
 }

--- a/src/inspect/server.rs
+++ b/src/inspect/server.rs
@@ -160,6 +160,7 @@ impl InspectServer {
                 InspectResponse::State(state)
             }
             "reload_config" => Self::handle_reload_config(context).await,
+            "reset_session" => Self::handle_reset_session(request, context).await,
             other => InspectResponse::Error {
                 error: format!("unknown method: {other}"),
             },
@@ -215,6 +216,59 @@ impl InspectServer {
         InspectResponse::ReloadResult {
             success: true,
             message: "configuration reloaded".to_string(),
+        }
+    }
+
+    /// Delete the opencode session file for a given thread.
+    async fn handle_reset_session(
+        request: &InspectRequest,
+        context: &InspectContext,
+    ) -> InspectResponse {
+        let thread_name = match request.params.as_ref().and_then(|p| p.get("thread_name")) {
+            Some(v) => match v.as_str() {
+                Some(s) => s.to_string(),
+                None => {
+                    return InspectResponse::ResetSessionResult {
+                        success: false,
+                        message: "thread_name must be a string".to_string(),
+                    };
+                }
+            },
+            None => {
+                return InspectResponse::ResetSessionResult {
+                    success: false,
+                    message: "missing thread_name param".to_string(),
+                };
+            }
+        };
+
+        let session_path = context
+            .workspace_dirs
+            .iter()
+            .map(|d| d.join(&thread_name).join(".jyc").join("opencode-session.json"))
+            .find(|p| p.exists());
+
+        match session_path {
+            Some(path) => match tokio::fs::remove_file(&path).await {
+                Ok(()) => {
+                    tracing::info!(thread = %thread_name, "Session reset via inspect protocol");
+                    InspectResponse::ResetSessionResult {
+                        success: true,
+                        message: format!("session deleted for {thread_name}"),
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(thread = %thread_name, error = %e, "Failed to delete session file");
+                    InspectResponse::ResetSessionResult {
+                        success: false,
+                        message: format!("failed to delete session: {e}"),
+                    }
+                }
+            },
+            None => InspectResponse::ResetSessionResult {
+                success: true,
+                message: format!("no session exists for {thread_name}"),
+            },
         }
     }
 
@@ -805,6 +859,158 @@ mode = "opencode"
         }
 
         assert_eq!(config_swap.load().general.max_concurrent_threads, 10);
+
+        cancel.cancel();
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_inspect_server_reset_session() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace_dir = tmp.path().to_path_buf();
+        let thread_name = "test-thread";
+        let jyc_dir = workspace_dir.join(thread_name).join(".jyc");
+        tokio::fs::create_dir_all(&jyc_dir).await.unwrap();
+        tokio::fs::write(
+            jyc_dir.join("opencode-session.json"),
+            r#"{"sessionId":"test-id"}"#,
+        )
+        .await
+        .unwrap();
+
+        let ctx = Arc::new(InspectContext {
+            thread_managers: vec![],
+            channels: vec![],
+            health_stats: Arc::new(Mutex::new(crate::core::metrics::HealthStats::default())),
+            activity_map: Arc::new(Mutex::new(HashMap::new())),
+            start_time: Instant::now(),
+            config_path: None,
+            config: None,
+            workspace_dirs: vec![workspace_dir],
+        });
+
+        let cancel = CancellationToken::new();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let server = InspectServer::new(addr.to_string(), ctx, cancel.clone());
+        let handle = server.start();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (reader, mut writer) = stream.into_split();
+        let mut reader = BufReader::new(reader);
+
+        writer
+            .write_all(b"{\"method\":\"reset_session\",\"params\":{\"thread_name\":\"test-thread\"}}\n")
+            .await
+            .unwrap();
+        writer.flush().await.unwrap();
+
+        let mut response = String::new();
+        reader.read_line(&mut response).await.unwrap();
+
+        let resp: InspectResponse = serde_json::from_str(&response).unwrap();
+        match resp {
+            InspectResponse::ResetSessionResult { success, message } => {
+                assert!(success, "reset should succeed: {message}");
+                assert!(message.contains("session deleted"));
+            }
+            other => panic!("expected ResetSessionResult, got {:?}", other),
+        }
+
+        assert!(!jyc_dir.join("opencode-session.json").exists());
+
+        cancel.cancel();
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_inspect_server_reset_session_missing_param() {
+        let ctx = test_context();
+
+        let cancel = CancellationToken::new();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let server = InspectServer::new(addr.to_string(), ctx, cancel.clone());
+        let handle = server.start();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (reader, mut writer) = stream.into_split();
+        let mut reader = BufReader::new(reader);
+
+        writer
+            .write_all(b"{\"method\":\"reset_session\"}\n")
+            .await
+            .unwrap();
+        writer.flush().await.unwrap();
+
+        let mut response = String::new();
+        reader.read_line(&mut response).await.unwrap();
+
+        let resp: InspectResponse = serde_json::from_str(&response).unwrap();
+        match resp {
+            InspectResponse::ResetSessionResult { success, message } => {
+                assert!(!success);
+                assert!(message.contains("missing thread_name"));
+            }
+            other => panic!("expected ResetSessionResult, got {:?}", other),
+        }
+
+        cancel.cancel();
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_inspect_server_reset_session_no_existing_session() {
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace_dir = tmp.path().to_path_buf();
+
+        let ctx = Arc::new(InspectContext {
+            thread_managers: vec![],
+            channels: vec![],
+            health_stats: Arc::new(Mutex::new(crate::core::metrics::HealthStats::default())),
+            activity_map: Arc::new(Mutex::new(HashMap::new())),
+            start_time: Instant::now(),
+            config_path: None,
+            config: None,
+            workspace_dirs: vec![workspace_dir],
+        });
+
+        let cancel = CancellationToken::new();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let server = InspectServer::new(addr.to_string(), ctx, cancel.clone());
+        let handle = server.start();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (reader, mut writer) = stream.into_split();
+        let mut reader = BufReader::new(reader);
+
+        writer
+            .write_all(b"{\"method\":\"reset_session\",\"params\":{\"thread_name\":\"nonexistent\"}}\n")
+            .await
+            .unwrap();
+        writer.flush().await.unwrap();
+
+        let mut response = String::new();
+        reader.read_line(&mut response).await.unwrap();
+
+        let resp: InspectResponse = serde_json::from_str(&response).unwrap();
+        match resp {
+            InspectResponse::ResetSessionResult { success, message } => {
+                assert!(success, "no-session case should still succeed: {message}");
+                assert!(message.contains("no session exists"));
+            }
+            other => panic!("expected ResetSessionResult, got {:?}", other),
+        }
 
         cancel.cancel();
         handle.await.unwrap();

--- a/src/inspect/server.rs
+++ b/src/inspect/server.rs
@@ -242,6 +242,16 @@ impl InspectServer {
             }
         };
 
+        if thread_name.contains("..")
+            || thread_name.contains('/')
+            || thread_name.contains('\\')
+        {
+            return InspectResponse::ResetSessionResult {
+                success: false,
+                message: "invalid thread_name: path traversal not allowed".to_string(),
+            };
+        }
+
         let session_path = context
             .workspace_dirs
             .iter()
@@ -249,22 +259,40 @@ impl InspectServer {
             .find(|p| p.exists());
 
         match session_path {
-            Some(path) => match tokio::fs::remove_file(&path).await {
-                Ok(()) => {
-                    tracing::info!(thread = %thread_name, "Session reset via inspect protocol");
-                    InspectResponse::ResetSessionResult {
-                        success: true,
-                        message: format!("session deleted for {thread_name}"),
+            Some(path) => {
+                let canonical_ws = context.workspace_dirs.iter().filter_map(|d| d.canonicalize().ok()).collect::<Vec<_>>();
+                let canonical_path = match path.canonicalize() {
+                    Ok(p) => p,
+                    Err(e) => {
+                        return InspectResponse::ResetSessionResult {
+                            success: false,
+                            message: format!("failed to resolve session path: {e}"),
+                        };
                     }
-                }
-                Err(e) => {
-                    tracing::warn!(thread = %thread_name, error = %e, "Failed to delete session file");
-                    InspectResponse::ResetSessionResult {
+                };
+                if !canonical_ws.iter().any(|ws| canonical_path.starts_with(ws)) {
+                    return InspectResponse::ResetSessionResult {
                         success: false,
-                        message: format!("failed to delete session: {e}"),
+                        message: "invalid thread_name: path escapes workspace".to_string(),
+                    };
+                }
+                match tokio::fs::remove_file(&path).await {
+                    Ok(()) => {
+                        tracing::info!(thread = %thread_name, "Session reset via inspect protocol");
+                        InspectResponse::ResetSessionResult {
+                            success: true,
+                            message: format!("session deleted for {thread_name}"),
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(thread = %thread_name, error = %e, "Failed to delete session file");
+                        InspectResponse::ResetSessionResult {
+                            success: false,
+                            message: format!("failed to delete session: {e}"),
+                        }
                     }
                 }
-            },
+            }
             None => InspectResponse::ResetSessionResult {
                 success: true,
                 message: format!("no session exists for {thread_name}"),
@@ -1008,6 +1036,45 @@ mode = "opencode"
             InspectResponse::ResetSessionResult { success, message } => {
                 assert!(success, "no-session case should still succeed: {message}");
                 assert!(message.contains("no session exists"));
+            }
+            other => panic!("expected ResetSessionResult, got {:?}", other),
+        }
+
+        cancel.cancel();
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_inspect_server_reset_session_path_traversal() {
+        let ctx = test_context();
+
+        let cancel = CancellationToken::new();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+
+        let server = InspectServer::new(addr.to_string(), ctx, cancel.clone());
+        let handle = server.start();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let (reader, mut writer) = stream.into_split();
+        let mut reader = BufReader::new(reader);
+
+        writer
+            .write_all(b"{\"method\":\"reset_session\",\"params\":{\"thread_name\":\"../../etc\"}}\n")
+            .await
+            .unwrap();
+        writer.flush().await.unwrap();
+
+        let mut response = String::new();
+        reader.read_line(&mut response).await.unwrap();
+
+        let resp: InspectResponse = serde_json::from_str(&response).unwrap();
+        match resp {
+            InspectResponse::ResetSessionResult { success, message } => {
+                assert!(!success);
+                assert!(message.contains("path traversal"), "expected path traversal error, got: {message}");
             }
             other => panic!("expected ResetSessionResult, got {:?}", other),
         }

--- a/src/inspect/types.rs
+++ b/src/inspect/types.rs
@@ -24,6 +24,11 @@ pub enum InspectResponse {
         success: bool,
         message: String,
     },
+    /// Result of a `reset_session` request.
+    ResetSessionResult {
+        success: bool,
+        message: String,
+    },
 }
 
 // ── State snapshot ──
@@ -281,6 +286,39 @@ mod tests {
         assert_eq!(format!("{}", ThreadStatus::Idle), "Idle");
         assert_eq!(format!("{}", ThreadStatus::WaitingForAnswer), "Waiting");
         assert_eq!(format!("{}", ThreadStatus::Error), "Error");
+    }
+
+    #[test]
+    fn test_inspect_response_reset_session_result() {
+        let resp = InspectResponse::ResetSessionResult {
+            success: true,
+            message: "session deleted".to_string(),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains(r#""type":"reset_session_result""#));
+        assert!(json.contains("session deleted"));
+
+        let parsed: InspectResponse = serde_json::from_str(&json).unwrap();
+        match parsed {
+            InspectResponse::ResetSessionResult { success, message } => {
+                assert!(success);
+                assert_eq!(message, "session deleted");
+            }
+            _ => panic!("expected ResetSessionResult"),
+        }
+
+        let resp_fail = InspectResponse::ResetSessionResult {
+            success: false,
+            message: "missing thread_name param".to_string(),
+        };
+        let json_fail = serde_json::to_string(&resp_fail).unwrap();
+        let parsed_fail: InspectResponse = serde_json::from_str(&json_fail).unwrap();
+        match parsed_fail {
+            InspectResponse::ResetSessionResult { success, .. } => {
+                assert!(!success);
+            }
+            _ => panic!("expected ResetSessionResult"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Spec

Allow users to reset a thread's OpenCode session (delete `opencode-session.json`) directly from the TUI dashboard. This complements the existing `/reset` command that works via message channels, providing a convenient way to reset sessions for threads that may be stuck or need a fresh start.

Fixes #174

## Implementation Plan

### Step 1: Extend inspect protocol types
**What:** Add `ResetSessionResult` variant to `InspectResponse` in `src/inspect/types.rs`. The `InspectRequest.params` field (already `Option<serde_json::Value>`) will carry `{"thread_name": "issue-42"}` for the `reset_session` method.
**Why:** The inspect protocol needs a new method and response type to support session reset over TCP.
**Verify:** `cargo test --lib inspect::types` passes; new `ResetSessionResult` variant serializes/deserializes correctly.

### Step 2: Implement `reset_session` handler in inspect server
**What:** Add `"reset_session"` match arm in `InspectServer::handle_request()` in `src/inspect/server.rs`. Extract `thread_name` from `request.params`, locate the thread directory across `context.workspace_dirs`, delete `.jyc/opencode-session.json`, and return `ResetSessionResult`.
**Why:** Server-side logic to find and delete the session file for the requested thread.
**Verify:** Unit test sending `{"method":"reset_session","params":{"thread_name":"test-thread"}}` returns `ResetSessionResult{success: true}` and the session file is deleted.

### Step 3: Add `reset_session` method to inspect client
**What:** Add `pub async fn reset_session(&mut self, thread_name: &str) -> Result<(bool, String)>` to `InspectClient` in `src/inspect/client.rs`. Send `{"method":"reset_session","params":{"thread_name":"..."}}` and parse the `ResetSessionResult` response.
**Why:** Dashboard needs a client method to invoke the new server endpoint.
**Verify:** `cargo test --lib inspect::client` passes; integration test confirms `reset_session` sends correct request and parses response.

### Step 4: Add `s` key binding with confirmation to dashboard
**What:** In `src/cli/dashboard.rs`:
- Add `pending_reset: Option<String>` field to `App` struct (stores thread name pending confirmation, auto-clears after 3s)
- First press of `s`: set `pending_reset` to selected thread name, show status message "Press `s` again to confirm reset session for <thread>"
- Second press of `s` within 3s: call `client.reset_session(&thread_name)`, clear `pending_reset`, show result
- Timeout or other key: clear `pending_reset`
- Update `render_status_bar` help text to include `[s]reset session`
- Use `app.tick_status()` mechanism (increase timeout to 3s for pending reset, or add separate timer)
**Why:** Two-step confirmation prevents accidental session resets while keeping the UX simple.
**Verify:** Manual test — press `s` once shows confirmation prompt, press `s` again within 3s resets session, waiting >3s cancels. `cargo build` succeeds.

### Step 5: Handle edge cases and add tests
**What:** 
- Handle case where no thread is selected (show status message "No thread selected")
- Handle case where session file doesn't exist (return success with "no session exists" message, same as `/reset` command)
- Handle `reset_session` request with missing `thread_name` param (return error)
- Add test for `ResetSessionResult` serde roundtrip in `src/inspect/types.rs`
- Add test for `reset_session` in `src/inspect/client.rs` (using mock server)
**Why:** Robustness and consistency with existing `/reset` command behavior.
**Verify:** `cargo test` passes with all new tests.

## Design Decisions
- Confirmation mechanism: press `s` twice within 3 seconds (same pattern as vim's `:q` vs `:q!`)
- Only resets when a thread is selected in the dashboard table
- Consistent behavior with `/reset` command: only deletes `opencode-session.json`, no OpenCode server restart (next prompt auto-creates new session)
- Shortcut key `s` chosen as mnemonic for "session reset"