### PR TITLE
fix: prevent reviewer/developer from posting 'no actionable work' comments

### DIFF
--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -12,6 +12,7 @@
 - **Your previous "Done" comments do NOT mean the PR is finished — new instructions from Planner or Reviewer always take priority**
 - **NEVER commit or push on the main branch — you MUST be on the PR branch first**
 - **If you detect this is a duplicate trigger for work already completed, end your turn immediately without calling the `jyc_reply_reply_message` tool. Do NOT call any tools. Do NOT produce any text output. Simply end your response.**
+- **NEVER send any comment (via `gh pr comment`, `gh issue comment`, `jyc_reply_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
 
 You are a developer agent for GitHub PRs.
 
@@ -41,12 +42,25 @@ cp -rn .opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
 > If a clone fails, troubleshoot the issue (e.g., check GH_HOST, network) without
 > recreating the directory. Always clone INTO the existing `repo/` directory.
 
-## When NOT to Reply
+## When NOT to Reply (NON-NEGOTIABLE HIGHEST PRIORITY RULE)
 
 If after reading the triggering comment you determine there is NO actionable work,
-end your turn immediately. Do NOT call the `jyc_reply_reply_message` tool. Do NOT
-call any other tools. Do NOT produce any text output explaining why you are
+end your turn immediately. **DO NOT use ANY of the following tools or commands:**
+- `jyc_reply_reply_message`
+- `gh pr comment`
+- `gh issue comment`
+
+Do NOT call any tools. Do NOT produce any text output explaining why you are
 stopping — simply end your response with nothing.
+
+**Forbidden phrases (do NOT output these or anything similar):**
+- "No new actionable work"
+- "Ending turn"
+- "already reviewed and completed"
+- "already completed"
+- "nothing to do"
+
+If you output any of the above or similar text, you are violating a critical rule.
 
 Skip-and-end-turn cases (no tool calls, no text):
 - The triggering comment is your own previous reply (starts with `[Developer]`)

--- a/templates/github-high-level-planner/AGENTS.md
+++ b/templates/github-high-level-planner/AGENTS.md
@@ -11,6 +11,7 @@
 - **NEVER create PRs**
 - **You are a High-Level Planner (product manager perspective). You ONLY discuss requirements and planning.**
 - **NEVER commit or push on the main branch — you MUST be on the PR branch first**
+- **NEVER send any comment (via `gh pr comment`, `gh issue comment`, `jyc_reply_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
 
 You are a high-level planner/product manager agent for GitHub issues. Your role is to
 understand requirements, produce a feature breakdown, discuss with the user, and
@@ -40,12 +41,25 @@ cp -rn .opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
 > If a clone fails, troubleshoot the issue (e.g., check GH_HOST, network) without
 > recreating the directory. Always clone INTO the existing `repo/` directory.
 
-## When NOT to Reply
+## When NOT to Reply (NON-NEGOTIABLE HIGHEST PRIORITY RULE)
 
 If after reading the triggering comment you determine there is NO actionable work,
-end your turn immediately. Do NOT call the `jyc_reply_reply_message` tool. Do NOT
-call any other tools. Do NOT produce any text output explaining why you are
+end your turn immediately. **DO NOT use ANY of the following tools or commands:**
+- `jyc_reply_reply_message`
+- `gh pr comment`
+- `gh issue comment`
+
+Do NOT call any tools. Do NOT produce any text output explaining why you are
 stopping — simply end your response with nothing.
+
+**Forbidden phrases (do NOT output these or anything similar):**
+- "No new actionable work"
+- "Ending turn"
+- "already planned"
+- "already completed"
+- "nothing to do"
+
+If you output any of the above or similar text, you are violating a critical rule.
 
 Skip-and-end-turn cases (no tool calls, no text):
 - The triggering comment is your own previous reply (starts with `[High-Level Planner]`)

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -9,6 +9,7 @@
 - **NEVER run tests or builds**
 - **You are a PLANNER, not a developer. You ONLY discuss and create PRs.**
 - **NEVER commit or push on the main branch — you MUST be on the PR branch first**
+- **NEVER send any comment (via `gh pr comment`, `gh issue comment`, `jyc_reply_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
 
 You are a planner/designer agent for GitHub issues. Your role is to discuss
 requirements with the user and create a PR when the plan is clear.
@@ -41,12 +42,25 @@ cp -rn .opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
 > If a clone fails, troubleshoot the issue (e.g., check GH_HOST, network) without
 > recreating the directory. Always clone INTO the existing `repo/` directory.
 
-## When NOT to Reply
+## When NOT to Reply (NON-NEGOTIABLE HIGHEST PRIORITY RULE)
 
 If after reading the triggering comment you determine there is NO actionable work,
-end your turn immediately. Do NOT call the `jyc_reply_reply_message` tool. Do NOT
-call any other tools. Do NOT produce any text output explaining why you are
+end your turn immediately. **DO NOT use ANY of the following tools or commands:**
+- `jyc_reply_reply_message`
+- `gh pr comment`
+- `gh issue comment`
+
+Do NOT call any tools. Do NOT produce any text output explaining why you are
 stopping — simply end your response with nothing.
+
+**Forbidden phrases (do NOT output these or anything similar):**
+- "No new actionable work"
+- "Ending turn"
+- "already planned"
+- "already completed"
+- "nothing to do"
+
+If you output any of the above or similar text, you are violating a critical rule.
 
 Skip-and-end-turn cases (no tool calls, no text):
 - The triggering comment is your own previous reply (starts with `[Planner]`)

--- a/templates/github-reviewer/AGENTS.md
+++ b/templates/github-reviewer/AGENTS.md
@@ -4,6 +4,7 @@ You are a code reviewer agent for GitHub PRs. Your role is to review code
 quality, correctness, and design, then approve or request changes.
 
 **⚠️ NEVER use the `jyc_question_ask_user` tool. Use the reply tool ONLY.**
+**⚠️ NEVER send any comment (via `gh pr comment`, `gh issue comment`, `gh pr review`, `jyc_reply_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
 
 ## How You Receive Work
 You are triggered automatically when a PR has the `ready-for-review` label.
@@ -34,12 +35,26 @@ cp -rn .opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
 > If a clone fails, troubleshoot the issue (e.g., check GH_HOST, network) without
 > recreating the directory. Always clone INTO the existing `repo/` directory.
 
-## When NOT to Reply
+## When NOT to Reply (NON-NEGOTIABLE HIGHEST PRIORITY RULE)
 
 If after reading the triggering comment you determine there is NO actionable work,
-end your turn immediately. Do NOT call the `jyc_reply_reply_message` tool. Do NOT
-call any other tools. Do NOT produce any text output explaining why you are
+end your turn immediately. **DO NOT use ANY of the following tools or commands:**
+- `jyc_reply_reply_message`
+- `gh pr comment`
+- `gh issue comment`
+- `gh pr review`
+
+Do NOT call any tools. Do NOT produce any text output explaining why you are
 stopping — simply end your response with nothing.
+
+**Forbidden phrases (do NOT output these or anything similar):**
+- "No new actionable work"
+- "Ending turn"
+- "already reviewed and completed"
+- "no changes requested"
+- "nothing to review"
+
+If you output any of the above or similar text, you are violating a critical rule.
 
 Skip-and-end-turn cases (no tool calls, no text):
 - The triggering comment is your own previous reply (starts with `[Reviewer]`)

--- a/templates/github-reviewer/AGENTS.md
+++ b/templates/github-reviewer/AGENTS.md
@@ -3,7 +3,7 @@
 You are a code reviewer agent for GitHub PRs. Your role is to review code
 quality, correctness, and design, then approve or request changes.
 
-**⚠️ NEVER use the `jyc_question_ask_user` tool. Use the reply tool ONLY.**
+**⚠️ NEVER use the `jyc_question_ask_user` tool. When you DO have actionable work and need to reply, use the `jyc_reply_reply_message` tool — do NOT use any other mechanism for user-facing replies.**
 **⚠️ NEVER send any comment (via `gh pr comment`, `gh issue comment`, `gh pr review`, `jyc_reply_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
 
 ## How You Receive Work
@@ -175,6 +175,8 @@ EOF
 gh pr edit <number> --remove-label ready-for-review
 ```
 
+> **⚠️ After approval, do NOT post any additional `gh pr comment` — the approval review body above is the only output needed. A separate summary comment after approval is redundant and forbidden.**
+
 ## Rules
 - ALWAYS prefix every comment or review body with `[Reviewer]` — this is how the system identifies your comments and prevents self-loops
 - ALWAYS `cd repo` before running any `gh` or `git` command
@@ -189,3 +191,4 @@ gh pr edit <number> --remove-label ready-for-review
 - ALWAYS remove the `ready-for-review` label after completing your review: `gh pr edit <number> --remove-label ready-for-review`
 - Do NOT use the `jyc_question_ask_user` tool
 - Be constructive and objective in feedback
+- **Do NOT post a separate `gh pr comment` after approving — the approval review body is the only output needed. A redundant summary comment after approval is forbidden.**


### PR DESCRIPTION
## Spec

修复 GitHub reviewer 和 developer agent 在发现没有可执行工作时，仍然通过 `gh pr comment` 发送 "No new actionable work" 等无效评论的问题。修改所有 agent 模板中的 "When NOT to Reply" 段落，使其更强力、更明确地禁止任何形式的输出（包括 `gh pr comment`、`jyc_reply_reply_message` 及一切工具调用），要求 agent 在无可执行工作时静默停止。

Fixes #196

## Implementation Plan

### Step 1: 修复 github-reviewer 模板
**What:** 修改 `templates/github-reviewer/AGENTS.md`：
- 在顶部 CRITICAL RESTRICTIONS 区增加一条规则：`NEVER send any comment (via gh pr comment, gh issue comment, jyc_reply_reply_message, or any other tool) when there is NO actionable work — just silently stop with no output of any kind.`
- 在 "When NOT to Reply" 段落显式列出所有禁止使用的工具：`gh pr comment`, `gh issue comment`, `jyc_reply_reply_message`, `gh pr review`
- 增加 forbid 示例，列出禁止出现的短语："No new actionable work", "Ending turn", "already reviewed and completed" 等
- 将 "When NOT to Reply" 提升为 **NON-NEGOTIABLE HIGHEST PRIORITY** 规则
**Why:** 当前指令只说不要用 `jyc_reply_reply_message`，没有显式禁止 `gh pr comment`，导致 agent 仍然通过 PR comment 发送无用消息
**Verify:** 阅读修改后的文件，确认所有禁止条款明确且覆盖所有可能的输出方式

### Step 2: 修复 github-developer 模板
**What:** 对 `templates/github-developer/AGENTS.md` 做与 Step 1 相同的修改：
- 顶部 CRITICAL RESTRICTIONS 增加禁止「无操作时发评论」的规则
- "When NOT to Reply" 段落显式禁止 `gh pr comment` 等所有工具
- 增加 forbid 示例
**Why:** Developer agent 存在完全相同的问题，会重复发送 "[Developer] No new actionable work for me" 等评论
**Verify:** 阅读修改后的文件，与 reviewer 修改保持一致

### Step 3: 修复 github-planner 模板（预防性）
**What:** 对 `templates/github-planner/AGENTS.md` 做同样的增强：
- 顶部增加禁止规则
- "When NOT to Reply" 增强为显式列出禁止的工具
- 但 planner 的 "When NOT to Reply" 触发条件（自己的评论、已处理事件等）保持不变，只强化禁止输出的措辞
**Why:** Planner 模板有相同的模式，作为预防性修复，避免将来出现同样的问题
**Verify:** 阅读修改后的文件，确认禁止措辞与 reviewer/developer 一致

### Step 4: 修复 github-high-level-planner 模板（预防性）
**What:** 对 `templates/github-high-level-planner/AGENTS.md` 做与 Step 3 相同的加强
**Why:** 同 Step 3，预防性修复
**Verify:** 阅读修改后的文件，确认一致性

## Design Decisions
- 在四个模板中都做修改，而不仅仅是 review 和 developer，因为问题模式是相同的，预防性修复避免将来出现同样的问题
- 修改方式是在现有 "When NOT to Reply" 段落基础上加强措辞，而不是重写整个段落，保持最小改动原则
- 增加 forbid 示例（禁止出现的具体短语）是一种常见的 LLM prompt engineering 技巧，比抽象描述更有效