### PR TITLE
chore: bump version to v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,20 +78,17 @@ All notable changes to JYC will be documented in this file.
 
 ## [Unreleased]
 
-### Changed
+## [0.3.1] - 2026-05-18
 
-- **Refactored to Rust workspace structure** (#179) — Split single crate into 8 workspace crates:
-  - `jyc-types` — Shared types (InboundMessage, ChannelPattern, AppConfig, etc.)
-  - `jyc-utils` — Utility functions (helpers, constants, attachment validation)
-  - `jyc-core` — Core business logic (AgentService trait, ThreadManager, MessageRouter, commands)
-  - `jyc-services` — External service integrations (OpenCode, IMAP, SMTP)
-  - `jyc-channels` — Channel adapters (email, feishu, github)
-  - `jyc-inspect` — Runtime inspection server/client
-  - `jyc-mcp` — MCP tools (reply, question, vision)
-  - `jyc-cli` — CLI binary
-- Eliminated config↔channels circular dependency by merging types into jyc-types
-- AgentService trait kept in jyc-core to avoid circular deps with ThreadEventBusRef
-- Dockerfile updated for workspace structure (crate directory layout)
+### Added
+- **Multi-path skill discovery** (#182) — Skills are now loaded from 9 priority paths (`.jyc/skills/` → `.claude/skills/` → `.opencode/skills/` → user home → system), with higher-priority paths overriding same-named skills from lower-priority paths. Supports YAML frontmatter with block scalar descriptions.
+- **Dashboard skills display** (#184) — Dashboard TUI detail panel now shows the list of skills loaded for each thread.
+
+### Fixed
+- **Read tool symlink support** — `read` tool now follows symlinks within the working directory (previously rejected symlinks as "outside working directory").
+
+### Changed
+- **40 unit tests** added for jyc-agent regression coverage (skill parsing, discovery, and formatting).
 
 ## [0.2.1] - 2026-04-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "jyc-agent"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1491,7 +1491,7 @@ dependencies = [
 
 [[package]]
 name = "jyc-channels"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "jyc-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "jyc-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "jyc-inspect"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1594,7 +1594,7 @@ dependencies = [
 
 [[package]]
 name = "jyc-mcp"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1612,7 +1612,7 @@ dependencies = [
 
 [[package]]
 name = "jyc-services"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "jyc-types"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1656,7 +1656,7 @@ dependencies = [
 
 [[package]]
 name = "jyc-utils"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "jyc-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 
 [profile.dev]

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3295,8 +3295,9 @@ Overseas Server (HK)                    Mainland China Server (Shanghai)
 ### Templates & Skills
 
 Agent templates define the role, instructions, and skills for each thread type.
-Templates live in the repo under `templates/`, skills under `.opencode/skills/`.
-A deploy script composes them at deploy time.
+Templates live in the repo under `templates/`. Skills are discovered from multiple
+priority paths at runtime, with thread-local paths overriding repo paths, which
+override system paths. A deploy script composes them at deploy time.
 
 **Repository structure:**
 
@@ -3309,7 +3310,7 @@ templates/                      ← AGENTS.md only (role + instructions)
   github-developer/AGENTS.md
   github-reviewer/AGENTS.md
 
-.opencode/skills/               ← Single source of truth for all skills
+.opencode/skills/               ← Default in-repo skills (lowest priority per-thread)
   invoice-processing/           ← Invoice extraction workflow
   dev-workflow/                 ← Branching, commits, releases
   incremental-dev/              ← Small-step development methodology
@@ -3317,7 +3318,34 @@ templates/                      ← AGENTS.md only (role + instructions)
   pr-review/                    ← Read-only PR review
   jyc-deploy-bare/              ← Bare metal deployment
   jyc-deploy-docker/            ← Docker deployment
+
+.claude/skills/                 ← Alternative in-repo skills (overrides .opencode/)
+.jyc/skills/                    ← Thread-local override (highest in-repo priority)
 ```
+
+**Multi-path skill discovery:**
+
+When building an agent's system prompt, `discover_skills()` scans 9 paths in
+priority order (lowest first, highest last). Same-named skills from
+higher-priority paths override those from lower-priority paths, so a
+`.jyc/skills/coding-principles/SKILL.md` completely replaces one in
+`.opencode/skills/coding-principles/SKILL.md`.
+
+| Priority | Path | Scope |
+|----------|------|-------|
+| 1 (lowest) | `$HOME/.config/opencode/skills/` | User system |
+| 2 | `$HOME/.claude/skills/` | User system |
+| 3 | `{jyc-data}/skills/` | JYC data directory |
+| 4 | `{thread}/repo/.claude/skills/` | Thread repo |
+| 5 | `{thread}/repo/.opencode/skills/` | Thread repo |
+| 6 | `{thread}/repo/.jyc/skills/` | Thread repo (highest in repo) |
+| 7 | `{thread}/.claude/skills/` | Thread-local |
+| 8 | `{thread}/.opencode/skills/` | Thread-local |
+| 9 (highest) | `{thread}/.jyc/skills/` | Thread-local override |
+
+Thread-local `.jyc/skills/` is the highest priority path — it provides a
+mechanism for overriding any skill on a per-thread basis without modifying the
+shared repository.
 
 **Skill → Template mapping:**
 
@@ -3338,9 +3366,11 @@ templates/                      ← AGENTS.md only (role + instructions)
 ```
 
 The script copies each template's `AGENTS.md` and its referenced skills from
-`.opencode/skills/` into the target directory. When a thread is created with
-a template, the `AGENTS.md` and `.opencode/skills/` are copied to the thread's
-workspace directory.
+the repository's skill directories into the target directory. When a thread is
+created with a template, the `AGENTS.md` is copied to the thread workspace.
+Skills are then discovered at runtime from all 9 priority paths (see table above)
+via `discover_skills()`, with thread-local paths overriding any repo or system
+skills of the same name.
 
 **Adding a new template:**
 


### PR DESCRIPTION
## Spec

Bump JYC version from v0.3.0 to v0.3.1. Update `Cargo.toml`, `CHANGELOG.md`, and `DESIGN.md` to reflect changes since the last release.

Fixes #185

## Implementation Plan

### Step 1: Update Cargo.toml version
**What:** Change `version = "0.3.0"` to `version = "0.3.1"` in `/Cargo.toml` line 6 (`[workspace.package]` section).
**Why:** This is the source of truth for the Rust binary version. The `--version` CLI flag and inspect protocol both derive from this field via `CARGO_PKG_VERSION`.
**Verify:** `grep 'version = "0.3.1"' Cargo.toml` returns the updated line.

### Step 2: Update CHANGELOG.md
**What:** 
- Remove the stale `[Unreleased]` section at lines 79-94 (workspace refactoring content already duplicated in v0.3.0 section at line 22).
- Insert a new `## [0.3.1] - 2026-05-18` section at line 79 (after the v0.3.0 block, before `## [0.2.1]`), with the following subsections:

  ```
  ### Added
  - **Multi-path skill discovery** (#182) — Skills are now loaded from 9 priority paths (`.jyc/skills/` → `.claude/skills/` → `.opencode/skills/` → user home → system), with higher-priority paths overriding same-named skills from lower-priority paths. Supports YAML frontmatter with block scalar descriptions.
  - **Dashboard skills display** (#184) — Dashboard TUI detail panel now shows the list of skills loaded for each thread.

  ### Fixed
  - **Read tool symlink support** — `read` tool now follows symlinks within the working directory (previously rejected symlinks as "outside working directory").

  ### Changed
  - **40 unit tests** added for jyc-agent regression coverage (skill parsing, discovery, and formatting).
  ```

- Add a new empty `## [Unreleased]` section at line 79 (above the new `[0.3.1]` section) for future changes.
**Why:** CHANGELOG.md is the user-facing change log. Remove stale duplicate content and document all post-v0.3.0 changes.
**Verify:** Read the updated CHANGELOG.md to confirm correct structure: `[Unreleased]` → `[0.3.1]` → `[0.3.0]` → `[0.2.1]`…

### Step 3: Update DESIGN.md — Templates & Skills section
**What:** In `/DESIGN.md`, update the **Templates & Skills** section (around lines 3295-3350):
- Update the repository structure diagram to show multiple skill source paths (`.jyc/skills/`, `.claude/skills/`, `.opencode/skills/`).
- Add a paragraph explaining the 9-path priority scanning mechanism: when building an agent's system prompt, `discover_skills()` scans paths in priority order, and same-named skills from higher-priority paths override those from lower-priority paths.
- Note the thread-local `.jyc/skills/` directory as the highest priority path.
**Why:** The current DESIGN.md describes skills as loaded from a single source (`.opencode/skills/`). #182 changed this to multi-path discovery, which is an architectural change that DESIGN.md should reflect.
**Verify:** Read the updated DESIGN.md Templates & Skills section to confirm it describes multi-path discovery with priority rules.

## Design Decisions
- **PATCH bump** (not MINOR): the changes since v0.3.0 are enhancements and fixes within existing architecture, no breaking changes.
- **Remove stale [Unreleased] content**: the workspace refactoring detail was committed before v0.3.0 and is already summarized in the v0.3.0 section.
- **DESIGN.md update scope**: only the Templates & Skills section needs updating; the multi-path discovery is the only architectural change since v0.3.0.