### PR TITLE
fix: prevent duplicate triggers per issue per poll cycle in GitHub channel

### DIFF
--- a/crates/jyc-channels/src/github/inbound.rs
+++ b/crates/jyc-channels/src/github/inbound.rs
@@ -840,6 +840,7 @@ impl GithubInboundAdapter {
         ci_status: &mut HashMap<u64, (String, String)>, // pr_number → (head_sha, overall_status)
     ) -> Result<()> {
         let poll_start = last_poll.clone();
+        let mut triggered_in_cycle: HashSet<u64> = HashSet::new();
 
         tracing::trace!(
             channel = %self.channel_name,
@@ -883,6 +884,11 @@ impl GithubInboundAdapter {
             // patterns can match on issue metadata (type, labels, assignees)
             // without requiring a comment.
             if is_new {
+                // Dedup: skip if this issue already triggered in this poll cycle
+                if !triggered_in_cycle.insert(issue.number) {
+                    continue;
+                }
+
                 let event_uid = format!("{}-{}-opened", github_type, issue.number);
 
                 let message = self.build_trigger_message(
@@ -1011,6 +1017,17 @@ impl GithubInboundAdapter {
                 "Comment detected → routing for Pattern mode"
             );
 
+            // Dedup: skip if this issue already triggered in this poll cycle
+            if !triggered_in_cycle.insert(issue_number) {
+                tracing::debug!(
+                    channel = %self.channel_name,
+                    issue_number = issue_number,
+                    "Skipping duplicate comment trigger for issue already triggered in this cycle"
+                );
+                self.track_comment(&comment_key, processed_comments).await;
+                continue;
+            }
+
             if let Err(e) = (options.on_message)(message) {
                 tracing::error!(error = %e, number = issue_number, "Failed to route comment event");
             }
@@ -1122,6 +1139,17 @@ impl GithubInboundAdapter {
                             "PR review detected → routing"
                         );
 
+                        // Dedup: skip if this PR already triggered in this poll cycle
+                        if !triggered_in_cycle.insert(*pr_number) {
+                            tracing::debug!(
+                                channel = %self.channel_name,
+                                pr_number = pr_number,
+                                "Skipping duplicate review trigger for PR already triggered in this cycle"
+                            );
+                            self.track_comment(&review_key, processed_comments).await;
+                            continue;
+                        }
+
                         if let Err(e) = (options.on_message)(message) {
                             tracing::error!(error = %e, pr_number = pr_number, "Failed to route review event");
                         }
@@ -1226,6 +1254,17 @@ impl GithubInboundAdapter {
                             user = %rc.user.login,
                             "PR review comment detected → routing"
                         );
+
+                        // Dedup: skip if this PR already triggered in this poll cycle
+                        if !triggered_in_cycle.insert(*pr_number) {
+                            tracing::debug!(
+                                channel = %self.channel_name,
+                                pr_number = pr_number,
+                                "Skipping duplicate review comment trigger for PR already triggered in this cycle"
+                            );
+                            self.track_comment(&rc_key, processed_comments).await;
+                            continue;
+                        }
 
                         if let Err(e) = (options.on_message)(message) {
                             tracing::error!(error = %e, pr_number = pr_number, "Failed to route review comment event");
@@ -1398,6 +1437,18 @@ impl GithubInboundAdapter {
                         failed_count = failed_checks.len(),
                         "CI failure detected → routing to developer agent"
                     );
+
+                    // Dedup: skip if this PR already triggered in this poll cycle
+                    if !triggered_in_cycle.insert(*pr_number) {
+                        tracing::debug!(
+                            channel = %self.channel_name,
+                            pr_number = pr_number,
+                            "Skipping duplicate CI failure trigger for PR already triggered in this cycle"
+                        );
+                        self.track_ci_status(*pr_number, &head_sha, overall_status, ci_status)
+                            .await;
+                        continue;
+                    }
 
                     if let Err(e) = (options.on_message)(message) {
                         tracing::error!(error = %e, pr_number = pr_number, "Failed to route CI failure event");

--- a/crates/jyc-channels/src/github/inbound.rs
+++ b/crates/jyc-channels/src/github/inbound.rs
@@ -3340,4 +3340,75 @@ mod tests {
         result.sort();
         assert_eq!(result, vec!["issue-42".to_string()]);
     }
+
+    // --- Dedup tests for triggered_in_cycle ---
+
+    #[test]
+    fn test_triggered_in_cycle_allows_first_trigger() {
+        // Simulates the dedup guard pattern used in poll_once() for all
+        // trigger types (label, comment, review, review_comment, CI failure).
+        // Validates that the first trigger for an issue/PR is allowed through.
+        let mut triggered_in_cycle: HashSet<u64> = HashSet::new();
+
+        // First insert for issue 42 should return true (allowed)
+        assert!(triggered_in_cycle.insert(42), "First trigger for an issue should be allowed");
+    }
+
+    #[test]
+    fn test_triggered_in_cycle_blocks_duplicate() {
+        let mut triggered_in_cycle: HashSet<u64> = HashSet::new();
+
+        // First insert returns true
+        assert!(triggered_in_cycle.insert(42));
+
+        // Second insert for same number returns false (blocked)
+        assert!(!triggered_in_cycle.insert(42), "Duplicate trigger for same issue should be blocked");
+    }
+
+    #[test]
+    fn test_triggered_in_cycle_allows_different_numbers() {
+        let mut triggered_in_cycle: HashSet<u64> = HashSet::new();
+
+        // Insert different issue numbers — all should be allowed
+        assert!(triggered_in_cycle.insert(42));
+        assert!(triggered_in_cycle.insert(43), "Different issue numbers should each be allowed");
+        assert!(triggered_in_cycle.insert(100));
+    }
+
+    #[test]
+    fn test_triggered_in_cycle_independent_per_cycle() {
+        // Validates that the dedup set is scoped per poll cycle — a fresh
+        // HashSet is created for each poll_once() call, so the same issue
+        // number can trigger again in a new cycle.
+        let mut cycle1: HashSet<u64> = HashSet::new();
+        assert!(cycle1.insert(42));  // First cycle: allowed
+        assert!(!cycle1.insert(42)); // First cycle: duplicate blocked
+
+        // New cycle = fresh HashSet
+        let mut cycle2: HashSet<u64> = HashSet::new();
+        assert!(cycle2.insert(42), "Same issue should be allowed in a new poll cycle");
+    }
+
+    #[test]
+    fn test_triggered_in_cycle_mixed_issues() {
+        // Validates realistic scenario: issue 42 triggers via label change,
+        // then a comment for issue 42 is blocked, while a comment for
+        // issue 43 is still allowed.
+        let mut triggered_in_cycle: HashSet<u64> = HashSet::new();
+
+        // Label trigger for issue 42 — allowed
+        assert!(triggered_in_cycle.insert(42));
+
+        // Comment trigger for issue 42 — blocked (duplicate)
+        assert!(!triggered_in_cycle.insert(42));
+
+        // Comment trigger for issue 43 — allowed (different issue)
+        assert!(triggered_in_cycle.insert(43));
+
+        // Review trigger for PR 42 — blocked (same number, still in cycle)
+        assert!(!triggered_in_cycle.insert(42));
+
+        // Review trigger for PR 99 — allowed
+        assert!(triggered_in_cycle.insert(99));
+    }
 }


### PR DESCRIPTION
## Spec

In `poll_once()`, add per-poll-cycle deduplication to prevent the same
issue/PR from generating multiple trigger messages within a single poll cycle.
This eliminates the scenario where a label-change trigger followed by a
comment trigger both route to the same agent, causing the second processing
to find no work and potentially produce a "no action" / "duplicate trigger"
comment.

Fixes #201

## Implementation Plan

### Step 1: Add per-cycle dedup set in `poll_once()`
**What:** In `GithubInboundAdapter::poll_once()` (`crates/jyc-channels/src/github/inbound.rs`), add a `HashSet<u64>` called `triggered_in_cycle` at the start of the method body, right after the `poll_start` variable.
**Why:** This set tracks which issue numbers have already generated a trigger in the current poll cycle. Any subsequent trigger for the same number is a duplicate and should be skipped.
**Verify:** `cargo check -p jyc-channels` compiles successfully.

### Step 2: Guard label-change trigger routing
**What:** At line ~909, wrap `(options.on_message)(message)` with a check on `triggered_in_cycle.insert(issue.number)`. Only call `on_message` when `insert` returns `true` (first time).
**Why:** This is the first trigger point in the cycle (label changes). The `insert` call returns `true` only if the issue number was not yet in the set, atomically marking it as triggered.
**Verify:** `cargo test -p jyc-channels` — all existing tests pass (no behavior change for single-trigger scenarios).

### Step 3: Guard comment trigger routing
**What:** At line ~1014 (after comment body is appended), wrap `(options.on_message)(message)` with the same `triggered_in_cycle.insert(issue_number)` check.
**Why:** If a label-change trigger already fired for this issue in the same cycle, the comment trigger is a duplicate. The agent will see the comment anyway via `gh pr view --comments` / `gh issue view --comments`.
**Verify:** `cargo test -p jyc-channels` — all existing tests pass.

### Step 4: Guard review trigger and review comment trigger routing
**What:** Apply the same `triggered_in_cycle.insert(pr_number)` guard for review triggers (~line 1125) and review comment triggers (~line 1230).
**Why:** Review events can also coincide with label changes in the same poll cycle (though less common, the same dedup protection applies).
**Verify:** `cargo test -p jyc-channels` — all existing tests pass.

### Step 5: Guard CI failure trigger routing
**What:** Apply the same `triggered_in_cycle.insert(pr_number)` guard for CI failure triggers (~line 1402).
**Why:** CI failure triggers could theoretically coincide with other triggers for the same PR in the same cycle.
**Verify:** `cargo test -p jyc-channels` — all existing tests pass.

### Step 6: Add unit test for dedup behavior
**What:** Add a new test `test_poll_once_dedup_same_issue` (or similar) that validates the dedup logic does not break routing. The test should verify:
- A single trigger per issue is still routed normally (no regression).
- The dedup set is correctly scoped per poll cycle (the set is created fresh each `poll_once` call).

Since `poll_once` is an async method with many dependencies, the test can validate at the integration level by verifying the `triggered_in_cycle` set behavior.
**Why:** Prevent regression — ensure the fix doesn't accidentally suppress legitimate triggers.
**Verify:** `cargo test -p jyc-channels test_poll_once_dedup` (or similar).

## Design Decisions
- **Scope**: Dedup is per poll cycle only — `triggered_in_cycle` is a local `HashSet` created fresh each `poll_once()` call. No persistent state change, no inter-cycle interference.
- **Precedence**: Label triggers fire first (existing code order preserved). Comment/review triggers for the same issue in the same cycle are skipped as duplicates. The agent reads all comments via `gh pr/issue view --comments` anyway, so no information is lost.
- **No behavioral change for single-trigger scenarios**: When only one trigger exists per issue per cycle, `insert` returns `true` and the trigger routes exactly as before.