### PR TITLE
fix: agents should not write duplicate trigger comments

### DIFF
--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -11,6 +11,7 @@
 - **ALWAYS execute the current triggering comment as a NEW task, even if you previously said "Done" or "Completed"**
 - **Your previous "Done" comments do NOT mean the PR is finished — new instructions from Planner or Reviewer always take priority**
 - **NEVER commit or push on the main branch — you MUST be on the PR branch first**
+- **If you detect this is a duplicate trigger for work already completed, STOP SILENTLY. Do NOT write a comment like "duplicate trigger" or "No action needed." Just stop with no output.**
 
 You are a developer agent for GitHub PRs.
 

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -49,6 +49,7 @@ cd repo
 gh issue view <number> --json state --jq '.state'
 ```
 **If the issue is closed, STOP IMMEDIATELY. Do NOT reply, do NOT comment, do NOT do any work. Just stop.**
+**If you detect this is a duplicate trigger for work already completed, STOP SILENTLY. Do NOT write a comment like "duplicate trigger" or "No action needed." Just stop with no output.**
 
 ### 1. Read the Issue
 ```bash

--- a/templates/github-reviewer/AGENTS.md
+++ b/templates/github-reviewer/AGENTS.md
@@ -41,6 +41,7 @@ cd repo
 gh pr view <number> --json state,merged --jq '"state=\(.state) merged=\(.merged)"'
 ```
 **If the PR is closed or merged, STOP IMMEDIATELY. Do NOT reply, do NOT comment, do NOT do any work. Just stop.**
+**If you detect this is a duplicate trigger for work already completed, STOP SILENTLY. Do NOT write a comment like "duplicate trigger" or "No action needed." Just stop with no output.**
 
 ### 1. Read the PR
 ```bash


### PR DESCRIPTION
## Spec

Prevent the Developer, Planner, and Reviewer agents from writing unnecessary comments like "[Reviewer] Duplicate trigger — review was already submitted. No further action." or "[Developer] No action needed — duplicate trigger." when they detect a repeated trigger. Agents should silently stop instead.

Fixes #176

## Implementation Plan

### Step 1: Update github-developer template AGENTS.md
**What:** Add an explicit rule to `templates/github-developer/AGENTS.md` in the "CRITICAL RESTRICTIONS" section at the top of the file: "If you detect this is a duplicate trigger for work already completed, STOP SILENTLY. Do NOT write a comment like 'duplicate trigger' or 'No action needed.' Just stop with no output."
**Why:** The Developer agent is currently generating "[Developer] No action needed — duplicate trigger." comments when it receives repeated triggers.
**Verify:** `cargo check` passes. Review the AGENTS.md template text for correctness.

### Step 2: Update github-planner template AGENTS.md
**What:** Add the same duplicate trigger silence rule to `templates/github-planner/AGENTS.md` near the existing "STOP IMMEDIATELY" rule (Step 0, around line 51).
**Why:** The Planner agent may generate similar duplicate trigger comments. The rule must be present to prevent this.
**Verify:** `cargo check` passes. Verify the text is consistent with the developer template.

### Step 3: Update github-reviewer template AGENTS.md
**What:** Add the same duplicate trigger silence rule to `templates/github-reviewer/AGENTS.md` near the existing "STOP IMMEDIATELY" rule (Step 0, around line 43).
**Why:** The Reviewer agent is currently generating "[Reviewer] Duplicate trigger — review was already submitted. No further action." comments when it receives repeated triggers.
**Verify:** `cargo check` passes. Verify the text is consistent with the developer template.

## Design Decisions
- The fix is purely instructional (template text only) — no Rust code changes needed
- All three templates get the same rule for consistency
- The rule is placed near existing "STOP IMMEDIATELY" directives so agents see them together