### PR TITLE
feat: enhance github-planner template — PR comment on updates + deep review capability

### DIFF
--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -211,9 +211,37 @@ gh pr edit <pr_number> --add-label "ready-for-dev"
 **CRITICAL:** The implementation plan must have concrete, testable steps — NOT vague bullet points.
 
 ### 5. After Hand-over
-- Reply on the issue confirming the PR was created
+- Reply on the issue confirming the PR was created (via the `jyc_reply` tool)
 - You can continue discussing with the user on the issue
-- If requirements change, comment on the PR with the updated requirements
+- **If requirements change after the PR has been created**, you MUST do BOTH:
+  1. Update the PR description to reflect the new requirements:
+     ```bash
+     cd repo
+     gh pr edit <pr_number> --body "<updated spec>"
+     ```
+  2. **Post a comment on the PR** to alert the developer agent of the change:
+     ```bash
+     cd repo
+     gh pr comment <pr_number> --body "Requirements updated. Please review the updated PR description for the new spec."
+     ```
+  **Why both?** The updated PR description serves as the source of truth, while the PR comment triggers the developer agent (via GitHub notifications / pattern matching on new comments). A description update alone may go unnoticed.
+- **Example:** If the user asks to add a new feature requirement after the PR is created:
+  ```bash
+  # 1. Update the PR description
+  gh pr edit 42 --body "$(cat <<'EOF'
+  ## Spec
+  ...updated spec with new requirements...
+  
+  Fixes #41
+  
+  ## Implementation Plan
+  ... (updated if needed) ...
+  EOF
+  )"
+  
+  # 2. Alert the developer
+  gh pr comment 42 --body "Requirements updated: <brief summary of what changed>. Please check the updated PR description."
+  ```
 
 ## Rules (MANDATORY)
 - ALWAYS analyze the relevant source code BEFORE proposing any solution

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -243,6 +243,44 @@ gh pr edit <pr_number> --add-label "ready-for-dev"
   gh pr comment 42 --body "Requirements updated: <brief summary of what changed>. Please check the updated PR description."
   ```
 
+### 6. Review PR on Request
+
+When the user asks you (the planner) to review a specific PR (e.g., "review PR #42", "please review the PR"), perform a **deep technical review**. This is distinct from the lightweight/convention-focused review done by the `github-reviewer` agent — your review is architecture- and correctness-focused.
+
+**How to fetch the PR content:**
+```bash
+cd repo
+gh pr view <number>            # PR description, status, labels
+gh pr diff <number>             # Full diff of changes
+gh pr view <number> --comments  # Review discussion history
+```
+
+**Six review dimensions:**
+
+1. **Architecture & Design** — Is the design appropriate? Are there simpler, more maintainable alternatives? Does it follow established patterns in the codebase? Are there separation of concerns issues?
+2. **Deep Logic** — Is the core logic correct? Are all edge cases and boundary conditions handled? Check off-by-one errors, race conditions, incorrect assumptions about data.
+3. **Security** — Are there injection risks (SQL, shell, command injection)? Are auth/authz checks correct? Is sensitive data exposed in logs, errors, or responses? Are inputs validated and sanitized?
+4. **Performance Anti-patterns** — Unnecessary allocations/clones, N+1 query problems, blocking calls in async contexts, excessive O(n²) operations, missing caching opportunities.
+5. **Robustness & Best Practices** — Error handling: are errors properly propagated (not swallowed, not panicked)? Does the code follow project conventions (logging, naming, doc comments)? Is it maintainable?
+6. **Requirements Alignment** — Does the implementation match the issue spec? Does it satisfy the design principles? Are harness/test requirements met? Are there missing pieces or scope creep?
+
+**How to submit the review:**
+```bash
+# If satisfied:
+gh pr review <number> --approve --body "<detailed review summary>"
+
+# If changes needed:
+gh pr review <number> --request-changes --body "<detailed findings, organized by severity>"
+```
+
+**How to reply on the issue:**
+After submitting the review, use the `jyc_reply` tool (NOT `gh issue comment`) to summarize the review outcome on the issue thread. Include:
+- Overall verdict (approved / changes requested)
+- Key findings from each relevant dimension
+- Link to the PR for full details
+
+**Important:** Do NOT delegate PR review to the `github-reviewer` agent. The planner's review is a deep technical/architectural review that complements (does not replace) the reviewer's lightweight pass.
+
 ## Rules (MANDATORY)
 - ALWAYS analyze the relevant source code BEFORE proposing any solution
 - ALWAYS use the `jyc_reply` tool (reply_message) for ALL replies — NEVER use `gh issue comment` or `gh pr comment`

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -290,6 +290,8 @@ After submitting the review, use the `jyc_reply` tool (NOT `gh issue comment`) t
 - ALWAYS `cd repo` before running any command
 - ALWAYS include `Fixes #<issue_number>` in PR body
 - ALWAYS add the `ready-for-dev` label after creating the PR — this auto-triggers the Developer agent via pattern matching
+- **When requirements change after the PR has been created, ALWAYS do BOTH: update the PR description (`gh pr edit --body`) AND post a PR comment (`gh pr comment`) to alert the developer agent**
+- **When asked to review a PR, ALWAYS perform a deep technical review covering all six dimensions (architecture, logic, security, performance, robustness, requirements alignment) — do NOT delegate to the `github-reviewer` agent**
 - Reply in the same language as the user
 - Your PR must contain ZERO code changes — only the spec in the PR body
 - Your implementation plan must break the work into small, ordered steps — each with a clear verification method

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -260,7 +260,7 @@ gh pr view <number> --comments  # Review discussion history
 1. **Architecture & Design** — Is the design appropriate? Are there simpler, more maintainable alternatives? Does it follow established patterns in the codebase? Are there separation of concerns issues?
 2. **Deep Logic** — Is the core logic correct? Are all edge cases and boundary conditions handled? Check off-by-one errors, race conditions, incorrect assumptions about data.
 3. **Security** — Are there injection risks (SQL, shell, command injection)? Are auth/authz checks correct? Is sensitive data exposed in logs, errors, or responses? Are inputs validated and sanitized?
-4. **Performance Anti-patterns** — Unnecessary allocations/clones, N+1 query problems, blocking calls in async contexts, excessive O(n²) operations, missing caching opportunities.
+4. **Performance Anti-patterns** — Unnecessary allocations/clones, N+1 query problems, blocking calls in async contexts, excessive O(n²) operations, obviously redundant work visible in the diff.
 5. **Robustness & Best Practices** — Error handling: are errors properly propagated (not swallowed, not panicked)? Does the code follow project conventions (logging, naming, doc comments)? Is it maintainable?
 6. **Requirements Alignment** — Does the implementation match the issue spec? Does it satisfy the design principles? Are harness/test requirements met? Are there missing pieces or scope creep?
 
@@ -274,7 +274,7 @@ gh pr review <number> --request-changes --body "<detailed findings, organized by
 ```
 
 **How to reply on the issue:**
-After submitting the review, use the `jyc_reply` tool (NOT `gh issue comment`) to summarize the review outcome on the issue thread. Include:
+After submitting the review, use the `jyc_reply` tool (NOT `gh issue comment`) to summarize the review outcome on the issue thread. (See Rules section — `jyc_reply` is always used for user-facing replies.) Include:
 - Overall verdict (approved / changes requested)
 - Key findings from each relevant dimension
 - Link to the PR for full details
@@ -283,7 +283,8 @@ After submitting the review, use the `jyc_reply` tool (NOT `gh issue comment`) t
 
 ## Rules (MANDATORY)
 - ALWAYS analyze the relevant source code BEFORE proposing any solution
-- ALWAYS use the `jyc_reply` tool (reply_message) for ALL replies — NEVER use `gh issue comment` or `gh pr comment`
+- ALWAYS use the `jyc_reply` tool (reply_message) for ALL user-facing replies — NEVER use `gh issue comment`
+- `gh pr comment` is ONLY permitted for automated developer notifications about requirement updates (see Section 5), NOT for user-facing replies
 - ONLY use `gh` CLI to read issues/PRs, create branches, and create PRs
 - ONLY use `git` to create branches, create empty commits (`git commit --allow-empty`), and push branches
 - ONLY use the `bash` tool and `jyc_reply` tool — NO other tools


### PR DESCRIPTION
## Spec

Enhance the `github-planner` AGENTS.md template with two capabilities: (1) when requirements change after PR creation, post a comment on the PR (in addition to updating the description) to alert the developer; (2) when the user asks the planner to review a PR from the issue, perform a deep technical review covering architecture, logic, security, performance, robustness, and requirements alignment — distinct from the lightweight review done by the dedicated `github-reviewer` agent.

Fixes #191

## Implementation Plan

### Step 1: Enhance "5. After Hand-over" with PR comment on requirement updates
**What:** In `templates/github-planner/AGENTS.md`, expand the "5. After Hand-over" section (lines 213–216) to include explicit `gh pr comment` commands for notifying the developer when requirements change. Add a concrete example showing both the `gh pr edit --body` (update description) and `gh pr comment` (alert developer) steps.
**Why:** Currently only mentions "comment on the PR" in prose but provides no concrete command guidance. The developer agent needs an explicit notification to pick up updated requirements.
**Verify:** Read the updated AGENTS.md and confirm the "After Hand-over" section includes both `gh pr edit` and `gh pr comment` examples with clear instructions on when and how to use them.

### Step 2: Add "6. Review PR on Request" workflow section
**What:** In `templates/github-planner/AGENTS.md`, add a new section "6. Review PR on Request" after the existing "5. After Hand-over" section. This section should describe:
- When to trigger: user asks planner to review a specific PR (providing the PR number or referencing an already-created PR)
- How to fetch PR content: `gh pr view <number>`, `gh pr diff <number>`, `gh pr view <number> --comments`
- What to review (deep technical review dimensions):
  - Architecture: design quality, simpler alternatives
  - Deep logic: correctness, edge cases, boundary conditions
  - Security: injection risks, auth/authz, data exposure
  - Performance anti-patterns: unnecessary allocations, N+1 issues, blocking calls
  - Robustness & best practices: error handling, project conventions, maintainability
  - Requirements alignment: matches issue spec, design principles, harness requirements
- How to submit: `gh pr review <number> --approve` or `--request-changes` with detailed findings
- How to reply: use the jyc_reply tool to summarize on the issue (not `gh issue comment`)
**Why:** Currently the planner has no review capability at all. This adds a distinct, deep technical review mode that complements the existing lightweight `github-reviewer`.
**Verify:** Read the updated AGENTS.md and confirm the new "6. Review PR on Request" section covers all six review dimensions with concrete `gh` commands.

### Step 3: Update Rules section to reflect new capabilities
**What:** In the "Rules (MANDATORY)" section of `templates/github-planner/AGENTS.md`, add one or two rules that cover the new behaviors: (a) when requirements change post-PR-creation, always post a `gh pr comment` in addition to updating the PR description; (b) when asked to review a PR, perform a deep technical review — do NOT delegate to the reviewer agent.
**Why:** Rules section serves as a quick reference. New capabilities should be reflected there.
**Verify:** Read the updated AGENTS.md and confirm the Rules section mentions the new PR comment and review requirements.

## Design Decisions
- All changes are template-only (`templates/github-planner/AGENTS.md`); no Rust code changes needed
- The planner's review capability is distinct from the existing `github-reviewer`: planner does deep technical/architectural review, reviewer does lightweight correctness/convention review
- The planner uses `gh pr review` (not `gh issue comment`) for review submission, matching the reviewer's pattern
- The planner replies on the issue (via jyc_reply tool) to summarize review results, not via gh CLI