### PR TITLE
fix: enforce gh pr comment as NON-NEGOTIABLE in planner workflow

### DIFF
--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -277,14 +277,15 @@ gh pr diff <number>             # Full diff of changes
 gh pr view <number> --comments  # Review discussion history
 ```
 
-**Six review dimensions:**
+**Seven review dimensions:**
 
 1. **Architecture & Design** — Is the design appropriate? Are there simpler, more maintainable alternatives? Does it follow established patterns in the codebase? Are there separation of concerns issues?
-2. **Deep Logic** — Is the core logic correct? Are all edge cases and boundary conditions handled? Check off-by-one errors, race conditions, incorrect assumptions about data.
-3. **Security** — Are there injection risks (SQL, shell, command injection)? Are auth/authz checks correct? Is sensitive data exposed in logs, errors, or responses? Are inputs validated and sanitized?
-4. **Performance Anti-patterns** — Unnecessary allocations/clones, N+1 query problems, blocking calls in async contexts, excessive O(n²) operations, obviously redundant work visible in the diff.
-5. **Robustness & Best Practices** — Error handling: are errors properly propagated (not swallowed, not panicked)? Does the code follow project conventions (logging, naming, doc comments)? Is it maintainable?
-6. **Requirements Alignment** — Does the implementation match the issue spec? Does it satisfy the design principles? Are harness/test requirements met? Are there missing pieces or scope creep?
+2. **Reusability** — Can code be reused in other contexts? Is there unnecessary coupling between unrelated concerns? Should common patterns be extracted into shared utilities? Are there hardcoded values that should be configurable? **Reusability issues are BLOCKING** — they must be addressed before merge, not treated as optional suggestions.
+3. **Deep Logic** — Is the core logic correct? Are all edge cases and boundary conditions handled? Check off-by-one errors, race conditions, incorrect assumptions about data.
+4. **Security** — Are there injection risks (SQL, shell, command injection)? Are auth/authz checks correct? Is sensitive data exposed in logs, errors, or responses? Are inputs validated and sanitized?
+5. **Performance Anti-patterns** — Unnecessary allocations/clones, N+1 query problems, blocking calls in async contexts, excessive O(n²) operations, obviously redundant work visible in the diff.
+6. **Robustness & Best Practices** — Error handling: are errors properly propagated (not swallowed, not panicked)? Does the code follow project conventions (logging, naming, doc comments)? Is it maintainable?
+7. **Requirements Alignment** — Does the implementation match the issue spec? Does it satisfy the design principles? Are harness/test requirements met? Are there missing pieces or scope creep?
 
 **How to submit the review:**
 ⚠️ **NON-NEGOTIABLE:** Both `gh pr comment` AND `jyc_reply` MUST be used — the PR comment is the core developer feedback channel and is NOT optional. The LLM MUST execute both commands; skipping the PR comment will leave the developer agent unaware of the review feedback.

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -287,6 +287,7 @@ gh pr view <number> --comments  # Review discussion history
 6. **Requirements Alignment** — Does the implementation match the issue spec? Does it satisfy the design principles? Are harness/test requirements met? Are there missing pieces or scope creep?
 
 **How to submit the review:**
+⚠️ **NON-NEGOTIABLE:** Both `gh pr comment` AND `jyc_reply` MUST be used — the PR comment is the core developer feedback channel and is NOT optional. The LLM MUST execute both commands; skipping the PR comment will leave the developer agent unaware of the review feedback.
 ```bash
 # If satisfied:
 gh pr review <number> --approve --body "<detailed review summary>"

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -330,8 +330,8 @@ After submitting the review, use the `jyc_reply` tool (NOT `gh issue comment`) t
 - ALWAYS `cd repo` before running any command
 - ALWAYS include `Fixes #<issue_number>` in PR body
 - ALWAYS add the `ready-for-dev` label after creating the PR — this auto-triggers the Developer agent via pattern matching
-- **When requirements change after the PR has been created, ALWAYS do BOTH: update the PR description (`gh pr edit --body`) AND post a PR comment (`gh pr comment`) to alert the developer agent**
-- **When asked to review a PR, ALWAYS perform a deep technical review covering all six dimensions (architecture, logic, security, performance, robustness, requirements alignment) — do NOT delegate to the `github-reviewer` agent**
+- **⚠️ NON-NEGOTIABLE — Review:** When asked to review a PR, ALWAYS post the review feedback via `gh pr comment` on the PR AND via `jyc_reply` on the issue. The PR comment is NON-NEGOTIABLE — even if `gh pr review` succeeds (or fails), you MUST still post the PR comment. Additionally, perform a deep technical review covering all seven dimensions (architecture, reusability, logic, security, performance, robustness, requirements alignment) — do NOT delegate to the `github-reviewer` agent.
+- **⚠️ NON-NEGOTIABLE — Requirements change:** When requirements change after the PR has been created, BOTH `gh pr edit --body` (update PR description) AND `gh pr comment` (post a PR comment) are NON-NEGOTIABLE. Editing only the description without the PR comment will cause the developer agent to miss the update.
 - Reply in the same language as the user
 - Your PR must contain ZERO code changes — only the spec in the PR body
 - Your implementation plan must break the work into small, ordered steps — each with a clear verification method

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -235,6 +235,7 @@ gh pr edit <pr_number> --add-label "ready-for-dev"
 - Reply on the issue confirming the PR was created (via the `jyc_reply` tool)
 - You can continue discussing with the user on the issue
 - **If requirements change after the PR has been created**, you MUST do BOTH:
+  ⚠️ **NON-NEGOTIABLE:** Both `gh pr edit --body` (update PR description) AND `gh pr comment` (post a comment on the PR) are MANDATORY — neither is optional. The LLM MUST execute both commands; skipping either will cause the developer agent to miss the update.
   1. Update the PR description to reflect the new requirements:
      ```bash
      cd repo


### PR DESCRIPTION
## Spec

Further enhance the GitHub planner agent's AGENTS.md to prevent the planner LLM from silently skipping mandatory `gh pr comment` steps (both during requirement changes and PR reviews), and add a Reusability dimension to the review checklist.

Fixes #194

## Implementation Plan

### Step 1: Add NON-NEGOTIABLE assertion before Section 5 requirement-change workflow
**What:** In `templates/github-planner/AGENTS.md`, insert a bold `⚠️ NON-NEGOTIABLE` warning directly before the "If requirements change" bullet (around line 237). The warning must state that both `gh pr edit --body` AND `gh pr comment` MUST be used — neither is optional.
**Why:** The `gh pr comment` instruction is currently only inside a bash code block. LLMs treat code blocks as examples, not mandatory instructions. An explicit non-code assertion forces attention.
**Verify:** Read the file and confirm the warning appears before the code block, not inside it.

### Step 2: Add NON-NEGOTIABLE assertion before Section 6 review-submission workflow
**What:** In `templates/github-planner/AGENTS.md`, insert a bold `⚠️ NON-NEGOTIABLE` warning directly before the "How to submit the review" code block (around line 288). The warning must state that both `gh pr comment` AND `jyc_reply` MUST be used — the PR comment is the core developer feedback channel.
**Why:** Same root cause as Step 1. The `gh pr comment` in the review code block is treated as optional/example code by the LLM.
**Verify:** Read the file and confirm the warning appears before the review-submission code block, not inside it.

### Step 3: Add Reusability as a new review dimension
**What:** In Section 6 "Six review dimensions", add a new **Reusability** dimension as the 2nd item, shifting existing dimensions 2-6 down to 3-7. The new dimension must cover: code reusability in other contexts, unnecessary coupling, extraction of common patterns, hardcoded values, tight coupling between unrelated concerns. Emphasize that reusability issues are BLOCKING — not optional suggestions.
**Why:** The current six dimensions (Architecture, Logic, Security, Performance, Robustness, Requirements Alignment) don't explicitly cover reusability. The user has identified this as a gap where the planner misses reusability concerns.
**Verify:** Read Section 6 and confirm seven dimensions with Reusability at position 2.

### Step 4: Strengthen Rules section with explicit gh pr comment rules
**What:** In the Rules (MANDATORY) section, split/strengthen the existing review rule (around line 331) into two explicit rules:
1. Review: "When asked to review a PR, ALWAYS post the review feedback via `gh pr comment` on the PR AND via `jyc_reply` on the issue. The PR comment is NON-NEGOTIABLE — even if `gh pr review` succeeds, you MUST still post the PR comment."
2. Requirements change: "When requirements change after the PR has been created, BOTH `gh pr edit --body` AND `gh pr comment` are NON-NEGOTIABLE. Editing only the description without the PR comment will cause the developer agent to miss the update."
**Why:** The Rules section is the highest-priority instruction block for LLMs. The current rule for review only mentions "deep technical review" without mentioning `gh pr comment`. The requirement-change rule exists but needs stronger "NON-NEGOTIABLE" language.
**Verify:** Read the Rules section and confirm both explicit rules are present.

## Design Decisions
- The `⚠️ NON-NEGOTIABLE` pattern uses visual severity markers that LLMs are trained to respect
- Non-code assertions are placed immediately before their corresponding code blocks, not after — this ensures the LLM sees the rule before trying to execute
- Reusability is positioned as the 2nd dimension (right after Architecture) because it's a design-level concern that should be checked early
- Reusability issues are explicitly marked BLOCKING to prevent the LLM from treating them as "nice-to-have" suggestions