### PR TITLE
feat: 在dashboard中显示每个thread加载的skills

### DIFF
--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -236,6 +236,12 @@ impl JycAgentService {
             prompt.push_str(&format_skills_section(&skills));
         }
 
+        // Persist skill names to .jyc/skills.json for dashboard inspection
+        let skill_names: Vec<&str> = skills.iter().map(|s| s.name.as_str()).collect();
+        if let Err(e) = persist_skill_names(thread_path, &skill_names) {
+            tracing::warn!(error = %e, "Failed to persist skill names to skills.json");
+        }
+
         // Reply instructions
         prompt.push_str(
             "## Reply Instructions\n\
@@ -301,6 +307,20 @@ impl JycAgentService {
     async fn get_event_bus(&self, thread_name: &str) -> Option<ThreadEventBusRef> {
         self.event_buses.lock().await.get(thread_name).cloned()
     }
+}
+
+/// Persist skill names to the thread's .jyc/skills.json file.
+///
+/// This allows the dashboard to read the skills list without re-scanning directories.
+fn persist_skill_names(thread_path: &Path, skill_names: &[&str]) -> Result<()> {
+    let jyc_dir = thread_path.join(".jyc");
+    std::fs::create_dir_all(&jyc_dir)
+        .with_context(|| format!("Failed to create .jyc dir: {}", jyc_dir.display()))?;
+    let skills_path = jyc_dir.join("skills.json");
+    let json = serde_json::to_string_pretty(skill_names)?;
+    std::fs::write(&skills_path, json)
+        .with_context(|| format!("Failed to write skills.json: {}", skills_path.display()))?;
+    Ok(())
 }
 
 /// Format the skills section for inclusion in the system prompt.

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -422,7 +422,7 @@ fn render_details(frame: &mut Frame, area: Rect, app: &App) {
     let detail_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(7), // Thread info
+            Constraint::Length(8), // Thread info
             Constraint::Min(4),   // Activity log
         ])
         .split(area);
@@ -449,6 +449,22 @@ fn render_details(frame: &mut Frame, area: Rect, app: &App) {
         Span::styled("Mode: ", Style::default().add_modifier(Modifier::BOLD)),
         Span::raw(selected.mode.as_deref().unwrap_or("build")),
     ]));
+
+    // Skills line
+    if selected.skills.is_empty() {
+        info_lines.push(Line::from(vec![
+            Span::styled("Skills: ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::styled("(none)", Style::default().fg(Color::DarkGray)),
+        ]));
+    } else {
+        info_lines.push(Line::from(vec![
+            Span::styled(
+                format!("Skills ({}): ", selected.skills.len()),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(selected.skills.join(", ")),
+        ]));
+    }
 
     let mut status_line = vec![
         Span::styled("Status: ", Style::default().add_modifier(Modifier::BOLD)),

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -702,6 +702,9 @@ impl ThreadManager {
             let model = read_model_override(&thread_path).await;
             let mode = read_mode_override(&thread_path).await;
 
+            // Read skills from .jyc/skills.json
+            let skills = read_skills(&thread_path).await;
+
             // Determine status
             let status = if thread_path.join(".jyc").join("question-sent.flag").exists() {
                 ThreadStatus::WaitingForAnswer
@@ -736,6 +739,7 @@ impl ThreadManager {
                 max_tokens,
                 activity: vec![],  // Filled by InspectServer from event bus
                 last_active_at,  // Filled by activity tracker; falls back to .jyc mtime
+                skills,
             });
         }
 
@@ -1430,6 +1434,17 @@ async fn read_signal_attachments(
         .collect();
 
     Some(attachments)
+}
+
+/// Read skills from thread's .jyc/skills.json file.
+async fn read_skills(thread_path: &Path) -> Vec<String> {
+    let skills_path = thread_path.join(".jyc").join("skills.json");
+    match tokio::fs::read_to_string(&skills_path).await {
+        Ok(content) => {
+            serde_json::from_str::<Vec<String>>(&content).unwrap_or_default()
+        }
+        Err(_) => Vec::new(),
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/jyc-types/src/inspect.rs
+++ b/crates/jyc-types/src/inspect.rs
@@ -88,6 +88,9 @@ pub struct ThreadInfo {
     /// Last activity timestamp (RFC 3339), if known
     #[serde(default)]
     pub last_active_at: Option<String>,
+    /// Skills loaded for this thread
+    #[serde(default)]
+    pub skills: Vec<String>,
 }
 
 /// Severity level for an activity entry.
@@ -224,6 +227,7 @@ mod tests {
                 max_tokens: Some(120000),
                 activity: vec![],
                 last_active_at: None,
+                skills: vec!["coding-principles".to_string(), "dev-workflow".to_string()],
             }],
             stats: GlobalStats {
                 active_workers: 2,


### PR DESCRIPTION
## Spec

在 dashboard TUI 的线程详情面板中显示当前线程已加载的 skills 名称和数量。通过持久化技能列表到 `.jyc/skills.json` 并在 `list_threads()` 中读取来实现。

Fixes #183

## Implementation Plan

### Step 1: `ThreadInfo` 增加 `skills` 字段
**What:** 在 `crates/jyc-types/src/inspect.rs` 的 `ThreadInfo` 结构体中添加 `#[serde(default)] pub skills: Vec<String>` 字段，并更新测试中的 `ThreadInfo` 构造。
**Why:** dashboard 需要从 inspect state 中获取每个线程的技能列表。
**Verify:** `cargo test -p jyc-types` 通过，所有涉及 `ThreadInfo` 构造的测试仍然通过。

### Step 2: `list_threads()` 读取 `.jyc/skills.json`
**What:** 在 `crates/jyc-core/src/thread_manager.rs` 的 `list_threads()` 方法中，读取 `thread_path.join(".jyc").join("skills.json")`，将 JSON 反序列化为 `Vec<String>` 并填入 `ThreadInfo::skills`。
**Why:** 使 inspect server 的 `build_state()` 能够获取到线程的技能列表。
**Verify:** 编译通过 `cargo check -p jyc-core`，逻辑正确性后续端到端验证。

### Step 3: 系统提示构建时持久化技能名
**What:** 在 `crates/jyc-agent/src/service.rs` 的 `build_system_prompt()` 方法中，调用 `discover_skills()` 后，将技能名的 `Vec<String>` 写入 `thread_path/.jyc/skills.json`（使用 `std::fs::write` + `serde_json::to_string_pretty`）。
**Why:** 确保每次构建系统提示时都同步更新磁盘上的技能列表，dashboard 读取时始终是最新数据。
**Verify:** 编译通过 `cargo check -p jyc-agent`，单元测试验证 `discover_skills` 后 skills.json 文件正确生成。

### Step 4: Dashboard 详情面板展示 Skills
**What:** 在 `crates/jyc-cli/src/cli/dashboard.rs` 的 `render_details()` 中：
  - 将 info 区域高度从 `Constraint::Length(7)` 改为 `Constraint::Length(8)`
  - 在 Model 行之后、Status 行之前插入 Skills 行：
    - 有技能时：`Skills (N): skill1, skill2, ...`
    - 无技能时：`Skills: (none)`
**Why:** 用户可以在 dashboard 中直观看到每个线程加载了哪些 skills。
**Verify:** `cargo check -p jyc-cli` 通过，格式符合预期。

## Design Decisions
- 使用 `.jyc/skills.json` 文件持久化，而非实时扫描目录，避免每次 poll 都做文件 I/O
- 技能列表只在 `build_system_prompt` 时更新（每条新消息处理时），与技能发现逻辑保持一致
- Skills 放在详情面板的 Model 行和 Status 行之间，显示格式为 `Skills (N): name1, name2, ...`