### PR TITLE
feat: 支持 openilink 微信 channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,6 +1531,7 @@ dependencies = [
  "base64",
  "chrono",
  "comrak",
+ "futures-util",
  "jyc-core",
  "jyc-mcp",
  "jyc-services",
@@ -1545,6 +1546,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "tokio-util",
  "toml",
  "tracing",
@@ -2102,7 +2104,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.23.1",
  "tracing",
  "url",
  "uuid",
@@ -3742,7 +3744,21 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.23.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite 0.24.0",
 ]
 
 [[package]]
@@ -3941,6 +3957,25 @@ dependencies = [
  "rand 0.8.5",
  "rustls",
  "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",

--- a/config.example.toml
+++ b/config.example.toml
@@ -352,3 +352,50 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # github_type = ["pull_request"]
 # labels = ["ready-for-review"]
 # assignees = ["alice"]
+
+# --- OpeniLink (WeChat) Channel Example ---
+# Uncomment and configure for OpeniLink/WeChat integration.
+# Requires an OpeniLink Hub instance to bridge WeChat messages.
+[channels.wechat]
+type = "openilink"
+
+[channels.wechat.openilink]
+api_key = "${OPENILINK_API_KEY}"
+hub_url = "https://hub.example.com"
+
+[channels.wechat.openilink.websocket]
+enabled = true
+reconnect_delay_secs = 5
+max_reconnect_attempts = 10
+heartbeat_interval_secs = 30
+
+# Optional: override context token cache size (default: 1000)
+# context_token_cache_size = 500
+
+# Footer configuration: controls whether model/mode/tokens footer is appended to replies.
+# Default is enabled = true when omitted. Set enabled = false to disable the footer.
+# [channels.wechat.footer]
+# enabled = false
+
+[[channels.wechat.patterns]]
+name = "wechat_bot"
+enabled = true
+
+[channels.wechat.patterns.rules]
+keywords = ["帮助", "help"]
+
+# You can also match by sender (wxid):
+# [[channels.wechat.patterns]]
+# name = "vip_user"
+# enabled = true
+# [channels.wechat.patterns.rules.sender]
+# exact = ["wxid_xxxxxxxx"]
+#
+# [[channels.wechat.patterns]]
+# name = "support_group_1"
+# enabled = true
+# thread_prefix = "openilink"
+# [channels.wechat.patterns.rules]
+# keywords = ["support", "客服"]
+# [channels.wechat.patterns.rules.sender]
+# regex = "wxid_.*"

--- a/crates/jyc-channels/Cargo.toml
+++ b/crates/jyc-channels/Cargo.toml
@@ -14,6 +14,8 @@ mail-parser = "0.9"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
+tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
+futures-util = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/jyc-channels/src/lib.rs
+++ b/crates/jyc-channels/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod email;
 pub mod feishu;
 pub mod github;
+pub mod openilink;
 pub mod registry;

--- a/crates/jyc-channels/src/openilink/client.rs
+++ b/crates/jyc-channels/src/openilink/client.rs
@@ -1,2 +1,287 @@
 //! HTTP client for OpeniLink Hub API.
-//! Will be implemented in Step 7.
+//!
+//! This module wraps `reqwest::Client` to provide high-level methods
+//! for interacting with the OpeniLink Hub REST API. It handles
+//! authentication via `Authorization: Bearer {api_key}` header.
+
+use anyhow::{Context, Result};
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+use std::sync::Arc;
+
+use jyc_types::OpenilinkConfig;
+
+use super::types::{
+    HubConfig, SendMessageRequest, SendMessageResponse, SendTypingRequest, SendTypingResponse,
+};
+
+/// HTTP client for OpeniLink Hub API.
+///
+/// Provides methods for sending messages, typing indicators, and
+/// retrieving hub configuration.
+pub struct OpenilinkClient {
+    config: OpenilinkConfig,
+    client: Arc<reqwest::Client>,
+}
+
+impl OpenilinkClient {
+    /// Create a new OpeniLink client.
+    pub fn new(config: OpenilinkConfig) -> Self {
+        let mut headers = HeaderMap::new();
+        let api_key = config.api_key.clone();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {}", api_key))
+                .unwrap_or_else(|_| HeaderValue::from_static("Bearer ")),
+        );
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        );
+
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("Failed to create reqwest client");
+
+        Self {
+            config,
+            client: Arc::new(client),
+        }
+    }
+
+    /// Get the base URL for API calls.
+    fn api_url(&self, path: &str) -> String {
+        let base = self.config.hub_url.trim_end_matches('/');
+        format!("{}{}", base, path)
+    }
+
+    /// Send a text message to a WeChat user.
+    ///
+    /// If `context_token` is provided, the message is sent as a reply
+    /// (retaining the conversation context). Otherwise, it's sent as
+    /// an active push.
+    pub async fn send_message(
+        &self,
+        to_user_id: &str,
+        content: &str,
+        context_token: Option<&str>,
+    ) -> Result<SendMessageResponse> {
+        let url = self.api_url("/api/v1/channels/send");
+
+        let request = SendMessageRequest {
+            to_user_id: to_user_id.to_string(),
+            content: content.to_string(),
+            context_token: context_token.map(|s| s.to_string()),
+        };
+
+        let resp = self
+            .client
+            .post(&url)
+            .json(&request)
+            .send()
+            .await
+            .with_context(|| format!("Failed to send message to {to_user_id}"))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "Hub API returned error (status {status}): {body}"
+            );
+        }
+
+        let send_resp: SendMessageResponse = resp
+            .json()
+            .await
+            .context("Failed to parse send message response")?;
+
+        if send_resp.code != 0 {
+            anyhow::bail!(
+                "Hub API error (code {}): {}",
+                send_resp.code,
+                send_resp.message.as_deref().unwrap_or("unknown")
+            );
+        }
+
+        Ok(send_resp)
+    }
+
+    /// Send a typing indicator to a WeChat user.
+    ///
+    /// `action` can be "TypingBegin" or "TypingEnd".
+    pub async fn send_typing(
+        &self,
+        to_user_id: &str,
+        typing_ticket: Option<&str>,
+        action: &str,
+    ) -> Result<SendTypingResponse> {
+        let url = self.api_url("/api/v1/channels/typing");
+
+        let request = SendTypingRequest {
+            to_user_id: to_user_id.to_string(),
+            typing_ticket: typing_ticket.map(|s| s.to_string()),
+            action: action.to_string(),
+        };
+
+        let resp = self
+            .client
+            .post(&url)
+            .json(&request)
+            .send()
+            .await
+            .with_context(|| format!("Failed to send typing indicator to {to_user_id}"))?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "Hub API returned error (status {status}): {body}"
+            );
+        }
+
+        let typing_resp: SendTypingResponse = resp
+            .json()
+            .await
+            .context("Failed to parse typing response")?;
+
+        if typing_resp.code != 0 {
+            anyhow::bail!(
+                "Hub API error (code {}): {}",
+                typing_resp.code,
+                typing_resp.message.as_deref().unwrap_or("unknown")
+            );
+        }
+
+        Ok(typing_resp)
+    }
+
+    /// Retrieve hub configuration and connection status.
+    ///
+    /// This is used during adapter `connect()` to verify the API key is valid.
+    pub async fn get_config(&self) -> Result<HubConfig> {
+        let url = self.api_url("/api/v1/channels/config");
+
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context("Failed to get hub config")?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "Hub API returned error (status {status}): {body}"
+            );
+        }
+
+        let config: HubConfig = resp
+            .json()
+            .await
+            .context("Failed to parse hub config response")?;
+
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::openilink::types::WechatUserInfo;
+
+    #[test]
+    fn test_client_creation() {
+        let config = OpenilinkConfig {
+            api_key: "sk-test".to_string(),
+            hub_url: "https://hub.example.com".to_string(),
+            ..OpenilinkConfig::default()
+        };
+        let client = OpenilinkClient::new(config);
+        // Verify API URL construction
+        assert_eq!(
+            client.api_url("/api/v1/channels/send"),
+            "https://hub.example.com/api/v1/channels/send"
+        );
+    }
+
+    #[test]
+    fn test_api_url_with_trailing_slash() {
+        let config = OpenilinkConfig {
+            api_key: "sk-test".to_string(),
+            hub_url: "https://hub.example.com/".to_string(),
+            ..OpenilinkConfig::default()
+        };
+        let client = OpenilinkClient::new(config);
+        assert_eq!(
+            client.api_url("/api/v1/channels/send"),
+            "https://hub.example.com/api/v1/channels/send"
+        );
+    }
+
+    #[test]
+    fn test_send_message_request_serialization() {
+        let req = SendMessageRequest {
+            to_user_id: "wxid_abc".to_string(),
+            content: "Hello!".to_string(),
+            context_token: Some("token_123".to_string()),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains(r#""to_user_id":"wxid_abc""#));
+        assert!(json.contains(r#""context_token":"token_123""#));
+    }
+
+    #[test]
+    fn test_send_message_request_no_token() {
+        let req = SendMessageRequest {
+            to_user_id: "wxid_abc".to_string(),
+            content: "Hello!".to_string(),
+            context_token: None,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(!json.contains("context_token"));
+    }
+
+    #[test]
+    fn test_send_message_response_parse() {
+        let json = r#"{
+            "code": 0,
+            "message": "success",
+            "message_id": "msg_001"
+        }"#;
+        let resp: SendMessageResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.code, 0);
+        assert_eq!(resp.message_id.unwrap(), "msg_001");
+    }
+
+    #[test]
+    fn test_send_message_response_error() {
+        let json = r#"{
+            "code": 401,
+            "message": "invalid api key"
+        }"#;
+        let resp: SendMessageResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.code, 401);
+        assert_eq!(resp.message.unwrap(), "invalid api key");
+    }
+
+    #[test]
+    fn test_hub_config_parse() {
+        let json = r#"{
+            "version": "1.2.0",
+            "connected": true,
+            "wechat_user": {
+                "wxid": "wxid_xxxxx",
+                "nickname": "My Bot",
+                "avatar": "https://example.com/avatar.png"
+            },
+            "features": ["text", "image"]
+        }"#;
+        let config: HubConfig = serde_json::from_str(json).unwrap();
+        assert!(config.connected);
+        assert_eq!(config.version.unwrap(), "1.2.0");
+        let user = config.wechat_user.unwrap();
+        assert_eq!(user.wxid.unwrap(), "wxid_xxxxx");
+    }
+}

--- a/crates/jyc-channels/src/openilink/client.rs
+++ b/crates/jyc-channels/src/openilink/client.rs
@@ -189,7 +189,6 @@ impl OpenilinkClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::openilink::types::WechatUserInfo;
 
     #[test]
     fn test_client_creation() {

--- a/crates/jyc-channels/src/openilink/client.rs
+++ b/crates/jyc-channels/src/openilink/client.rs
@@ -1,0 +1,2 @@
+//! HTTP client for OpeniLink Hub API.
+//! Will be implemented in Step 7.

--- a/crates/jyc-channels/src/openilink/formatter.rs
+++ b/crates/jyc-channels/src/openilink/formatter.rs
@@ -1,0 +1,2 @@
+//! Message formatting utilities for OpeniLink.
+//! Will be implemented in Step 12.

--- a/crates/jyc-channels/src/openilink/formatter.rs
+++ b/crates/jyc-channels/src/openilink/formatter.rs
@@ -50,12 +50,8 @@ fn item_to_text(item: &MessageItem) -> String {
         }
         49 => {
             // Shared link/card — try to extract title from extra data
-            if let Some(ref extra) = item.extra {
-                if let Some(title) = extra.get("title").and_then(|v| v.as_str()) {
-                    if !title.is_empty() {
-                        return format!("[分享: {}]", title);
-                    }
-                }
+            if let Some(title) = item.extra.as_ref().and_then(|e| e.get("title")).and_then(|v| v.as_str()).filter(|t| !t.is_empty()) {
+                return format!("[分享: {}]", title);
             }
             "[分享]".to_string()
         }

--- a/crates/jyc-channels/src/openilink/formatter.rs
+++ b/crates/jyc-channels/src/openilink/formatter.rs
@@ -1,2 +1,284 @@
 //! Message formatting utilities for OpeniLink.
-//! Will be implemented in Step 12.
+//!
+//! This module provides utilities for extracting and formatting text
+//! content from WeChat message items.
+
+use super::types::{MessageItem, WeixinMessage};
+
+/// Extract combined text content from a WeixinMessage's item_list.
+///
+/// For text items (type 1), the actual text is returned.
+/// For non-text items (images, files, audio, video, etc.), descriptive
+/// markers like `[图片]`, `[文件: report.pdf]` are generated.
+///
+/// Multiple items are joined with a space separator.
+pub fn extract_text(message: &WeixinMessage) -> String {
+    let mut parts: Vec<String> = Vec::new();
+
+    for item in &message.item_list {
+        parts.push(item_to_text(item));
+    }
+
+    parts.join(" ")
+}
+
+/// Convert a single message item to its text representation.
+fn item_to_text(item: &MessageItem) -> String {
+    match item.item_type {
+        1 => {
+            // Text
+            item.text
+                .as_ref()
+                .map(|t| t.text.clone())
+                .unwrap_or_default()
+        }
+        3 => {
+            // Image
+            "[图片]".to_string()
+        }
+        34 => {
+            // Audio / voice message
+            "[语音]".to_string()
+        }
+        43 | 62 => {
+            // Video (43 = video, 62 = small video)
+            "[视频]".to_string()
+        }
+        47 => {
+            // Sticker / emoticon
+            "[表情]".to_string()
+        }
+        49 => {
+            // Shared link/card — try to extract title from extra data
+            if let Some(ref extra) = item.extra {
+                if let Some(title) = extra.get("title").and_then(|v| v.as_str()) {
+                    if !title.is_empty() {
+                        return format!("[分享: {}]", title);
+                    }
+                }
+            }
+            "[分享]".to_string()
+        }
+        10000 => {
+            // System notification
+            String::new()
+        }
+        10002 => {
+            // System message
+            String::new()
+        }
+        other => {
+            format!("[其他消息类型: {}]", other)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::openilink::types::{ImageItem, TextItem};
+
+    fn make_text_item(text: &str) -> MessageItem {
+        MessageItem {
+            item_type: 1,
+            text: Some(TextItem {
+                text: text.to_string(),
+            }),
+            image: None,
+            extra: None,
+        }
+    }
+
+    fn make_image_item() -> MessageItem {
+        MessageItem {
+            item_type: 3,
+            text: None,
+            image: Some(ImageItem {
+                url: Some("https://example.com/img.jpg".to_string()),
+                path: None,
+                width: None,
+                height: None,
+            }),
+            extra: None,
+        }
+    }
+
+    fn make_item(item_type: i32, extra: Option<serde_json::Value>) -> MessageItem {
+        MessageItem {
+            item_type,
+            text: None,
+            image: None,
+            extra,
+        }
+    }
+
+    #[test]
+    fn test_extract_text_simple() {
+        let msg = WeixinMessage {
+            message_type: 1,
+            from_user_id: "wxid_abc".to_string(),
+            from_user_name: None,
+            item_list: vec![make_text_item("Hello, World!")],
+            context_token: None,
+            timestamp: None,
+        };
+        assert_eq!(extract_text(&msg), "Hello, World!");
+    }
+
+    #[test]
+    fn test_extract_text_chinese() {
+        let msg = WeixinMessage {
+            message_type: 1,
+            from_user_id: "wxid_abc".to_string(),
+            from_user_name: None,
+            item_list: vec![make_text_item("你好，请问有什么可以帮助的吗？")],
+            context_token: None,
+            timestamp: None,
+        };
+        assert_eq!(
+            extract_text(&msg),
+            "你好，请问有什么可以帮助的吗？"
+        );
+    }
+
+    #[test]
+    fn test_extract_text_image_only() {
+        let msg = WeixinMessage {
+            message_type: 1,
+            from_user_id: "wxid_abc".to_string(),
+            from_user_name: None,
+            item_list: vec![make_image_item()],
+            context_token: None,
+            timestamp: None,
+        };
+        assert_eq!(extract_text(&msg), "[图片]");
+    }
+
+    #[test]
+    fn test_extract_text_text_and_image() {
+        let msg = WeixinMessage {
+            message_type: 1,
+            from_user_id: "wxid_abc".to_string(),
+            from_user_name: None,
+            item_list: vec![
+                make_text_item("看这张图片"),
+                make_image_item(),
+            ],
+            context_token: None,
+            timestamp: None,
+        };
+        assert_eq!(extract_text(&msg), "看这张图片 [图片]");
+    }
+
+    #[test]
+    fn test_extract_text_audio() {
+        let msg = WeixinMessage {
+            message_type: 1,
+            from_user_id: "wxid_abc".to_string(),
+            from_user_name: None,
+            item_list: vec![make_item(34, None)],
+            context_token: None,
+            timestamp: None,
+        };
+        assert_eq!(extract_text(&msg), "[语音]");
+    }
+
+    #[test]
+    fn test_extract_text_video() {
+        let msg = WeixinMessage {
+            message_type: 1,
+            from_user_id: "wxid_abc".to_string(),
+            from_user_name: None,
+            item_list: vec![make_item(43, None)],
+            context_token: None,
+            timestamp: None,
+        };
+        assert_eq!(extract_text(&msg), "[视频]");
+    }
+
+    #[test]
+    fn test_extract_text_sticker() {
+        let msg = WeixinMessage {
+            message_type: 1,
+            from_user_id: "wxid_abc".to_string(),
+            from_user_name: None,
+            item_list: vec![make_item(47, None)],
+            context_token: None,
+            timestamp: None,
+        };
+        assert_eq!(extract_text(&msg), "[表情]");
+    }
+
+    #[test]
+    fn test_extract_text_shared_link() {
+        let extra = serde_json::json!({
+            "title": "Interesting Article"
+        });
+        let msg = WeixinMessage {
+            message_type: 1,
+            from_user_id: "wxid_abc".to_string(),
+            from_user_name: None,
+            item_list: vec![make_item(49, Some(extra))],
+            context_token: None,
+            timestamp: None,
+        };
+        assert_eq!(extract_text(&msg), "[分享: Interesting Article]");
+    }
+
+    #[test]
+    fn test_extract_text_shared_link_no_title() {
+        let msg = WeixinMessage {
+            message_type: 1,
+            from_user_id: "wxid_abc".to_string(),
+            from_user_name: None,
+            item_list: vec![make_item(49, None)],
+            context_token: None,
+            timestamp: None,
+        };
+        assert_eq!(extract_text(&msg), "[分享]");
+    }
+
+    #[test]
+    fn test_extract_text_system_notification() {
+        let msg = WeixinMessage {
+            message_type: 1,
+            from_user_id: "wxid_abc".to_string(),
+            from_user_name: None,
+            item_list: vec![make_item(10000, None)],
+            context_token: None,
+            timestamp: None,
+        };
+        assert_eq!(extract_text(&msg), "");
+    }
+
+    #[test]
+    fn test_extract_text_mixed_types() {
+        let msg = WeixinMessage {
+            message_type: 1,
+            from_user_id: "wxid_abc".to_string(),
+            from_user_name: None,
+            item_list: vec![
+                make_text_item("你好"),
+                make_image_item(),
+                make_text_item("请看"),
+                make_item(34, None), // audio
+            ],
+            context_token: None,
+            timestamp: None,
+        };
+        assert_eq!(extract_text(&msg), "你好 [图片] 请看 [语音]");
+    }
+
+    #[test]
+    fn test_extract_text_empty() {
+        let msg = WeixinMessage {
+            message_type: 1,
+            from_user_id: "wxid_empty".to_string(),
+            from_user_name: None,
+            item_list: vec![],
+            context_token: None,
+            timestamp: None,
+        };
+        assert_eq!(extract_text(&msg), "");
+    }
+}

--- a/crates/jyc-channels/src/openilink/inbound.rs
+++ b/crates/jyc-channels/src/openilink/inbound.rs
@@ -1,2 +1,440 @@
-//! Inbound adapter for OpeniLink channel.
-//! Will be implemented in Step 10.
+//! OpeniLink inbound adapter implementation.
+//!
+//! This module handles receiving WeChat messages from the OpeniLink Hub
+//! via WebSocket and provides channel-specific pattern matching and
+//! thread name derivation.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use tokio_util::sync::CancellationToken;
+
+use jyc_types::{
+    ChannelMatcher, ChannelPattern, InboundAdapterOptions, InboundMessage, PatternMatch,
+};
+use jyc_types::OpenilinkConfig;
+
+use super::websocket::OpenilinkWebSocket;
+
+/// OpeniLink-specific pattern matching logic.
+///
+/// Matches messages based on:
+/// - `sender`: wxid (exact match or regex)
+/// - `keywords`: message body contains any of the configured keywords
+///
+/// All present rules use AND logic. Within each rule, sub-values use OR logic.
+pub struct OpenilinkMatcher;
+
+impl ChannelMatcher for OpenilinkMatcher {
+    fn channel_type(&self) -> &str {
+        "openilink"
+    }
+
+    fn derive_thread_name(
+        &self,
+        message: &InboundMessage,
+        _patterns: &[ChannelPattern],
+        _pattern_match: Option<&PatternMatch>,
+    ) -> String {
+        // Each WeChat user gets an independent thread based on their wxid
+        format!("wx_{}", message.sender_address)
+    }
+
+    fn match_message(
+        &self,
+        message: &InboundMessage,
+        patterns: &[ChannelPattern],
+    ) -> Option<PatternMatch> {
+        openilink_match_message(message, patterns)
+    }
+
+    /// OpeniLink does NOT store unmatched messages by default.
+    /// This avoids creating threads for every random WeChat message.
+    fn store_unmatched_messages(&self) -> bool {
+        false
+    }
+}
+
+/// Match a message against openilink-specific patterns.
+///
+/// Rules within a pattern use AND logic — all present rules must match.
+/// Within each rule, sub-values use OR logic.
+/// Returns the first matching pattern.
+pub fn openilink_match_message(
+    message: &InboundMessage,
+    patterns: &[ChannelPattern],
+) -> Option<PatternMatch> {
+    for pattern in patterns {
+        if !pattern.enabled {
+            continue;
+        }
+
+        let mut matches = true;
+        let mut match_details = HashMap::new();
+
+        // --- Sender rule ---
+        // Match by wxid (exact or regex)
+        if matches {
+            if let Some(ref sender_rule) = pattern.rules.sender {
+                let addr = message.sender_address.to_lowercase();
+
+                let sender_matches = {
+                    let mut any_rule_present = false;
+                    let mut any_rule_matched = false;
+
+                    if let Some(ref exact_addrs) = sender_rule.exact {
+                        any_rule_present = true;
+                        if exact_addrs.iter().any(|e| e.to_lowercase() == addr) {
+                            any_rule_matched = true;
+                            match_details.insert("sender.exact".to_string(), addr.clone());
+                        }
+                    }
+
+                    if let Some(ref regex_str) = sender_rule.regex {
+                        any_rule_present = true;
+                        if let Ok(re) = regex::Regex::new(regex_str) {
+                            if re.is_match(&addr) {
+                                any_rule_matched = true;
+                                match_details.insert("sender.regex".to_string(), addr.clone());
+                            }
+                        }
+                    }
+
+                    !any_rule_present || any_rule_matched
+                };
+
+                if !sender_matches {
+                    matches = false;
+                }
+            }
+        }
+
+        // --- Keywords rule ---
+        if matches {
+            if let Some(ref keywords) = pattern.rules.keywords {
+                let body = message
+                    .content
+                    .text
+                    .as_deref()
+                    .unwrap_or("")
+                    .to_lowercase();
+
+                let keyword_matches = keywords
+                    .iter()
+                    .any(|kw| body.contains(&kw.to_lowercase()));
+
+                if !keyword_matches {
+                    matches = false;
+                } else {
+                    let matched_kw: Vec<&str> = keywords
+                        .iter()
+                        .filter(|kw| body.contains(&kw.to_lowercase()))
+                        .map(|s| s.as_str())
+                        .collect();
+                    match_details.insert("keywords".to_string(), matched_kw.join(","));
+                }
+            }
+        }
+
+        if matches {
+            return Some(PatternMatch {
+                pattern_name: pattern.name.clone(),
+                channel: "openilink".to_string(),
+                matches: match_details,
+            });
+        }
+    }
+
+    None
+}
+
+/// OpeniLink inbound adapter for receiving WeChat messages via WebSocket.
+pub struct OpenilinkInboundAdapter {
+    config: OpenilinkConfig,
+    /// Channel name from config (e.g., "wechat")
+    channel_name: String,
+}
+
+impl OpenilinkInboundAdapter {
+    /// Create a new OpeniLink inbound adapter.
+    pub fn new(config: &OpenilinkConfig, channel_name: String) -> Self {
+        Self {
+            config: config.clone(),
+            channel_name,
+        }
+    }
+}
+
+impl ChannelMatcher for OpenilinkInboundAdapter {
+    fn channel_type(&self) -> &str {
+        "openilink"
+    }
+
+    fn derive_thread_name(
+        &self,
+        message: &InboundMessage,
+        patterns: &[ChannelPattern],
+        pattern_match: Option<&PatternMatch>,
+    ) -> String {
+        // Delegate to the stateless OpenilinkMatcher
+        OpenilinkMatcher.derive_thread_name(message, patterns, pattern_match)
+    }
+
+    fn match_message(
+        &self,
+        message: &InboundMessage,
+        patterns: &[ChannelPattern],
+    ) -> Option<PatternMatch> {
+        openilink_match_message(message, patterns)
+    }
+}
+
+#[async_trait]
+impl jyc_types::InboundAdapter for OpenilinkInboundAdapter {
+    async fn start(
+        &self,
+        options: InboundAdapterOptions,
+        cancel: CancellationToken,
+    ) -> Result<()> {
+        // Create WebSocket handler and run the event loop
+        let mut ws = OpenilinkWebSocket::new(&self.config);
+        let channel_name = self.channel_name.clone();
+
+        loop {
+            tracing::info!("Starting OpeniLink WebSocket connection...");
+
+            match ws
+                .run(&channel_name, &*options.on_message, &cancel)
+                .await
+            {
+                Ok(()) => {
+                    // Clean exit (cancelled)
+                    tracing::info!("OpeniLink WebSocket stopped cleanly");
+                    break;
+                }
+                Err(e) => {
+                    if cancel.is_cancelled() {
+                        tracing::info!("OpeniLink WebSocket shutting down (cancelled)");
+                        break;
+                    }
+                    tracing::error!(error = %e, "OpeniLink WebSocket error");
+
+                    if !ws.handle_reconnection().await {
+                        tracing::error!(
+                            "Max reconnection attempts reached, stopping OpeniLink channel"
+                        );
+                        break;
+                    }
+                    // Loop continues → reconnect
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jyc_types::{MessageContent, PatternRules, SenderRule};
+    use chrono::Utc;
+
+    fn make_openilink_message(
+        sender_addr: &str,
+        body: &str,
+        context_token: Option<&str>,
+    ) -> InboundMessage {
+        let mut metadata = HashMap::new();
+        if let Some(token) = context_token {
+            metadata.insert(
+                "context_token".to_string(),
+                serde_json::Value::String(token.to_string()),
+            );
+        }
+
+        InboundMessage {
+            id: "test".to_string(),
+            channel: "openilink".to_string(),
+            channel_uid: sender_addr.to_string(),
+            sender: sender_addr.to_string(),
+            sender_address: sender_addr.to_string(),
+            recipients: vec![],
+            topic: String::new(),
+            content: MessageContent {
+                text: Some(body.to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata,
+            matched_pattern: None,
+        }
+    }
+
+    fn make_pattern(
+        name: &str,
+        keywords: Option<Vec<String>>,
+        sender: Option<SenderRule>,
+    ) -> ChannelPattern {
+        ChannelPattern {
+            name: name.to_string(),
+            channel: "openilink".to_string(),
+            enabled: true,
+            rules: PatternRules {
+                sender,
+                subject: None,
+                mentions: None,
+                keywords,
+                chat_name: None,
+                github_type: None,
+                labels: None,
+                assignees: None,
+                exclude_labels: None,
+            },
+            attachments: None,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_match_by_keywords() {
+        let msg = make_openilink_message("wxid_abc", "我需要帮助", None);
+        let patterns = vec![make_pattern(
+            "help_bot",
+            Some(vec!["帮助".to_string(), "help".to_string()]),
+            None,
+        )];
+
+        let result = openilink_match_message(&msg, &patterns);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().pattern_name, "help_bot");
+    }
+
+    #[test]
+    fn test_match_keywords_case_insensitive() {
+        let msg = make_openilink_message("wxid_abc", "I need HELP", None);
+        let patterns = vec![make_pattern(
+            "help_bot",
+            Some(vec!["help".to_string()]),
+            None,
+        )];
+
+        assert!(openilink_match_message(&msg, &patterns).is_some());
+    }
+
+    #[test]
+    fn test_no_match_wrong_keywords() {
+        let msg = make_openilink_message("wxid_abc", "Just chatting", None);
+        let patterns = vec![make_pattern(
+            "help_bot",
+            Some(vec!["帮助".to_string(), "help".to_string()]),
+            None,
+        )];
+
+        assert!(openilink_match_message(&msg, &patterns).is_none());
+    }
+
+    #[test]
+    fn test_match_by_sender() {
+        let msg = make_openilink_message("wxid_vip123", "Hello", None);
+        let patterns = vec![make_pattern(
+            "vip_user",
+            None,
+            Some(SenderRule {
+                exact: Some(vec!["wxid_vip123".to_string()]),
+                ..Default::default()
+            }),
+        )];
+
+        assert!(openilink_match_message(&msg, &patterns).is_some());
+    }
+
+    #[test]
+    fn test_no_match_wrong_sender() {
+        let msg = make_openilink_message("wxid_other", "Hello", None);
+        let patterns = vec![make_pattern(
+            "vip_user",
+            None,
+            Some(SenderRule {
+                exact: Some(vec!["wxid_vip123".to_string()]),
+                ..Default::default()
+            }),
+        )];
+
+        assert!(openilink_match_message(&msg, &patterns).is_none());
+    }
+
+    #[test]
+    fn test_match_sender_and_keywords_and_logic() {
+        let msg = make_openilink_message("wxid_vip", "help me please", None);
+        let patterns = vec![make_pattern(
+            "vip_help",
+            Some(vec!["help".to_string()]),
+            Some(SenderRule {
+                exact: Some(vec!["wxid_vip".to_string()]),
+                ..Default::default()
+            }),
+        )];
+
+        assert!(openilink_match_message(&msg, &patterns).is_some());
+
+        // Sender matches but keywords don't
+        let msg2 = make_openilink_message("wxid_vip", "random text", None);
+        assert!(openilink_match_message(&msg2, &patterns).is_none());
+
+        // Keywords match but sender doesn't
+        let msg3 = make_openilink_message("wxid_other", "help me", None);
+        assert!(openilink_match_message(&msg3, &patterns).is_none());
+    }
+
+    #[test]
+    fn test_disabled_pattern_skipped() {
+        let msg = make_openilink_message("wxid_abc", "help", None);
+        let mut pattern = make_pattern(
+            "help_bot",
+            Some(vec!["help".to_string()]),
+            None,
+        );
+        pattern.enabled = false;
+
+        assert!(openilink_match_message(&msg, &[pattern]).is_none());
+    }
+
+    #[test]
+    fn test_first_pattern_wins() {
+        let msg = make_openilink_message("wxid_abc", "help", None);
+        let patterns = vec![
+            make_pattern("first", Some(vec!["help".to_string()]), None),
+            make_pattern("second", Some(vec!["help".to_string()]), None),
+        ];
+
+        let result = openilink_match_message(&msg, &patterns).unwrap();
+        assert_eq!(result.pattern_name, "first");
+    }
+
+    #[test]
+    fn test_empty_rules_matches_all() {
+        let msg = make_openilink_message("wxid_abc", "anything", None);
+        let patterns = vec![make_pattern("catch_all", None, None)];
+
+        assert!(openilink_match_message(&msg, &patterns).is_some());
+    }
+
+    #[test]
+    fn test_derive_thread_name() {
+        let msg = make_openilink_message("wxid_abc123", "Hello", Some("token_xxx"));
+        let matcher = OpenilinkMatcher;
+        let name = matcher.derive_thread_name(&msg, &[], None);
+        assert_eq!(name, "wx_wxid_abc123");
+    }
+
+    #[test]
+    fn test_store_unmatched_default() {
+        let matcher = OpenilinkMatcher;
+        assert!(!matcher.store_unmatched_messages());
+    }
+}

--- a/crates/jyc-channels/src/openilink/inbound.rs
+++ b/crates/jyc-channels/src/openilink/inbound.rs
@@ -64,6 +64,7 @@ pub fn openilink_match_message(
     message: &InboundMessage,
     patterns: &[ChannelPattern],
 ) -> Option<PatternMatch> {
+    #[allow(clippy::collapsible_if)]
     for pattern in patterns {
         if !pattern.enabled {
             continue;

--- a/crates/jyc-channels/src/openilink/inbound.rs
+++ b/crates/jyc-channels/src/openilink/inbound.rs
@@ -1,0 +1,2 @@
+//! Inbound adapter for OpeniLink channel.
+//! Will be implemented in Step 10.

--- a/crates/jyc-channels/src/openilink/mod.rs
+++ b/crates/jyc-channels/src/openilink/mod.rs
@@ -1,0 +1,12 @@
+//! OpeniLink (WeChat) channel implementation for JYC.
+//!
+//! This module provides inbound and outbound adapters for the OpeniLink
+//! messaging platform, which bridges WeChat messages through a Hub server.
+//! It uses WebSocket for receiving messages and HTTP API for sending replies.
+
+pub mod types;
+pub mod client;
+pub mod inbound;
+pub mod outbound;
+pub mod websocket;
+pub mod formatter;

--- a/crates/jyc-channels/src/openilink/outbound.rs
+++ b/crates/jyc-channels/src/openilink/outbound.rs
@@ -1,2 +1,202 @@
-//! Outbound adapter for OpeniLink channel.
-//! Will be implemented in Step 11.
+//! OpeniLink outbound adapter implementation.
+//!
+//! This module handles sending WeChat messages via the OpeniLink Hub HTTP API.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+
+use jyc_types::{InboundMessage, OutboundAttachment, SendResult};
+use jyc_types::OpenilinkConfig;
+
+use super::client::OpenilinkClient;
+
+/// OpeniLink outbound adapter for sending messages via HTTP API.
+pub struct OpenilinkOutboundAdapter {
+    client: OpenilinkClient,
+    footer_enabled: bool,
+}
+
+impl OpenilinkOutboundAdapter {
+    /// Create a new OpeniLink outbound adapter.
+    pub fn new(config: OpenilinkConfig, footer_enabled: bool) -> Self {
+        Self {
+            client: OpenilinkClient::new(config),
+            footer_enabled,
+        }
+    }
+}
+
+#[async_trait]
+impl jyc_types::OutboundAdapter for OpenilinkOutboundAdapter {
+    fn channel_type(&self) -> &str {
+        "openilink"
+    }
+
+    async fn connect(&self) -> Result<()> {
+        // Verify API key is valid by fetching hub config
+        let config = self
+            .client
+            .get_config()
+            .await
+            .context("Failed to connect to OpeniLink Hub: invalid API key or hub unreachable")?;
+
+        tracing::info!(
+            version = ?config.version,
+            connected = config.connected,
+            wechat_user = ?config.wechat_user.as_ref().map(|u| u.nickname.as_deref()).flatten(),
+            "OpeniLink outbound adapter connected"
+        );
+        Ok(())
+    }
+
+    async fn disconnect(&self) -> Result<()> {
+        tracing::info!("OpeniLink outbound adapter disconnected");
+        Ok(())
+    }
+
+    fn clean_body(&self, raw_body: &str) -> String {
+        // WeChat messages don't have quoted reply history.
+        // Just trim whitespace.
+        raw_body.trim().to_string()
+    }
+
+    async fn send_reply(
+        &self,
+        original: &InboundMessage,
+        reply_text: &str,
+        thread_path: &Path,
+        _message_dir: &str,
+        _attachments: Option<&[OutboundAttachment]>,
+    ) -> Result<SendResult> {
+        // Extract the target user ID from the original message
+        let to_user_id = original.sender_address.as_str();
+
+        // Extract context_token from metadata for reply mode
+        let context_token = original
+            .metadata
+            .get("context_token")
+            .and_then(|v| v.as_str());
+
+        // Build footer with model/mode/tokens information
+        let reply_ctx = jyc_mcp::context::load_reply_context(thread_path).await.ok();
+        let model = reply_ctx.as_ref().and_then(|c| c.model.as_deref());
+        let mode = reply_ctx.as_ref().and_then(|c| c.mode.as_deref());
+
+        let (input_tokens, max_tokens) =
+            jyc_core::session_state::read_input_tokens(thread_path).await;
+
+        let footer = jyc_core::email_parser::build_footer(
+            model,
+            mode,
+            input_tokens,
+            max_tokens,
+            self.footer_enabled,
+        );
+
+        // Clean reply text
+        let clean_reply = jyc_core::email_parser::strip_trailing_separators(reply_text);
+
+        // Combine with footer
+        let full_reply = if footer.is_empty() {
+            clean_reply
+        } else {
+            format!("{}\n\n{}", clean_reply, footer)
+        };
+
+        // Send the message
+        let result = if let Some(token) = context_token {
+            // Reply mode: use context token to maintain conversation context
+            self.client
+                .send_message(to_user_id, &full_reply, Some(token))
+                .await
+                .context("Failed to send OpeniLink reply")?
+        } else {
+            // Active push mode: no context token (fallback)
+            tracing::warn!(
+                to_user_id = %to_user_id,
+                "No context_token in message metadata, sending as active push"
+            );
+            self.client
+                .send_message(to_user_id, &full_reply, None)
+                .await
+                .context("Failed to send OpeniLink reply")?
+        };
+
+        tracing::info!(
+            to_user_id = %to_user_id,
+            message_id = ?result.message_id,
+            text_len = full_reply.len(),
+            "OpeniLink reply sent"
+        );
+
+        Ok(SendResult {
+            message_id: result.message_id.unwrap_or_default(),
+        })
+    }
+
+    async fn send_alert(
+        &self,
+        _recipient: &str,
+        _subject: &str,
+        _body: &str,
+    ) -> Result<SendResult> {
+        // OpeniLink does not support alert sending in the initial version
+        anyhow::bail!("OpeniLink channel does not support send_alert in this version");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jyc_types::MessageContent;
+    use chrono::Utc;
+
+    fn make_test_message(to_user_id: &str, context_token: Option<&str>) -> InboundMessage {
+        let mut metadata = std::collections::HashMap::new();
+        if let Some(token) = context_token {
+            metadata.insert(
+                "context_token".to_string(),
+                serde_json::Value::String(token.to_string()),
+            );
+        }
+
+        InboundMessage {
+            id: "test_msg".to_string(),
+            channel: "openilink".to_string(),
+            channel_uid: to_user_id.to_string(),
+            sender: to_user_id.to_string(),
+            sender_address: to_user_id.to_string(),
+            recipients: vec![],
+            topic: String::new(),
+            content: MessageContent {
+                text: Some("Test message".to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata,
+            matched_pattern: None,
+        }
+    }
+
+    #[test]
+    fn test_channel_type() {
+        let config = OpenilinkConfig::default();
+        let adapter = OpenilinkOutboundAdapter::new(config, true);
+        assert_eq!(adapter.channel_type(), "openilink");
+    }
+
+    #[test]
+    fn test_clean_body() {
+        let config = OpenilinkConfig::default();
+        let adapter = OpenilinkOutboundAdapter::new(config, true);
+        assert_eq!(adapter.clean_body("  Hello, World!  "), "Hello, World!");
+        assert_eq!(adapter.clean_body("No change"), "No change");
+    }
+}

--- a/crates/jyc-channels/src/openilink/outbound.rs
+++ b/crates/jyc-channels/src/openilink/outbound.rs
@@ -45,7 +45,7 @@ impl jyc_types::OutboundAdapter for OpenilinkOutboundAdapter {
         tracing::info!(
             version = ?config.version,
             connected = config.connected,
-            wechat_user = ?config.wechat_user.as_ref().map(|u| u.nickname.as_deref()).flatten(),
+            wechat_user = ?config.wechat_user.as_ref().and_then(|u| u.nickname.as_deref()),
             "OpeniLink outbound adapter connected"
         );
         Ok(())
@@ -150,40 +150,7 @@ impl jyc_types::OutboundAdapter for OpenilinkOutboundAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use jyc_types::MessageContent;
-    use chrono::Utc;
-
-    fn make_test_message(to_user_id: &str, context_token: Option<&str>) -> InboundMessage {
-        let mut metadata = std::collections::HashMap::new();
-        if let Some(token) = context_token {
-            metadata.insert(
-                "context_token".to_string(),
-                serde_json::Value::String(token.to_string()),
-            );
-        }
-
-        InboundMessage {
-            id: "test_msg".to_string(),
-            channel: "openilink".to_string(),
-            channel_uid: to_user_id.to_string(),
-            sender: to_user_id.to_string(),
-            sender_address: to_user_id.to_string(),
-            recipients: vec![],
-            topic: String::new(),
-            content: MessageContent {
-                text: Some("Test message".to_string()),
-                html: None,
-                markdown: None,
-            },
-            timestamp: Utc::now(),
-            thread_refs: None,
-            reply_to_id: None,
-            external_id: None,
-            attachments: vec![],
-            metadata,
-            matched_pattern: None,
-        }
-    }
+    use jyc_types::OutboundAdapter;
 
     #[test]
     fn test_channel_type() {

--- a/crates/jyc-channels/src/openilink/outbound.rs
+++ b/crates/jyc-channels/src/openilink/outbound.rs
@@ -1,0 +1,2 @@
+//! Outbound adapter for OpeniLink channel.
+//! Will be implemented in Step 11.

--- a/crates/jyc-channels/src/openilink/types.rs
+++ b/crates/jyc-channels/src/openilink/types.rs
@@ -1,0 +1,369 @@
+//! OpeniLink-specific types and message definitions.
+//!
+//! This module contains types for WebSocket message events received from
+//! OpeniLink Hub, and HTTP request/response types for the Hub REST API.
+//!
+//! The message format follows the OpeniLink Node SDK's `WeixinMessage` structure.
+
+use serde::{Deserialize, Serialize};
+
+// ─── WebSocket Message Types ───────────────────────────────────────────
+
+/// A WeChat message received via OpeniLink Hub WebSocket.
+///
+/// Represents the message format sent by the OpeniLink Hub through the
+/// WebSocket connection. Messages are received in real-time when someone
+/// sends a message to the connected WeChat account.
+#[derive(Debug, Clone, Deserialize)]
+pub struct WeixinMessage {
+    /// Message type identifier:
+    /// - 1: received from a WeChat user
+    /// - 2: sent by the bot itself (should be filtered out)
+    /// - 3: system notification
+    pub message_type: i32,
+
+    /// The WeChat ID (wxid) of the user who sent the message
+    pub from_user_id: String,
+
+    /// Display name of the sender (may be empty for some accounts)
+    pub from_user_name: Option<String>,
+
+    /// The message content items
+    pub item_list: Vec<MessageItem>,
+
+    /// Context token for replying to this message through the HTTP API.
+    /// Must be stored in metadata for outbound reply.
+    pub context_token: Option<String>,
+
+    /// Unix timestamp in milliseconds when the message was received by the hub
+    pub timestamp: Option<i64>,
+}
+
+/// A single item within a WeChat message.
+///
+/// A WeChat message can contain multiple items (e.g., text + image),
+/// each with a specific type.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MessageItem {
+    /// Item type:
+    /// - 1: Text
+    /// - 3: Image
+    /// - 34: Audio (voice)
+    /// - 43: Video
+    /// - 47: Sticker/emoticon
+    /// - 49: Shared link/card
+    /// - 62: Small video
+    /// - 10000: System notification
+    /// - 10002: System message
+    #[serde(rename = "type")]
+    pub item_type: i32,
+
+    /// Text content (present when type == 1)
+    pub text: Option<TextItem>,
+
+    /// Image content (present when type == 3)
+    pub image: Option<ImageItem>,
+
+    /// File/video/other content
+    #[serde(flatten)]
+    pub extra: Option<serde_json::Value>,
+}
+
+/// Text content within a message item.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TextItem {
+    /// The text content of the message
+    pub text: String,
+}
+
+/// Image content within a message item.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ImageItem {
+    /// Image URL or file path
+    pub url: Option<String>,
+
+    /// Image file path on the hub server
+    pub path: Option<String>,
+
+    /// Image width in pixels
+    pub width: Option<i32>,
+
+    /// Image height in pixels
+    pub height: Option<i32>,
+}
+
+// ─── WebSocket Connection Types ────────────────────────────────────────
+
+/// Response from the WebSocket connect endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct WsConnectResponse {
+    /// Connection status
+    pub code: i32,
+
+    /// Status message
+    pub message: Option<String>,
+}
+
+// ─── HTTP API Request/Response Types ───────────────────────────────────
+
+/// Request body for sending a message via the HTTP API.
+///
+/// POST {hub_url}/api/v1/channels/send
+#[derive(Debug, Clone, Serialize)]
+pub struct SendMessageRequest {
+    /// The WeChat user ID (wxid) to send the message to
+    pub to_user_id: String,
+
+    /// The text content to send
+    pub content: String,
+
+    /// Context token from the original message (for reply mode).
+    /// When absent, the message is sent as an active push.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_token: Option<String>,
+}
+
+/// Response from the send message API.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SendMessageResponse {
+    /// Result code (0 = success)
+    pub code: i32,
+
+    /// Status message
+    pub message: Option<String>,
+
+    /// Message ID assigned by the hub
+    pub message_id: Option<String>,
+}
+
+/// Request body for sending a typing indicator.
+///
+/// POST {hub_url}/api/v1/channels/typing
+#[derive(Debug, Clone, Serialize)]
+pub struct SendTypingRequest {
+    /// The WeChat user ID (wxid) to send typing indicator to
+    pub to_user_id: String,
+
+    /// Typing ticket from the original message
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub typing_ticket: Option<String>,
+
+    /// Action: "TypingBegin" or "TypingEnd"
+    pub action: String,
+}
+
+/// Response from the typing API.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SendTypingResponse {
+    /// Result code (0 = success)
+    pub code: i32,
+
+    /// Status message
+    pub message: Option<String>,
+}
+
+/// Hub configuration retrieved from the GET config endpoint.
+///
+/// GET {hub_url}/api/v1/channels/config
+#[derive(Debug, Clone, Deserialize)]
+pub struct HubConfig {
+    /// Hub version
+    pub version: Option<String>,
+
+    /// Whether the hub is connected to WeChat
+    pub connected: bool,
+
+    /// Current WeChat login user info
+    pub wechat_user: Option<WechatUserInfo>,
+
+    /// Supported features
+    pub features: Option<Vec<String>>,
+}
+
+/// WeChat user information from the hub.
+#[derive(Debug, Clone, Deserialize)]
+pub struct WechatUserInfo {
+    /// WeChat ID
+    pub wxid: Option<String>,
+
+    /// WeChat nickname
+    pub nickname: Option<String>,
+
+    /// Avatar URL
+    pub avatar: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_text_message() {
+        let json = r#"{
+            "message_type": 1,
+            "from_user_id": "wxid_abc123",
+            "from_user_name": "张三",
+            "item_list": [
+                {
+                    "type": 1,
+                    "text": { "text": "你好，请问有什么可以帮助的吗？" }
+                }
+            ],
+            "context_token": "token_xxx",
+            "timestamp": 1704067200000
+        }"#;
+
+        let msg: WeixinMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.message_type, 1);
+        assert_eq!(msg.from_user_id, "wxid_abc123");
+        assert_eq!(msg.from_user_name, Some("张三".to_string()));
+        assert_eq!(msg.item_list.len(), 1);
+        assert_eq!(msg.item_list[0].item_type, 1);
+        assert_eq!(
+            msg.item_list[0].text.as_ref().unwrap().text,
+            "你好，请问有什么可以帮助的吗？"
+        );
+        assert_eq!(msg.context_token, Some("token_xxx".to_string()));
+    }
+
+    #[test]
+    fn test_parse_image_message() {
+        let json = r#"{
+            "message_type": 1,
+            "from_user_id": "wxid_def456",
+            "from_user_name": null,
+            "item_list": [
+                {
+                    "type": 3,
+                    "image": {
+                        "url": "https://example.com/image.jpg",
+                        "path": "/data/images/abc.jpg",
+                        "width": 800,
+                        "height": 600
+                    }
+                }
+            ],
+            "context_token": null,
+            "timestamp": 1704067200000
+        }"#;
+
+        let msg: WeixinMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.message_type, 1);
+        assert_eq!(msg.item_list.len(), 1);
+        assert_eq!(msg.item_list[0].item_type, 3);
+        let image = msg.item_list[0].image.as_ref().unwrap();
+        assert_eq!(image.url.as_deref(), Some("https://example.com/image.jpg"));
+        assert_eq!(image.width, Some(800));
+        assert_eq!(image.height, Some(600));
+    }
+
+    #[test]
+    fn test_parse_multi_item_message() {
+        let json = r#"{
+            "message_type": 1,
+            "from_user_id": "wxid_ghi789",
+            "item_list": [
+                {
+                    "type": 1,
+                    "text": { "text": "看这张图片" }
+                },
+                {
+                    "type": 3,
+                    "image": {
+                        "url": "https://example.com/photo.png",
+                        "width": 1920,
+                        "height": 1080
+                    }
+                }
+            ],
+            "context_token": "token_yyy",
+            "timestamp": 1704067201000
+        }"#;
+
+        let msg: WeixinMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.item_list.len(), 2);
+        assert_eq!(msg.item_list[0].item_type, 1);
+        assert_eq!(msg.item_list[1].item_type, 3);
+        assert_eq!(msg.context_token, Some("token_yyy".to_string()));
+    }
+
+    #[test]
+    fn test_filter_bot_message() {
+        let json = r#"{
+            "message_type": 2,
+            "from_user_id": "wxid_bot",
+            "item_list": [
+                {
+                    "type": 1,
+                    "text": { "text": "这是机器人自己发的消息" }
+                }
+            ],
+            "context_token": null,
+            "timestamp": 1704067200000
+        }"#;
+
+        let msg: WeixinMessage = serde_json::from_str(json).unwrap();
+        assert_eq!(msg.message_type, 2);
+        // Messages with message_type == 2 should be filtered out by the websocket handler
+    }
+
+    #[test]
+    fn test_send_message_request_serialize() {
+        let req = SendMessageRequest {
+            to_user_id: "wxid_abc".to_string(),
+            content: "Hello, World!".to_string(),
+            context_token: Some("token_xxx".to_string()),
+        };
+
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains(r#""to_user_id":"wxid_abc""#));
+        assert!(json.contains(r#""content":"Hello, World!""#));
+        assert!(json.contains(r#""context_token":"token_xxx""#));
+    }
+
+    #[test]
+    fn test_send_message_request_no_context_token() {
+        let req = SendMessageRequest {
+            to_user_id: "wxid_abc".to_string(),
+            content: "Hello!".to_string(),
+            context_token: None,
+        };
+
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains(r#""to_user_id":"wxid_abc""#));
+        assert!(!json.contains("context_token"));
+    }
+
+    #[test]
+    fn test_send_message_response() {
+        let json = r#"{
+            "code": 0,
+            "message": "success",
+            "message_id": "msg_id_123"
+        }"#;
+
+        let resp: SendMessageResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.code, 0);
+        assert_eq!(resp.message_id, Some("msg_id_123".to_string()));
+    }
+
+    #[test]
+    fn test_hub_config() {
+        let json = r#"{
+            "version": "1.0.0",
+            "connected": true,
+            "wechat_user": {
+                "wxid": "wxid_bot",
+                "nickname": "My Bot",
+                "avatar": "https://example.com/avatar.png"
+            },
+            "features": ["text", "image", "file"]
+        }"#;
+
+        let config: HubConfig = serde_json::from_str(json).unwrap();
+        assert!(config.connected);
+        assert_eq!(config.version, Some("1.0.0".to_string()));
+        assert_eq!(config.wechat_user.as_ref().unwrap().wxid.as_deref(), Some("wxid_bot"));
+        assert_eq!(config.features.as_ref().unwrap().len(), 3);
+    }
+}

--- a/crates/jyc-channels/src/openilink/websocket.rs
+++ b/crates/jyc-channels/src/openilink/websocket.rs
@@ -1,2 +1,471 @@
-//! WebSocket handler for OpeniLink channel.
-//! Will be implemented in Step 9.
+//! WebSocket connection handler for OpeniLink real-time message receiving.
+//!
+//! This module manages the WebSocket connection to the OpeniLink Hub,
+//! parsing incoming JSON messages, filtering bot's own messages,
+//! and delivering them through a callback.
+
+use anyhow::{Context, Result};
+use futures_util::{SinkExt, StreamExt};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::Message,
+};
+use tokio_util::sync::CancellationToken;
+
+use jyc_types::{InboundMessage, MessageContent};
+use jyc_types::OpenilinkConfig;
+
+use super::types::WeixinMessage;
+
+/// WebSocket connection handler for OpeniLink.
+///
+/// Manages the lifecycle of a WebSocket connection to the Hub:
+/// connect → receive messages → parse → convert to InboundMessage → callback.
+///
+/// Supports:
+/// - Exponential backoff reconnection
+/// - Heartbeat (periodic ping)
+/// - Graceful shutdown via CancellationToken
+pub struct OpenilinkWebSocket {
+    config: OpenilinkConfig,
+    /// Current reconnection attempt count
+    reconnect_count: usize,
+}
+
+impl OpenilinkWebSocket {
+    /// Create a new OpeniLink WebSocket handler.
+    pub fn new(config: &OpenilinkConfig) -> Self {
+        Self {
+            config: config.clone(),
+            reconnect_count: 0,
+        }
+    }
+
+    /// Get the WebSocket URL with authentication query parameter.
+    fn ws_url(&self) -> String {
+        let base = self.config.hub_url.trim_end_matches('/');
+        // Strip https:// prefix and replace with wss://
+        let ws_base = if base.starts_with("https://") {
+            base.replacen("https://", "wss://", 1)
+        } else if base.starts_with("http://") {
+            base.replacen("http://", "wss://", 1)
+        } else {
+            format!("wss://{}", base)
+        };
+        format!("{}/api/v1/channels/connect?token={}", ws_base, self.config.api_key)
+    }
+
+    /// Run the WebSocket event loop.
+    ///
+    /// Connects to the Hub, receives messages, and delivers them via
+    /// the `on_message` callback. Blocks until cancelled or connection
+    /// failure.
+    pub async fn run(
+        &mut self,
+        channel_name: &str,
+        on_message: &(dyn Fn(InboundMessage) -> Result<()> + Send + Sync),
+        cancel: &CancellationToken,
+    ) -> Result<()> {
+        let url = self.ws_url();
+        tracing::info!(url = %url, "Connecting to OpeniLink WebSocket...");
+
+        // Connect to WebSocket
+        let (ws_stream, _) = connect_async(&url)
+            .await
+            .with_context(|| format!("Failed to connect to OpeniLink WebSocket: {url}"))?;
+
+        tracing::info!("OpeniLink WebSocket connected, listening for messages");
+        self.reset_reconnection_count();
+
+        let (write, mut read) = ws_stream.split();
+        let write = Arc::new(Mutex::new(write));
+        let cancel_clone = cancel.clone();
+
+        // Spawn a heartbeat task that sends pings every 30 seconds
+        let heartbeat_write = write.clone();
+        let heartbeat_handle = tokio::spawn(async move {
+            let interval = std::time::Duration::from_secs(30);
+            loop {
+                tokio::select! {
+                    _ = tokio::time::sleep(interval) => {
+                        let mut w = heartbeat_write.lock().await;
+                        if let Err(e) = w.send(Message::Ping(vec![])).await {
+                            tracing::debug!("Failed to send ping: {}", e);
+                            break;
+                        }
+                    }
+                    _ = cancel_clone.cancelled() => {
+                        break;
+                    }
+                }
+            }
+        });
+
+        // Receive messages
+        loop {
+            tokio::select! {
+                msg = read.next() => {
+                    match msg {
+                        Some(Ok(Message::Text(text))) => {
+                            if let Err(e) = self.handle_message(channel_name, &text, on_message) {
+                                tracing::warn!(error = %e, "Failed to process message");
+                            }
+                        }
+                        Some(Ok(Message::Pong(_))) => {
+                            // Pong received, connection is healthy
+                            tracing::trace!("WebSocket pong received");
+                        }
+                        Some(Ok(Message::Ping(data))) => {
+                            // Respond to server ping
+                            let mut w = write.lock().await;
+                            if let Err(e) = w.send(Message::Pong(data.to_vec())).await {
+                                tracing::debug!("Failed to send pong: {}", e);
+                            }
+                        }
+                        Some(Ok(Message::Close(_))) => {
+                            tracing::info!("WebSocket connection closed by server");
+                            break;
+                        }
+                        Some(Ok(other)) => {
+                            tracing::debug!("Received non-text WebSocket message: {:?}", other);
+                        }
+                        Some(Err(e)) => {
+                            tracing::error!(error = %e, "WebSocket error");
+                            return Err(anyhow::anyhow!("WebSocket error: {e}"));
+                        }
+                        None => {
+                            // Stream ended
+                            tracing::info!("WebSocket stream ended");
+                            break;
+                        }
+                    }
+                }
+                _ = cancel.cancelled() => {
+                    tracing::info!("OpeniLink WebSocket cancelled");
+                    heartbeat_handle.abort();
+                    return Ok(());
+                }
+            }
+        }
+
+        tracing::info!("OpeniLink WebSocket disconnected");
+        heartbeat_handle.abort();
+
+        Err(anyhow::anyhow!("WebSocket connection closed"))
+    }
+
+    /// Parse a WebSocket text message and deliver it as an `InboundMessage`.
+    fn handle_message(
+        &self,
+        channel_name: &str,
+        text: &str,
+        on_message: &(dyn Fn(InboundMessage) -> Result<()> + Send + Sync),
+    ) -> Result<()> {
+        // Parse the JSON message
+        let weixin_msg: WeixinMessage = serde_json::from_str(text)
+            .with_context(|| format!("Failed to parse Weixin message: {}", &text[..text.len().min(200)]))?;
+
+        // Filter out bot's own messages (message_type == 2)
+        if weixin_msg.message_type == 2 {
+            tracing::debug!(
+                from_user_id = %weixin_msg.from_user_id,
+                "Skipping bot's own message (message_type=2)"
+            );
+            return Ok(());
+        }
+
+        // Extract text content from item_list
+        let text_content = self.extract_text(&weixin_msg);
+
+        let from_user_id = weixin_msg.from_user_id.clone();
+        let display_name = weixin_msg
+            .from_user_name
+            .clone()
+            .unwrap_or_else(|| from_user_id.clone());
+
+        // Build metadata
+        let mut metadata = std::collections::HashMap::new();
+        if let Some(token) = &weixin_msg.context_token {
+            metadata.insert(
+                "context_token".to_string(),
+                serde_json::Value::String(token.clone()),
+            );
+        }
+        metadata.insert(
+            "from_user_id".to_string(),
+            serde_json::Value::String(from_user_id.clone()),
+        );
+
+        let message = InboundMessage {
+            id: uuid::Uuid::new_v4().to_string(),
+            channel: channel_name.to_string(),
+            channel_uid: from_user_id.clone(),
+            sender: display_name,
+            sender_address: from_user_id,
+            recipients: vec![],
+            topic: String::new(),
+            content: MessageContent {
+                text: Some(text_content),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata,
+            matched_pattern: None,
+        };
+
+        tracing::info!(
+            message_id = %message.channel_uid,
+            sender = %message.sender_address,
+            "OpeniLink message received"
+        );
+
+        on_message(message)?;
+        Ok(())
+    }
+
+    /// Extract text content from a WeixinMessage's item_list.
+    ///
+    /// For text items, returns the text content directly.
+    /// For non-text items (images, files, etc.), returns a descriptive marker.
+    fn extract_text(&self, msg: &WeixinMessage) -> String {
+        let mut parts: Vec<String> = Vec::new();
+
+        for item in &msg.item_list {
+            match item.item_type {
+                1 => {
+                    // Text
+                    if let Some(ref text_item) = item.text {
+                        parts.push(text_item.text.clone());
+                    }
+                }
+                3 => {
+                    // Image
+                    parts.push("[图片]".to_string());
+                }
+                34 => {
+                    // Audio
+                    parts.push("[语音]".to_string());
+                }
+                43 | 62 => {
+                    // Video
+                    parts.push("[视频]".to_string());
+                }
+                47 => {
+                    // Sticker
+                    parts.push("[表情]".to_string());
+                }
+                49 => {
+                    // Shared link/card - try to extract title
+                    parts.push("[分享]".to_string());
+                }
+                10000 => {
+                    // System notification - skip
+                }
+                _ => {
+                    parts.push(format!("[其他消息类型: {}]", item.item_type));
+                }
+            }
+        }
+
+        if parts.is_empty() {
+            String::new()
+        } else {
+            parts.join(" ")
+        }
+    }
+
+    /// Handle reconnection with exponential backoff.
+    ///
+    /// Returns `true` if we should retry, `false` if max attempts reached.
+    pub async fn handle_reconnection(&mut self) -> bool {
+        if self.reconnect_count >= self.config.websocket.max_reconnect_attempts {
+            tracing::error!(
+                max_attempts = self.config.websocket.max_reconnect_attempts,
+                "Maximum reconnection attempts reached"
+            );
+            return false;
+        }
+
+        // Exponential backoff: base_delay * 2^attempt, capped at max_delay
+        let base_delay = self.config.websocket.reconnect_delay_secs;
+        let delay_secs = base_delay * (1u64 << self.reconnect_count.min(5));
+        self.reconnect_count += 1;
+
+        tracing::info!(
+            attempt = self.reconnect_count,
+            max_attempts = self.config.websocket.max_reconnect_attempts,
+            delay_secs = delay_secs,
+            "Reconnecting to OpeniLink WebSocket"
+        );
+
+        tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+        true
+    }
+
+    /// Reset reconnection count after successful connection.
+    pub fn reset_reconnection_count(&mut self) {
+        self.reconnect_count = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_ws() -> OpenilinkWebSocket {
+        let config = OpenilinkConfig {
+            api_key: "sk-test".to_string(),
+            hub_url: "https://hub.example.com".to_string(),
+            ..OpenilinkConfig::default()
+        };
+        OpenilinkWebSocket::new(&config)
+    }
+
+    #[test]
+    fn test_ws_url_construction() {
+        let ws = make_ws();
+        let url = ws.ws_url();
+        assert!(url.starts_with("wss://"));
+        assert!(url.contains("hub.example.com"));
+        assert!(url.contains("/api/v1/channels/connect"));
+        assert!(url.contains("token=sk-test"));
+    }
+
+    #[test]
+    fn test_ws_url_with_http() {
+        let config = OpenilinkConfig {
+            api_key: "sk-test".to_string(),
+            hub_url: "http://hub.example.com".to_string(),
+            ..OpenilinkConfig::default()
+        };
+        let ws = OpenilinkWebSocket::new(&config);
+        let url = ws.ws_url();
+        assert!(url.starts_with("wss://"));
+    }
+
+    #[test]
+    fn test_ws_url_without_protocol() {
+        let config = OpenilinkConfig {
+            api_key: "sk-test".to_string(),
+            hub_url: "hub.example.com".to_string(),
+            ..OpenilinkConfig::default()
+        };
+        let ws = OpenilinkWebSocket::new(&config);
+        let url = ws.ws_url();
+        assert!(url.starts_with("wss://hub.example.com"));
+    }
+
+    #[test]
+    fn test_extract_text_simple() {
+        let ws = make_ws();
+        let msg = WeixinMessage {
+            message_type: 1,
+            from_user_id: "wxid_abc".to_string(),
+            from_user_name: None,
+            item_list: vec![super::super::types::MessageItem {
+                item_type: 1,
+                text: Some(super::super::types::TextItem {
+                    text: "Hello, World!".to_string(),
+                }),
+                image: None,
+                extra: None,
+            }],
+            context_token: None,
+            timestamp: None,
+        };
+        assert_eq!(ws.extract_text(&msg), "Hello, World!");
+    }
+
+    #[test]
+    fn test_extract_text_mixed() {
+        let ws = make_ws();
+        let msg = WeixinMessage {
+            message_type: 1,
+            from_user_id: "wxid_abc".to_string(),
+            from_user_name: None,
+            item_list: vec![
+                super::super::types::MessageItem {
+                    item_type: 1,
+                    text: Some(super::super::types::TextItem {
+                        text: "看这张图片".to_string(),
+                    }),
+                    image: None,
+                    extra: None,
+                },
+                super::super::types::MessageItem {
+                    item_type: 3,
+                    text: None,
+                    image: Some(super::super::types::ImageItem {
+                        url: Some("https://example.com/img.jpg".to_string()),
+                        path: None,
+                        width: None,
+                        height: None,
+                    }),
+                    extra: None,
+                },
+            ],
+            context_token: None,
+            timestamp: None,
+        };
+        assert_eq!(ws.extract_text(&msg), "看这张图片 [图片]");
+    }
+
+    #[test]
+    fn test_extract_text_empty() {
+        let ws = make_ws();
+        let msg = WeixinMessage {
+            message_type: 1,
+            from_user_id: "wxid_abc".to_string(),
+            from_user_name: None,
+            item_list: vec![],
+            context_token: None,
+            timestamp: None,
+        };
+        assert_eq!(ws.extract_text(&msg), "");
+    }
+
+    #[test]
+    fn test_handle_message_filter_bot() {
+        // Test that message_type == 2 is filtered: we should get Ok(()) and
+        // the callback should NOT be called.
+        // We'll test by checking the handler doesn't call the callback.
+        let ws = make_ws();
+        let json = r#"{
+            "message_type": 2,
+            "from_user_id": "wxid_bot",
+            "item_list": [
+                {"type": 1, "text": {"text": "bot message"}}
+            ],
+            "context_token": null
+        }"#;
+
+        let callback_called = std::sync::atomic::AtomicBool::new(false);
+        let callback = |_: InboundMessage| {
+            callback_called.store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(())
+        };
+
+        let result = ws.handle_message("test_channel", json, &callback);
+        assert!(result.is_ok());
+        assert!(!callback_called.load(std::sync::atomic::Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_reconnection_count() {
+        let mut config = OpenilinkConfig::default();
+        config.websocket.max_reconnect_attempts = 3;
+        let mut ws = OpenilinkWebSocket::new(&config);
+        assert_eq!(ws.reconnect_count, 0);
+
+        ws.reconnect_count = 2;
+        ws.reset_reconnection_count();
+        assert_eq!(ws.reconnect_count, 0);
+    }
+}

--- a/crates/jyc-channels/src/openilink/websocket.rs
+++ b/crates/jyc-channels/src/openilink/websocket.rs
@@ -1,0 +1,2 @@
+//! WebSocket handler for OpeniLink channel.
+//! Will be implemented in Step 9.

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -16,6 +16,8 @@ use jyc_channels::feishu::inbound::{FeishuInboundAdapter, FeishuMatcher};
 use jyc_channels::feishu::outbound::FeishuOutboundAdapter;
 use jyc_channels::github::inbound::GithubMatcher;
 use jyc_channels::github::outbound::GithubOutboundAdapter;
+use jyc_channels::openilink::inbound::{OpenilinkInboundAdapter, OpenilinkMatcher};
+use jyc_channels::openilink::outbound::OpenilinkOutboundAdapter;
 use jyc_types::OutboundAdapter;
 use jyc_types::MonitorConfig;
 use jyc_types::{load_config, validation};
@@ -149,6 +151,19 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     storage.clone(),
                     footer_enabled,
                 )?)
+            }
+            "openilink" => {
+                let openilink_config = channel_config
+                    .openilink
+                    .as_ref()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("channel '{channel_name}': missing openilink config")
+                    })?
+                    .clone();
+                Arc::new(OpenilinkOutboundAdapter::new(
+                    openilink_config,
+                    footer_enabled,
+                ))
             }
             other => {
                 tracing::warn!(
@@ -450,6 +465,54 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                         tracing::error!(
                             error = %e,
                             "GitHub inbound adapter error"
+                        );
+                    }
+
+                    // Shutdown thread manager for this channel
+                    tm.shutdown().await;
+                }.instrument(channel_span));
+
+                tasks.push(task);
+            }
+            "openilink" => {
+                let openilink_config = channel_config
+                    .openilink
+                    .as_ref()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("channel '{channel_name}': missing openilink config")
+                    })?
+                    .clone();
+
+                let patterns_for_callback = patterns.clone();
+                let router_for_callback = router.clone();
+
+                let task = tokio::spawn(async move {
+                    let adapter = OpenilinkInboundAdapter::new(&openilink_config, channel_name_owned.clone());
+
+                    use jyc_types::InboundAdapter;
+
+                    let options = jyc_types::InboundAdapterOptions {
+                        on_message: Box::new(move |message| {
+                            let router = router_for_callback.clone();
+                            let patterns = patterns_for_callback.clone();
+
+                            tokio::spawn(async move {
+                                router.route(&OpenilinkMatcher, message, &patterns).await;
+                            });
+
+                            Ok(())
+                        }),
+                        on_thread_close: None,
+                        on_error: Box::new(|error| {
+                            tracing::error!(error = %error, "OpeniLink inbound error");
+                        }),
+                        attachment_config: inbound_attachment_config.clone(),
+                    };
+
+                    if let Err(e) = adapter.start(options, cancel_child).await {
+                        tracing::error!(
+                            error = %e,
+                            "OpeniLink inbound adapter error"
                         );
                     }
 

--- a/crates/jyc-types/src/config.rs
+++ b/crates/jyc-types/src/config.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use crate::channel::ChannelPattern;
 use crate::feishu_config::FeishuConfig;
 use crate::github_config::GithubConfig;
+use crate::openilink_config::OpenilinkConfig;
 
 /// MCP server configuration for agent dynamic tool loading.
 ///
@@ -112,6 +113,9 @@ pub struct ChannelConfig {
 
     /// GitHub configuration (for github channels)
     pub github: Option<GithubConfig>,
+
+    /// OpeniLink configuration (for openilink/wechat channels)
+    pub openilink: Option<OpenilinkConfig>,
 
     /// Monitoring settings (IDLE vs poll, interval, etc.)
     pub monitor: Option<MonitorConfig>,

--- a/crates/jyc-types/src/lib.rs
+++ b/crates/jyc-types/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod inspect;
 pub mod feishu_config;
 pub mod github_config;
+pub mod openilink_config;
 pub mod validation;
 
 pub use agent::*;
@@ -11,4 +12,5 @@ pub use channel::*;
 pub use config::*;
 pub use feishu_config::*;
 pub use github_config::*;
+pub use openilink_config::*;
 pub use inspect::*;

--- a/crates/jyc-types/src/openilink_config.rs
+++ b/crates/jyc-types/src/openilink_config.rs
@@ -1,0 +1,84 @@
+use serde::{Deserialize, Serialize};
+use crate::feishu_config::WebSocketConfig;
+
+/// OpeniLink-specific configuration for a channel.
+///
+/// Connects to an OpeniLink Hub instance via WebSocket for receiving
+/// messages and HTTP API for sending replies.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct OpenilinkConfig {
+    /// API key for authenticating with the OpeniLink Hub
+    pub api_key: String,
+
+    /// Base URL of the OpeniLink Hub (e.g., "https://hub.example.com")
+    pub hub_url: String,
+
+    /// WebSocket configuration for receiving messages
+    #[serde(default)]
+    pub websocket: WebSocketConfig,
+
+    /// Max size of the context_token cache (maps sender wxid -> token)
+    /// Default: 1000
+    #[serde(default = "default_cache_size")]
+    pub context_token_cache_size: usize,
+}
+
+impl Default for OpenilinkConfig {
+    fn default() -> Self {
+        Self {
+            api_key: String::new(),
+            hub_url: String::new(),
+            websocket: WebSocketConfig::default(),
+            context_token_cache_size: default_cache_size(),
+        }
+    }
+}
+
+fn default_cache_size() -> usize {
+    1000
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = OpenilinkConfig::default();
+        assert_eq!(config.api_key, "");
+        assert_eq!(config.hub_url, "");
+        assert!(config.websocket.enabled);
+        assert_eq!(config.websocket.reconnect_delay_secs, 5);
+        assert_eq!(config.context_token_cache_size, 1000);
+    }
+
+    #[test]
+    fn test_config_deserialize() {
+        let toml_str = r#"
+            api_key = "sk-xxxxxxxx"
+            hub_url = "https://hub.example.com"
+
+            [websocket]
+            enabled = false
+            reconnect_delay_secs = 10
+        "#;
+
+        let config: OpenilinkConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.api_key, "sk-xxxxxxxx");
+        assert_eq!(config.hub_url, "https://hub.example.com");
+        assert!(!config.websocket.enabled);
+        assert_eq!(config.websocket.reconnect_delay_secs, 10);
+    }
+
+    #[test]
+    fn test_config_deserialize_with_cache_size() {
+        let toml_str = r#"
+            api_key = "sk-xxxxxxxx"
+            hub_url = "https://hub.example.com"
+            context_token_cache_size = 500
+        "#;
+
+        let config: OpenilinkConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.context_token_cache_size, 500);
+    }
+}

--- a/crates/jyc-types/src/validation.rs
+++ b/crates/jyc-types/src/validation.rs
@@ -186,6 +186,55 @@ pub fn validate_config(config: &AppConfig) -> Vec<ValidationError> {
                     message: "Feishu configuration is required for feishu channel type".into(),
                 });
             }
+        } else if channel.channel_type == "openilink" {
+            // Validate OpeniLink channel specifics
+            if let Some(ref openilink_config) = channel.openilink {
+                if openilink_config.api_key.is_empty() {
+                    errors.push(ValidationError {
+                        path: format!("{prefix}.openilink.api_key"),
+                        message: "OpeniLink api_key is required (use ${ENV_VAR} syntax)".into(),
+                    });
+                }
+                if openilink_config.hub_url.is_empty() {
+                    errors.push(ValidationError {
+                        path: format!("{prefix}.openilink.hub_url"),
+                        message: "OpeniLink hub_url is required".into(),
+                    });
+                } else if !openilink_config.hub_url.starts_with("https://") {
+                    errors.push(ValidationError {
+                        path: format!("{prefix}.openilink.hub_url"),
+                        message: "OpeniLink hub_url must start with https://".into(),
+                    });
+                }
+
+                // Validate WebSocket configuration
+                if openilink_config.websocket.enabled {
+                    if openilink_config.websocket.reconnect_delay_secs == 0 {
+                        errors.push(ValidationError {
+                            path: format!("{prefix}.openilink.websocket.reconnect_delay_secs"),
+                            message: "must be greater than 0".into(),
+                        });
+                    }
+                    if openilink_config.websocket.heartbeat_interval_secs < 10 {
+                        errors.push(ValidationError {
+                            path: format!("{prefix}.openilink.websocket.heartbeat_interval_secs"),
+                            message: "must be at least 10".into(),
+                        });
+                    }
+                }
+
+                if openilink_config.context_token_cache_size == 0 {
+                    errors.push(ValidationError {
+                        path: format!("{prefix}.openilink.context_token_cache_size"),
+                        message: "must be at least 1".into(),
+                    });
+                }
+            } else {
+                errors.push(ValidationError {
+                    path: format!("{prefix}.openilink"),
+                    message: "OpeniLink configuration is required for openilink channel type".into(),
+                });
+            }
         }
 
         // Validate patterns


### PR DESCRIPTION
## Spec

新增 OpeniLink channel，通过 OpeniLink Hub 的 WebSocket 接收微信消息、通过 HTTP API 发送回复。实现 InboundAdapter、OutboundAdapter 和 ChannelMatcher，支持基于 sender 和 keywords 的模式匹配。

Fixes #203

## Implementation Plan

### Step 1: 配置类型 (`crates/jyc-types/src/openilink_config.rs`)
**What:** 新建 `OpenilinkConfig` 结构体，包含 `api_key`、`hub_url`、`websocket` 嵌套配置。参照 `feishu_config.rs` 的模式（复用 `WebSocketConfig`）。
**Why:** JYC 的 channel 配置由独立类型定义，通过 `ChannelConfig` 的 Option 字段引用。
**Verify:** `cargo check -p jyc-types`

### Step 2: 集成到 ChannelConfig (`crates/jyc-types/src/config.rs`)
**What:** 在 `ChannelConfig` 添加 `pub openilink: Option<OpenilinkConfig>`。在 `lib.rs` 中导出 `pub mod openilink_config;`。
**Why:** 所有 channel 配置统一通过 `ChannelConfig` 反序列化。
**Verify:** `cargo check -p jyc-types`

### Step 3: 配置校验 (`crates/jyc-types/src/validation.rs`)
**What:** 在 `validate_config` 中添加 `"openilink"` 分支，校验 `api_key` 非空、`hub_url` 以 `https://` 开头。
**Why:** 启动时尽早发现配置错误，避免运行时失败。
**Verify:** `cargo test -p jyc-types`

### Step 4: 消息类型定义 (`crates/jyc-channels/src/openilink/types.rs`)
**What:** 定义 WebSocket 接收的消息结构体（基于 Node SDK 的 `WeixinMessage`），包括 `OpenilinkMessage`、`TextItem`、`ImageItem`、`MessageItem` 等。定义 HTTP 请求/响应类型 `SendMessageRequest`/`SendMessageResponse`。
**Why:** 需要将 JSON 反序列化为 Rust 类型，用于消息转换和 API 调用。
**Verify:** `cargo check -p jyc-channels`

### Step 5: 模块入口 (`crates/jyc-channels/src/openilink/mod.rs`)
**What:** 声明子模块：`pub mod types; pub mod client; pub mod inbound; pub mod outbound; pub mod websocket; pub mod formatter;`
**Why:** 模块声明是文件被编译的前提。
**Verify:** `cargo check -p jyc-channels`

### Step 6: 注册模块 (`crates/jyc-channels/src/lib.rs`)
**What:** 添加 `pub mod openilink;`
**Why:** 将 openilink 模块暴露给 `jyc-cli` 使用。
**Verify:** `cargo check -p jyc-channels`

### Step 7: HTTP 客户端 (`crates/jyc-channels/src/openilink/client.rs`)
**What:** 封装 `reqwest::Client`，提供三个方法：
- `send_message(to_user_id, content, context_token)` → `POST {hub_url}/api/v1/channels/send`
- `send_typing(to_user_id, typing_ticket, action)` → `POST {hub_url}/api/v1/channels/typing`
- `get_config()` → `GET {hub_url}/api/v1/channels/config`
每个请求统一添加 `Authorization: Bearer {api_key}` 头。
**Why:** 出站消息需要调用 Hub 的 REST API。统一封装便于管理认证和错误处理。
**Verify:** `cargo check -p jyc-channels`

### Step 8: 添加 WebSocket 依赖 (`crates/jyc-channels/Cargo.toml`)
**What:** 添加 `tokio-tungstenite = { version = "0.24", features = ["native-tls"] }` 和 `futures-util = "0.3"`。
**Why:** 入站消息通过 WebSocket 实时推送，需要 WebSocket 客户端库。
**Verify:** `cargo check -p jyc-channels`

### Step 9: WebSocket 事件循环 (`crates/jyc-channels/src/openilink/websocket.rs`)
**What:** 实现 `OpenilinkWebSocket`：
- 连接 `wss://{hub_url}/api/v1/channels/connect`（带 `Authorization` 头）
- 解析收到的 JSON 消息为 `WeixinMessage`
- 过滤掉 `message_type == 2`（Bot 自己发的消息）
- 调用 `on_message` 回调传递消息
- 支持重连（指数退避）和心跳（ping/pong）
- 监听 `CancellationToken` 实现优雅关闭
**Why:** WebSocket 是消息接收的核心通道。参照 `feishu/websocket.rs` 的模式。
**Verify:** `cargo build -p jyc-channels`

### Step 10: 入站适配器 (`crates/jyc-channels/src/openilink/inbound.rs`)
**What:** 实现 `InboundAdapter` + `ChannelMatcher`：
- `channel_type()` → `"openilink"`
- `start()` → 启动 `OpenilinkWebSocket::run()`
- `match_message()` → 基于 `sender_address`（wxid）和 `keywords` 匹配
- `derive_thread_name()` → 返回 `"wx_{from_user_id}"`，确保每个微信用户有独立 thread
- `store_unmatched_messages()` → 返回 `false`（默认不存储未匹配消息）
- 将 `WeixinMessage` 转换为 `InboundMessage`：提取 `from_user_id` 为 sender，`text_item.text` 为 content，`context_token` 存 metadata
**Why:** 这是 JYC channel 系统的核心接口，负责接收消息并路由到 AI agent。
**Verify:** `cargo check -p jyc-channels`

### Step 11: 出站适配器 (`crates/jyc-channels/src/openilink/outbound.rs`)
**What:** 实现 `OutboundAdapter`：
- `channel_type()` → `"openilink"`
- `connect()` → 调用 `client.get_config()` 验证 API Key 有效
- `send_reply()` → 从 `original.metadata` 提取 `context_token`，调用 `client.send_message()`。若 `context_token` 缺失则记录 warning 并降级为不带 token 的发送（主动推送模式）
- `clean_body()` → 对纯文本不做清理（no-op）
- `send_alert()` → 不支持，返回错误
**Why:** AI agent 通过此接口发送回复消息。参照 `feishu/outbound.rs` 模式。
**Verify:** `cargo check -p jyc-channels`

### Step 12: 消息格式化 (`crates/jyc-channels/src/openilink/formatter.rs`)
**What:** 实现 `extract_text(message)` 从 `item_list` 中提取文本内容。对图片/视频/文件消息生成描述文本（如 `"[图片]"`、`"[文件: report.pdf]"`）。
**Why:** AI agent 需要文本内容进行处理。
**Verify:** `cargo test -p jyc-channels`

### Step 13: Monitor 启动集成 (`crates/jyc-cli/src/cli/monitor.rs`)
**What:**
1. 添加 import：`use jyc_channels::openilink::inbound::OpenilinkInboundAdapter;` 和 `use jyc_channels::openilink::outbound::OpenilinkOutboundAdapter;`
2. 在出站适配器 match 中添加 `"openilink"` 分支，创建 `OpenilinkOutboundAdapter`
3. 在入站适配器 match 中添加 `"openilink"` 分支，创建 `OpenilinkInboundAdapter` 并注册 matcher
**Why:** 新 channel 类型需要在此处注册才能被 monitor 进程加载。
**Verify:** `cargo check -p jyc-cli`

### Step 14: 配置示例 (`config.example.toml`)
**What:** 在文件末尾添加 openilink channel 配置示例：
```toml
[channels.wechat]
type = "openilink"

[channels.wechat.openilink]
api_key = "${OPENILINK_API_KEY}"
hub_url = "https://hub.example.com"

[channels.wechat.openilink.websocket]
enabled = true
reconnect_delay_secs = 5
max_reconnect_attempts = 10

[[channels.wechat.patterns]]
name = "wechat_bot"
enabled = true

[channels.wechat.patterns.rules]
keywords = ["帮助", "help"]
```
**Why:** 用户需要参考配置模板来配置自己的 openilink channel。
**Verify:** 肉眼检查格式

### Step 15: 编译与 clippy 检查
**What:** 运行 `cargo build` 和 `cargo clippy --all-targets` 确保无编译错误和 lint 警告。
**Why:** 最终交付前确保代码可编译且符合代码规范。
**Verify:** `cargo build && cargo clippy --all-targets`

## Design Decisions
- **WebSocket 优先**：选择 WebSocket 而非长轮询作为入站通道，与 Feishu channel 架构一致，降低延迟
- **复用 WebSocketConfig**：与 `feishu_config.rs` 共用同一个 `WebSocketConfig` 类型，避免重复定义
- **thread_name 基于 wxid**：每个微信用户独立 thread，类似 Feishu 基于 chat_id 的策略
- **context_token 缓存**：在 InboundAdapter 中维护 `HashMap<from_user_id, context_token>`，供出站回复使用（实现主动推送）
- **无附件支持（一期）**：首版仅支持文本消息收发，图片/文件消息转为文本描述。后续迭代添加文件上传下载