### PR TITLE
feat: jyc-agent 支持多路径 skill 发现与加载

### DIFF
--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -46,7 +46,7 @@ pub fn parse_skill_frontmatter(content: &str) -> Option<SkillMeta> {
     let mut name = None;
     let mut description = None;
 
-    for line in &mut lines {
+    while let Some(line) = lines.next() {
         let trimmed = line.trim();
         // End of frontmatter
         if trimmed == "---" {
@@ -55,7 +55,28 @@ pub fn parse_skill_frontmatter(content: &str) -> Option<SkillMeta> {
         if let Some(value) = trimmed.strip_prefix("name:") {
             name = Some(value.trim().to_string());
         } else if let Some(value) = trimmed.strip_prefix("description:") {
-            description = Some(value.trim().to_string());
+            let val = value.trim();
+            if val == "|" || val == "|-" || val == ">" {
+                // YAML block scalar: collect indented lines until --- or non-indented line
+                let mut desc = String::new();
+                while let Some(line) = lines.next() {
+                    let trimmed = line.trim();
+                    if trimmed == "---" {
+                        // Put back the --- terminator so the outer loop can handle it
+                        // Actually we've already consumed it; just break
+                        break;
+                    }
+                    if !trimmed.is_empty() {
+                        if !desc.is_empty() {
+                            desc.push(' ');
+                        }
+                        desc.push_str(trimmed);
+                    }
+                }
+                description = Some(desc);
+            } else if !val.is_empty() {
+                description = Some(val.to_string());
+            }
         }
     }
 
@@ -169,6 +190,13 @@ impl JycAgentService {
         let mut result: Vec<SkillMeta> = skills.into_values().collect();
         // Sort by name for deterministic output
         result.sort_by(|a, b| a.name.cmp(&b.name));
+
+        tracing::info!(
+            thread_path = %thread_path.display(),
+            skills = ?result.iter().map(|s| s.name.as_str()).collect::<Vec<_>>(),
+            "Discovered {} skill(s)", result.len()
+        );
+
         result
     }
 

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -173,8 +173,6 @@ impl JycAgentService {
     }
 
     /// Build the system prompt for a thread.
-
-    /// Build the system prompt for a thread.
     fn build_system_prompt(&self, thread_path: &Path) -> String {
         let mut prompt = String::new();
 

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -22,20 +22,20 @@ use crate::types::AgentConfig;
 
 /// Metadata for a discovered skill.
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct SkillMeta {
+pub struct SkillMeta {
     /// Skill name (e.g., "coding-principles")
-    name: String,
+    pub name: String,
     /// Human-readable description
-    description: String,
+    pub description: String,
     /// Path to the skill's directory (contains SKILL.md)
-    source_path: PathBuf,
+    pub source_path: PathBuf,
 }
 
 /// Parse frontmatter from a SKILL.md file.
 ///
 /// Frontmatter is delimited by `---` lines. Supports `name:` and `description:` fields.
 /// Returns `None` if the file has no valid frontmatter or missing required fields.
-fn parse_skill_frontmatter(content: &str) -> Option<SkillMeta> {
+pub fn parse_skill_frontmatter(content: &str) -> Option<SkillMeta> {
     let mut lines = content.lines();
 
     // First line must be "---"
@@ -98,7 +98,7 @@ impl JycAgentService {
     ///
     /// Scans paths from lowest to highest priority (later paths override earlier ones
     /// when skills share the same name).
-    fn discover_skills(&self, thread_path: &Path) -> Vec<SkillMeta> {
+    pub fn discover_skills(&self, thread_path: &Path) -> Vec<SkillMeta> {
         let mut skills: HashMap<String, SkillMeta> = HashMap::new();
 
         // Build scan paths from low to high priority
@@ -281,7 +281,7 @@ impl JycAgentService {
 ///
 /// Produces a markdown-formatted list of available skills with their paths.
 /// Returns an empty string if the skills list is empty.
-fn format_skills_section(skills: &[SkillMeta]) -> String {
+pub fn format_skills_section(skills: &[SkillMeta]) -> String {
     if skills.is_empty() {
         return String::new();
     }

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -5,7 +5,7 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tokio::sync::{mpsc, Mutex};
 use tokio_util::sync::CancellationToken;
 use tracing;
@@ -20,6 +20,58 @@ use crate::session;
 use crate::tools::registry::ToolRegistry;
 use crate::types::AgentConfig;
 
+/// Metadata for a discovered skill.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SkillMeta {
+    /// Skill name (e.g., "coding-principles")
+    name: String,
+    /// Human-readable description
+    description: String,
+    /// Path to the skill's directory (contains SKILL.md)
+    source_path: PathBuf,
+}
+
+/// Parse frontmatter from a SKILL.md file.
+///
+/// Frontmatter is delimited by `---` lines. Supports `name:` and `description:` fields.
+/// Returns `None` if the file has no valid frontmatter or missing required fields.
+fn parse_skill_frontmatter(content: &str) -> Option<SkillMeta> {
+    let mut lines = content.lines();
+
+    // First line must be "---"
+    if lines.next()?.trim() != "---" {
+        return None;
+    }
+
+    let mut name = None;
+    let mut description = None;
+
+    for line in &mut lines {
+        let trimmed = line.trim();
+        // End of frontmatter
+        if trimmed == "---" {
+            break;
+        }
+        if let Some(value) = trimmed.strip_prefix("name:") {
+            name = Some(value.trim().to_string());
+        } else if let Some(value) = trimmed.strip_prefix("description:") {
+            description = Some(value.trim().to_string());
+        }
+    }
+
+    let name = name?;
+    let description = description?;
+    if name.is_empty() || description.is_empty() {
+        return None;
+    }
+
+    Some(SkillMeta {
+        name,
+        description,
+        source_path: PathBuf::new(), // caller fills this in
+    })
+}
+
 /// In-process AI agent service.
 ///
 /// Implements `AgentService` by running LLM inference and tool execution
@@ -28,16 +80,99 @@ pub struct JycAgentService {
     config: AgentConfig,
     /// Per-thread event bus map.
     event_buses: Mutex<HashMap<String, ThreadEventBusRef>>,
+    /// JYC workdir (for discovering global skills).
+    workdir: PathBuf,
 }
 
 impl JycAgentService {
-    /// Create a new agent service with the given configuration.
-    pub fn new(config: AgentConfig) -> Self {
+    /// Create a new agent service with the given configuration and workdir.
+    pub fn new(config: AgentConfig, workdir: PathBuf) -> Self {
         Self {
             config,
             event_buses: Mutex::new(HashMap::new()),
+            workdir,
         }
     }
+
+    /// Discover skills from multiple paths, with priority-based deduplication.
+    ///
+    /// Scans paths from lowest to highest priority (later paths override earlier ones
+    /// when skills share the same name).
+    fn discover_skills(&self, thread_path: &Path) -> Vec<SkillMeta> {
+        let mut skills: HashMap<String, SkillMeta> = HashMap::new();
+
+        // Build scan paths from low to high priority
+        let scan_paths: Vec<PathBuf> = {
+            let mut paths = Vec::new();
+
+            // $HOME/.config/opencode/skills/
+            if let Ok(home) = std::env::var("HOME") {
+                paths.push(PathBuf::from(&home).join(".config/opencode/skills"));
+                // $HOME/.claude/skills/
+                paths.push(PathBuf::from(&home).join(".claude/skills"));
+            }
+
+            // {jyc-data}/skills/ (via workdir)
+            paths.push(self.workdir.join("skills"));
+
+            // {thread_path}/repo/.claude/skills/
+            paths.push(thread_path.join("repo/.claude/skills"));
+            // {thread_path}/repo/.opencode/skills/
+            paths.push(thread_path.join("repo/.opencode/skills"));
+            // {thread_path}/repo/.jyc/skills/
+            paths.push(thread_path.join("repo/.jyc/skills"));
+
+            // {thread_path}/.claude/skills/
+            paths.push(thread_path.join(".claude/skills"));
+            // {thread_path}/.opencode/skills/
+            paths.push(thread_path.join(".opencode/skills"));
+            // {thread_path}/.jyc/skills/
+            paths.push(thread_path.join(".jyc/skills"));
+
+            paths
+        };
+
+        for scan_dir in &scan_paths {
+            if !scan_dir.exists() || !scan_dir.is_dir() {
+                continue;
+            }
+
+            let entries = match std::fs::read_dir(scan_dir) {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+
+            for entry in entries.flatten() {
+                let skill_dir = entry.path();
+                if !skill_dir.is_dir() {
+                    continue;
+                }
+
+                let skill_md = skill_dir.join("SKILL.md");
+                if !skill_md.exists() {
+                    continue;
+                }
+
+                let content = match std::fs::read_to_string(&skill_md) {
+                    Ok(c) => c,
+                    Err(_) => continue,
+                };
+
+                if let Some(mut meta) = parse_skill_frontmatter(&content) {
+                    meta.source_path = skill_dir;
+                    // HashMap insert: later (higher-priority) paths overwrite earlier ones
+                    skills.insert(meta.name.clone(), meta);
+                }
+            }
+        }
+
+        let mut result: Vec<SkillMeta> = skills.into_values().collect();
+        // Sort by name for deterministic output
+        result.sort_by(|a, b| a.name.cmp(&b.name));
+        result
+    }
+
+    /// Build the system prompt for a thread.
 
     /// Build the system prompt for a thread.
     fn build_system_prompt(&self, thread_path: &Path) -> String {
@@ -67,6 +202,12 @@ impl JycAgentService {
                 prompt.push_str(&content);
                 prompt.push_str("\n\n");
             }
+        }
+
+        // Discover and inject skill metadata
+        let skills = self.discover_skills(thread_path);
+        if !skills.is_empty() {
+            prompt.push_str(&format_skills_section(&skills));
         }
 
         // Reply instructions
@@ -134,6 +275,36 @@ impl JycAgentService {
     async fn get_event_bus(&self, thread_name: &str) -> Option<ThreadEventBusRef> {
         self.event_buses.lock().await.get(thread_name).cloned()
     }
+}
+
+/// Format the skills section for inclusion in the system prompt.
+///
+/// Produces a markdown-formatted list of available skills with their paths.
+/// Returns an empty string if the skills list is empty.
+fn format_skills_section(skills: &[SkillMeta]) -> String {
+    if skills.is_empty() {
+        return String::new();
+    }
+
+    let mut section = String::new();
+    section.push_str("## Available Skills\n\n");
+
+    for skill in skills {
+        section.push_str(&format!(
+            "- **{}** (at {})\n  {}\n\n",
+            skill.name,
+            skill.source_path.display(),
+            skill.description
+        ));
+    }
+
+    section.push_str(
+        "To load a skill's full instructions, use `read <skill-path>/SKILL.md`.\n\
+         All file paths within a SKILL.md are relative to that skill's directory.\n\
+         When running skill scripts: cd <skill-path> && <command>\n\n"
+    );
+
+    section
 }
 
 #[async_trait]

--- a/crates/jyc-agent/tests/unit_tests.rs
+++ b/crates/jyc-agent/tests/unit_tests.rs
@@ -563,9 +563,11 @@ mod skills {
         // but leave them empty so no system skills leak
         std::fs::create_dir_all(tmp.join(".config/opencode/skills")).ok();
         std::fs::create_dir_all(tmp.join(".claude/skills")).ok();
+        // SAFETY: guarded by HOME_LOCK mutex and restored after f() returns
         unsafe { std::env::set_var("HOME", tmp.as_os_str()); }
         f();
         if let Some(old) = old_home {
+            // SAFETY: restoring original value within same lock scope
             unsafe { std::env::set_var("HOME", old); }
         }
     }

--- a/crates/jyc-agent/tests/unit_tests.rs
+++ b/crates/jyc-agent/tests/unit_tests.rs
@@ -543,3 +543,210 @@ mod mcp_bridge {
         );
     }
 }
+
+mod skills {
+    use jyc_agent::service::{SkillMeta, format_skills_section, parse_skill_frontmatter};
+    use jyc_agent::JycAgentService;
+    use jyc_agent::types::AgentConfig;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+    use std::sync::Mutex;
+
+    /// Ensure HOME is set to a temp dir so system-level skills don't leak into tests.
+    /// Returns the guard that keeps the override alive.
+    static HOME_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_temp_home(tmp: &std::path::Path, f: impl FnOnce()) {
+        let _lock = HOME_LOCK.lock().unwrap();
+        let old_home = std::env::var("HOME").ok();
+        // Create .config/opencode/skills and .claude/skills in the temp dir
+        // but leave them empty so no system skills leak
+        std::fs::create_dir_all(tmp.join(".config/opencode/skills")).ok();
+        std::fs::create_dir_all(tmp.join(".claude/skills")).ok();
+        unsafe { std::env::set_var("HOME", tmp.as_os_str()); }
+        f();
+        if let Some(old) = old_home {
+            unsafe { std::env::set_var("HOME", old); }
+        }
+    }
+
+    /// Helper: create a JycAgentService with a specific workdir.
+    fn make_service(workdir: PathBuf) -> JycAgentService {
+        JycAgentService::new(
+            AgentConfig {
+                model: None,
+                providers: HashMap::new(),
+            },
+            workdir,
+        )
+    }
+
+    #[test]
+    fn no_skills_dir_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_temp_home(tmp.path(), || {
+            let svc = make_service(tmp.path().to_path_buf());
+            let skills = svc.discover_skills(tmp.path());
+            assert!(skills.is_empty());
+        });
+    }
+
+    #[test]
+    fn single_skill_parsed() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Create .jyc/skills/test-skill/SKILL.md
+        let skill_dir = tmp.path().join(".jyc/skills/test-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: test-skill\ndescription: A test skill\n---\n\n# Full content here\n",
+        ).unwrap();
+
+        with_temp_home(tmp.path(), || {
+            let svc = make_service(tmp.path().to_path_buf());
+            let skills = svc.discover_skills(tmp.path());
+            assert_eq!(skills.len(), 1);
+            assert_eq!(skills[0].name, "test-skill");
+            assert_eq!(skills[0].description, "A test skill");
+            assert!(skills[0].source_path.ends_with("test-skill"));
+        });
+    }
+
+    #[test]
+    fn empty_skills_dir_handled() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Create the directory but leave it empty
+        std::fs::create_dir_all(tmp.path().join(".jyc/skills")).unwrap();
+
+        with_temp_home(tmp.path(), || {
+            let svc = make_service(tmp.path().to_path_buf());
+            let skills = svc.discover_skills(tmp.path());
+            assert!(skills.is_empty());
+        });
+    }
+
+    #[test]
+    fn malformed_skill_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Create a valid skill
+        let good_dir = tmp.path().join(".jyc/skills/good-skill");
+        std::fs::create_dir_all(&good_dir).unwrap();
+        std::fs::write(
+            good_dir.join("SKILL.md"),
+            "---\nname: good-skill\ndescription: Valid\n---\n",
+        ).unwrap();
+
+        // Create a malformed skill (no frontmatter)
+        let bad_dir = tmp.path().join(".jyc/skills/bad-skill");
+        std::fs::create_dir_all(&bad_dir).unwrap();
+        std::fs::write(bad_dir.join("SKILL.md"), "Just some text, no frontmatter").unwrap();
+
+        with_temp_home(tmp.path(), || {
+            let svc = make_service(tmp.path().to_path_buf());
+            let skills = svc.discover_skills(tmp.path());
+            assert_eq!(skills.len(), 1);
+            assert_eq!(skills[0].name, "good-skill");
+        });
+    }
+
+    #[test]
+    fn same_name_priority() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Create .claude/skills/my-skill/ (lower priority — scanned earlier)
+        let claude_dir = tmp.path().join(".claude/skills/my-skill");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        std::fs::write(
+            claude_dir.join("SKILL.md"),
+            "---\nname: my-skill\ndescription: From claude\n---\n",
+        ).unwrap();
+
+        // Create .jyc/skills/my-skill/ (higher priority — scanned later, overwrites)
+        let jyc_dir = tmp.path().join(".jyc/skills/my-skill");
+        std::fs::create_dir_all(&jyc_dir).unwrap();
+        std::fs::write(
+            jyc_dir.join("SKILL.md"),
+            "---\nname: my-skill\ndescription: From JYC (overrides)\n---\n",
+        ).unwrap();
+
+        with_temp_home(tmp.path(), || {
+            let svc = make_service(tmp.path().to_path_buf());
+            let skills = svc.discover_skills(tmp.path());
+            assert_eq!(skills.len(), 1);
+            // Should take the .jyc version (higher priority)
+            assert_eq!(skills[0].description, "From JYC (overrides)");
+        });
+    }
+
+    #[test]
+    fn multi_path_discovery() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Skill 1 in .jyc/skills/
+        let d1 = tmp.path().join(".jyc/skills/skill-one");
+        std::fs::create_dir_all(&d1).unwrap();
+        std::fs::write(d1.join("SKILL.md"), "---\nname: skill-one\ndescription: One\n---\n").unwrap();
+
+        // Skill 2 in repo/.opencode/skills/
+        let d2 = tmp.path().join("repo/.opencode/skills/skill-two");
+        std::fs::create_dir_all(&d2).unwrap();
+        std::fs::write(d2.join("SKILL.md"), "---\nname: skill-two\ndescription: Two\n---\n").unwrap();
+
+        with_temp_home(tmp.path(), || {
+            let svc = make_service(tmp.path().to_path_buf());
+            let skills = svc.discover_skills(tmp.path());
+            assert_eq!(skills.len(), 2);
+            let names: Vec<&str> = skills.iter().map(|s| s.name.as_str()).collect();
+            assert!(names.contains(&"skill-one"));
+            assert!(names.contains(&"skill-two"));
+        });
+    }
+
+    #[test]
+    fn format_includes_path() {
+        let meta = SkillMeta {
+            name: "test-skill".to_string(),
+            description: "A test skill".to_string(),
+            source_path: PathBuf::from("/some/path/to/test-skill"),
+        };
+        let section = format_skills_section(&[meta]);
+        assert!(section.contains("(at /some/path/to/test-skill)"));
+        assert!(section.contains("**test-skill**"));
+        assert!(section.contains("A test skill"));
+        assert!(section.contains("## Available Skills"));
+        assert!(section.contains("read <skill-path>/SKILL.md"));
+    }
+
+    #[test]
+    fn format_section_empty_returns_empty_string() {
+        let section = format_skills_section(&[]);
+        assert!(section.is_empty());
+    }
+
+    #[test]
+    fn parse_frontmatter_valid() {
+        let content = "---\nname: my-skill\ndescription: Does something useful\n---\n\nBody text here";
+        let meta = parse_skill_frontmatter(content).unwrap();
+        assert_eq!(meta.name, "my-skill");
+        assert_eq!(meta.description, "Does something useful");
+    }
+
+    #[test]
+    fn parse_frontmatter_no_delimiter_returns_none() {
+        assert!(parse_skill_frontmatter("no frontmatter here").is_none());
+    }
+
+    #[test]
+    fn parse_frontmatter_missing_name_returns_none() {
+        assert!(parse_skill_frontmatter("---\ndescription: desc\n---\n").is_none());
+    }
+
+    #[test]
+    fn parse_frontmatter_missing_description_returns_none() {
+        assert!(parse_skill_frontmatter("---\nname: n\n---\n").is_none());
+    }
+
+    #[test]
+    fn parse_frontmatter_empty_values_returns_none() {
+        assert!(parse_skill_frontmatter("---\nname: \ndescription: d\n---\n").is_none());
+        assert!(parse_skill_frontmatter("---\nname: n\ndescription: \n---\n").is_none());
+    }
+}

--- a/crates/jyc-agent/tests/unit_tests.rs
+++ b/crates/jyc-agent/tests/unit_tests.rs
@@ -751,4 +751,29 @@ mod skills {
         assert!(parse_skill_frontmatter("---\nname: \ndescription: d\n---\n").is_none());
         assert!(parse_skill_frontmatter("---\nname: n\ndescription: \n---\n").is_none());
     }
+
+    #[test]
+    fn parse_frontmatter_block_scalar_pipe() {
+        // Multi-line description using YAML block scalar |
+        let content = "---\nname: my-skill\ndescription: |\n  Line one\n  Line two\n---\n\nBody";
+        let meta = parse_skill_frontmatter(content).unwrap();
+        assert_eq!(meta.name, "my-skill");
+        assert_eq!(meta.description, "Line one Line two");
+    }
+
+    #[test]
+    fn parse_frontmatter_block_scalar_greater_than() {
+        // Folded block scalar >
+        let content = "---\nname: fs\ndescription: >\n  Folded line one\n  Folded line two\n---\n";
+        let meta = parse_skill_frontmatter(content).unwrap();
+        assert_eq!(meta.name, "fs");
+        assert_eq!(meta.description, "Folded line one Folded line two");
+    }
+
+    #[test]
+    fn parse_frontmatter_block_scalar_empty_returns_none() {
+        // Block scalar with no content lines → empty description → None
+        let content = "---\nname: n\ndescription: |\n---\n";
+        assert!(parse_skill_frontmatter(content).is_none());
+    }
 }

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -196,7 +196,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     model,
                     providers,
                 };
-                Arc::new(JycAgentService::new(agent_cfg))
+                Arc::new(JycAgentService::new(agent_cfg, workdir.to_path_buf()))
             }
             "static" => {
                 let text = agent_config


### PR DESCRIPTION
## Spec

为 JYC-agent（进程内模式）添加 skill 支持。采用与成熟 agent（Claude Code / OpenCode）一致的模式：多路径发现 → 元数据入 prompt → agent 按需加载。Skill 内容保持原位，不做文件系统归一化。与 OpenCode 模式完全解耦。

Fixes #181

## Implementation Plan

### Step 1: 新增 `SkillMeta` 结构和 frontmatter 解析
**What:** 在 `crates/jyc-agent/src/service.rs` 中新增：
```rust
struct SkillMeta {
    name: String,
    description: String,
    source_path: PathBuf,
}

fn parse_skill_frontmatter(content: &str) -> Option<SkillMeta>
```
- `---` 分割取 frontmatter，逐行解析 `name:` 和 `description:`
- 使用字符串解析，不引入 yaml 依赖

**Why:** 数据结构基础；frontmatter 解析是读取 skill 元数据的前提

**Verify:** 对现有 8 个 SKILL.md 逐一测试解析 → 全部成功提取 name 和 description

### Step 2: `JycAgentService` 新增 `workdir` 字段
**What:** 
- `JycAgentService` 新增 `workdir: PathBuf` 字段
- `new()` 签名改为 `new(config: AgentConfig, workdir: PathBuf) -> Self`
- `crates/jyc-cli/src/cli/monitor.rs:199` 改为 `JycAgentService::new(agent_cfg, workdir.to_path_buf())`

**Why:** `{jyc-data}/skills/` 全局路径需要通过 `workdir` 访问

**Verify:** `cargo check` 编译通过

### Step 3: 实现 `discover_skills()` — 多路径扫描 + 优先级去重
**What:** 在 `JycAgentService` 中新增：
```rust
fn discover_skills(&self, thread_path: &Path) -> Vec<SkillMeta>
```

扫描路径（从低到高优先级，后覆盖前）：

| 优先级 | 路径 |
|--------|------|
| 最低 | `$HOME/.config/opencode/skills/` |
| ↓ | `$HOME/.claude/skills/` |
| ↓ | `{jyc-data}/skills/` |
| ↓ | `{thread_path}/repo/.claude/skills/` |
| ↓ | `{thread_path}/repo/.opencode/skills/` |
| ↓ | `{thread_path}/repo/.jyc/skills/` |
| ↓ | `{thread_path}/.claude/skills/` |
| ↓ | `{thread_path}/.opencode/skills/` |
| 最高 | `{thread_path}/.jyc/skills/` |

每个路径：`read_dir` → 子目录过滤 → 读 `SKILL.md` → `parse_skill_frontmatter()` → 按 name 去重（HashMap insert 覆盖）

**Why:** 多路径覆盖所有可能的 skill 来源，优先级保证最特定路径胜出

**Verify:** 
- `cargo test -p jyc-agent -- skills` 测试通过
- 关键用例：同名 skill 在 `.jyc/skills/` 和 `$HOME/.claude/skills/` → 前者胜出

### Step 4: 实现 `format_skills_section()` — Prompt 格式化
**What:** 将 `Vec<SkillMeta>` 格式化为 system prompt 段落：
```
## Available Skills

- **invoice-processing** (at .opencode/skills/invoice-processing/)
  Process invoices from messages (PDF/image attachments or URLs)...

- **coding-principles** (at /home/jiny/.claude/skills/coding-principles/)
  Andrej Karpathy's 4 coding principles for LLM agents...

To load a skill's full instructions, use `read <skill-path>/SKILL.md`.
All file paths within a SKILL.md are relative to that skill's directory.
When running skill scripts: cd <skill-path> && <command>
```
- 空列表返回空字符串
- 路径使用 `source_path.display()` 透传

**Why:** 清晰告知 agent skill 的存在及其实际位置

**Verify:** 格式化输出包含正确的 `(at <path>)` 标注

### Step 5: 修改 `build_system_prompt()` 集成 skill 发现
**What:** 在 `service.rs:54`（repo/AGENTS.md 加载后）插入：
```rust
let skills = self.discover_skills(thread_path);
if !skills.is_empty() {
    prompt.push_str(&format_skills_section(&skills));
}
```

**Why:** 将 skill 信息注入 system prompt，agent 在推理前即可获知可用 skill

**Verify:**
- 无 skill 目录 → prompt 不含 skill 段
- 有 2 个 skill → prompt 含 2 行元数据，带路径标注

### Step 6: 编写单元测试
**What:** 在 `crates/jyc-agent/tests/unit_tests.rs` 新增 `mod skills` 测试模块

| 测试 | 验证 |
|------|------|
| `no_skills_dir_returns_empty` | 无任何 skill 目录 → `[]` |
| `single_skill_parsed` | 单个 skill → name/description/source_path 正确 |
| `empty_skills_dir_handled` | 目录存在但为空 → 不崩溃 |
| `malformed_skill_skipped` | SKILL.md 格式损坏 → 跳过，不影响其他 |
| `same_name_priority` | `.jyc/skills/` 覆盖 `$HOME/.claude/skills/` |
| `multi_path_discovery` | 多个路径 → 所有 skill 均被发现 |
| `format_includes_path` | 格式化输出包含 `(at ...)` |

**Why:** 覆盖边界情况，确保鲁棒性

**Verify:** `cargo test -p jyc-agent` 全部通过

## Design Decisions

| 决策 | 理由 |
|------|------|
| 不做文件系统归一化 | 与 Claude Code / OpenCode 一致；最小副作用 |
| 路径透传 | Agent 知道真实位置，`cd` 即可正确执行脚本 |
| 元数据入 prompt，内容 `read` 按需加载 | 节省 token；成熟 agent 通用模式 |
| 不新增 skill 工具 | `read` + `bash` + `cd` 足够 |
| 字符串解析 frontmatter | 格式固定简单，不引入 yaml 依赖 |
| `.jyc/skills/` 最高优先级 | JYC 自身 skill 覆盖外部来源 |

## Files Changed

| 文件 | 改动 |
|------|------|
| `crates/jyc-agent/src/service.rs` | +~120 行（SkillMeta + 3 函数 + prompt 集成 + workdir 字段） |
| `crates/jyc-agent/tests/unit_tests.rs` | +~120 行（mod skills + 7 测试） |
| `crates/jyc-cli/src/cli/monitor.rs` | 1 行改动（传 workdir） |