### PR TITLE
fix: planner review 同时反馈到 PR comment

### DIFF
--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -268,9 +268,19 @@ gh pr view <number> --comments  # Review discussion history
 ```bash
 # If satisfied:
 gh pr review <number> --approve --body "<detailed review summary>"
+# gh pr review may fail if planner and developer are the same user
+# (GitHub does not allow self-approve/request-changes). Ignore errors.
+
+# ALWAYS post a PR comment — this is the core channel for developer feedback.
+gh pr comment <number> --body "✅ Review: Approved — <key summary>"
 
 # If changes needed:
 gh pr review <number> --request-changes --body "<detailed findings, organized by severity>"
+# gh pr review may fail if planner and developer are the same user.
+# Ignore errors and proceed.
+
+# ALWAYS post a PR comment — this is the core channel for developer feedback.
+gh pr comment <number> --body "❌ Review: Changes requested — <key summary>"
 ```
 
 **How to reply on the issue:**
@@ -279,12 +289,17 @@ After submitting the review, use the `jyc_reply` tool (NOT `gh issue comment`) t
 - Key findings from each relevant dimension
 - Link to the PR for full details
 
+**Three-channel feedback summary:**
+1. `gh pr review` — **Best-effort** formal review (approve/request-changes). May fail when planner and developer are the same user — ignore errors.
+2. `gh pr comment` — **Mandatory** PR comment. This is the core channel for developer feedback. Always executed regardless of `gh pr review` outcome.
+3. `jyc_reply` — **Mandatory** issue reply for user-facing summary. Keeps the issue thread in sync.
+
 **Important:** Do NOT delegate PR review to the `github-reviewer` agent. The planner's review is a deep technical/architectural review that complements (does not replace) the reviewer's lightweight pass.
 
 ## Rules (MANDATORY)
 - ALWAYS analyze the relevant source code BEFORE proposing any solution
 - ALWAYS use the `jyc_reply` tool (reply_message) for ALL user-facing replies — NEVER use `gh issue comment`
-- `gh pr comment` is ONLY permitted for automated developer notifications about requirement updates (see Section 5), NOT for user-facing replies
+- `gh pr comment` is permitted for: (1) automated developer notifications about requirement updates (see Section 5), and (2) posting review comments on the PR (see Section 6 — this is the core channel for developer feedback). `gh pr comment` is NOT for user-facing replies — use `jyc_reply` for that.
 - ONLY use `gh` CLI to read issues/PRs, create branches, and create PRs
 - ONLY use `git` to create branches, create empty commits (`git commit --allow-empty`), and push branches
 - ONLY use the `bash` tool and `jyc_reply` tool — NO other tools


### PR DESCRIPTION
## Spec

增强 github planner 的 review 功能：当 planner 对 PR 进行 review 后，除了在 issue 中回复（`jyc_reply`），**必须**同时通过 `gh pr comment` 将 review 意见发布到 PR 上，确保 developer 能收到反馈。考虑到 planner 和 developer 可能是同一用户（无法对自己 PR 做 approve/request-changes），`gh pr review` 作为尽力而为的步骤，`gh pr comment` 作为必须执行的核心步骤。

Fixes #194

## Implementation Plan

### Step 1: 更新 Section 6 "How to submit the review" — 增加 PR comment 步骤
**What:** 修改 `templates/github-planner/AGENTS.md` 第 267-274 行（"How to submit the review" 代码块）。
- 在 `gh pr review --approve` 和 `gh pr review --request-changes` 命令后，都增加 `gh pr comment <number> --body "..."` 命令。
- 添加注释说明：`gh pr review` 可能在 planner 与 developer 同用户时失败（GitHub 不允许对自己 PR approve/request changes），此时忽略错误继续执行。
- `gh pr comment` 始终执行，这是 developer 获取反馈的核心渠道。

**Why:** 当前 planner review 只通过 `gh pr review`（formal review）+ `jyc_reply`（issue 回复），PR 上没有普通 comment，developer 无法在 PR 层面直接收到 planner 的 review 反馈。

**Verify:** 
- 打开 `templates/github-planner/AGENTS.md`，确认 Section 6 的 "How to submit the review" 代码块包含 `gh pr comment` 命令。
- 确认代码块中有注释说明 `gh pr review` 可能因同用户限制失败。

### Step 2: 更新 Section 6 "How to reply on the issue" — 明确三通道反馈
**What:** 修改 `templates/github-planner/AGENTS.md` 第 276-280 行（"How to reply on the issue" 描述段落）。
- 将描述从"提交 review → 回复 issue"两通道，更新为"提交 review（尽力而为）→ PR comment（必须）→ 回复 issue（保持）"三通道。
- 明确说明 review 意见需要同时在 PR comment 和 issue reply 中出现。

**Why:** 让 planner agent 的行为规范明确、完整，确保未来所有 review 操作都包含 PR comment。

**Verify:**
- 阅读更新后的 "How to reply on the issue" 描述，确认包含三通道反馈的说明。
- 确认 `jyc_reply` 的使用规则没有被破坏。

## Design Decisions
- `gh pr review` 保持为尽力而为（best-effort）：因 GitHub 不允许对自己 PR approve/request-changes，当 planner 和 developer 同用户时会失败，不应阻塞流程。
- `gh pr comment` 是必须执行的核心步骤：无论 approval 还是 changes requested，始终执行，确保 developer 收到反馈。
- `jyc_reply` 保持不变：继续在 issue 线程中回复用户。
- 变更仅涉及模板文件 `templates/github-planner/AGENTS.md`，不需要修改任何 Rust 代码。