### PR TITLE
feat: 通过 OpenILink Bridge 新增微信 (WeChat) channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1531,6 +1531,7 @@ dependencies = [
  "base64",
  "chrono",
  "comrak",
+ "futures-util",
  "jyc-core",
  "jyc-mcp",
  "jyc-services",
@@ -1545,6 +1546,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "tokio-util",
  "toml",
  "tracing",
@@ -2102,7 +2104,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.23.1",
  "tracing",
  "url",
  "uuid",
@@ -3742,7 +3744,19 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.23.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.24.0",
 ]
 
 [[package]]
@@ -3941,6 +3955,24 @@ dependencies = [
  "rand 0.8.5",
  "rustls",
  "rustls-pki-types",
+ "sha1",
+ "thiserror 1.0.69",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3251,6 +3251,115 @@ skills of the same name.
 2. Add the skill mapping to `deploy-templates.sh` (`get_skills` function)
 3. Run `./deploy-templates.sh <target>` to deploy
 
+## WeChat Channel Implementation
+
+The WeChat (微信) channel implementation provides messaging capabilities through the OpenILink WebSocket Bridge. Unlike Feishu which uses separate WebSocket (inbound) and HTTP API (outbound) paths, WeChat uses a **single shared WebSocket connection** for both receiving and sending messages. One bot corresponds to one fixed thread.
+
+### Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                   OpenILink Bridge (Server)                  │
+│                                                             │
+│  ┌──────────────────────────────────────────────────────┐  │
+│  │          WebSocket (wss://host/bot/v1/ws)            │  │
+│  │  ┌─────────────┐     ┌──────────────┐               │  │
+│  │  │   Inbound   │     │   Outbound  │               │  │
+│  │  │   Messages  │     │   Messages  │               │  │
+│  │  │  (Receive)  │     │   (Send)    │               │  │
+│  │  └──────┬──────┘     └──────▲───────┘               │  │
+│  └─────────┼──────────────────┼──────────────────────────┘  │
+└────────────┼──────────────────┼─────────────────────────────┘
+             │                  │
+             │         mpsc::UnboundedSender<String>
+             │                  │
+             │                  ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    JYC WeChat Channel                        │
+│                                                             │
+│  ┌─────────────────────────────────────────────────────┐  │
+│  │             WechatWebSocket                          │  │
+│  │  • Single WebSocket for both send and receive       │  │
+│  │  • tokio-tungstenite connection management          │  │
+│  │  • JSON parsing: extract 'content' field            │  │
+│  │  • Auto-reconnect with exponential backoff          │  │
+│  │  • CancellationToken support                        │  │
+│  │  • Exposes mpsc::UnboundedSender for outbound       │  │
+│  └────────────────────────┬────────────────────────────┘  │
+│                           │                                │
+│            ┌──────────────┴──────────────┐                │
+│            ▼                             ▼                │
+│  ┌──────────────────┐    ┌─────────────────────────┐     │
+│  │WechatInboundAdapter│   │ WechatOutboundAdapter  │     │
+│  │ • WechatMatcher    │   │ • JSON format sending  │     │
+│  │ • Pattern matching │   │ • Footer concatenation │     │
+│  │ • Thread name =    │   │ • Reply storage        │     │
+│  │   channel name     │   │ • v1: text-only        │     │
+│  └──────────────────┘    └─────────────────────────┘     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Key Features Implemented
+
+1. **Single WebSocket Connection for Inbound + Outbound**
+   - `WechatWebSocket` manages a single `tokio-tungstenite` connection
+   - Incoming messages parsed as JSON, `content` field extracted to `InboundMessage`
+   - Outbound messages sent via shared `mpsc::UnboundedSender<String>` in `{"type":"send","content":"..."}` format
+   - Both read and write handled in a single tokio::select! event loop
+
+2. **Auto-Reconnection with Exponential Backoff**
+   - Reconnect delay: `2^attempt` seconds (capped at 60s)
+   - Configurable max reconnect attempts
+   - `CancellationToken` for graceful shutdown
+
+3. **One Bot = One Fixed Thread**
+   - `derive_thread_name()` returns the channel name directly (e.g., `"wechat_bot"`)
+   - Unlike Feishu which supports multiple chats, WeChat v1 uses a single-thread model
+   - Simplifies implementation and matches typical WeChat bot usage patterns
+
+4. **Pattern Matching**
+   - `keywords`: match by message content (case-insensitive, OR logic)
+   - `sender`: match by sender address (exact or regex)
+   - Empty rules match all messages (AND logic across present rules)
+
+### Architecture Differences from Feishu
+
+| Aspect | Feishu | WeChat |
+|--------|--------|--------|
+| Inbound transport | LarkWsClient (SDK) WebSocket | Raw tokio-tungstenite WebSocket |
+| Outbound transport | REST API (HTTP) | Same WebSocket as inbound |
+| Thread model | One thread per chat | One fixed thread per bot |
+| Message format | Rich (text, image, file, card) | v1: text-only |
+| Name resolution | API-based with caching | Not needed (fixed thread) |
+| SDK dependency | openlark SDK | None (direct WS protocol) |
+
+### Message Formats
+
+**Incoming** (from OpenILink Bridge):
+```json
+{
+  "id": "msg_001",
+  "type": "text",
+  "content": "用户消息内容",
+  "sender": "wx_user_123",
+  "sender_name": "用户名称",
+  "timestamp": 1234567890
+}
+```
+
+**Outgoing** (sent by JYC):
+```json
+{
+  "type": "send",
+  "content": "AI回复内容"
+}
+```
+
+### Limitations (v1)
+- Text-only messages — no image, file, or rich media support
+- Single thread per bot — no multi-chat routing
+- JSON format is OpenILink-specific — no protocol abstraction layer
+
 ## References
 
 - [SYSTEMD.md](SYSTEMD.md) - systemd service management for process supervision and self-bootstrapping

--- a/config.example.toml
+++ b/config.example.toml
@@ -352,3 +352,44 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # github_type = ["pull_request"]
 # labels = ["ready-for-review"]
 # assignees = ["alice"]
+#
+# # --- Channel: my_wechat_bot ---
+# # WeChat channel via OpenILink WebSocket Bridge
+# # Both inbound and outbound share the same WebSocket connection.
+# # One bot = one fixed thread (thread name = channel name).
+# # v1 supports text-only messages.
+#
+# [channels.my_wechat_bot]
+# type = "wechat"
+#
+# [channels.my_wechat_bot.wechat]
+# base_url = "openilink.example.com"
+# token = "${WECHAT_BOT_TOKEN}"
+#
+# [channels.my_wechat_bot.wechat.websocket]
+# enabled = true
+# reconnect_delay_secs = 5
+# max_reconnect_attempts = 10
+#
+# # Pattern: match all messages (empty rules = catch-all)
+# [[channels.my_wechat_bot.patterns]]
+# name = "catch_all"
+# enabled = true
+#
+# [channels.my_wechat_bot.patterns.rules]
+#
+# # Pattern: match messages from specific sender
+# # [[channels.my_wechat_bot.patterns]]
+# # name = "vip_user"
+# # enabled = true
+# #
+# # [channels.my_wechat_bot.patterns.rules.sender]
+# # exact = ["wx_vip_user_123"]
+#
+# # Pattern: match messages containing keywords
+# # [[channels.my_wechat_bot.patterns]]
+# # name = "support"
+# # enabled = true
+# #
+# # [channels.my_wechat_bot.patterns.rules]
+# # keywords = ["help", "support", "问题"]

--- a/crates/jyc-channels/Cargo.toml
+++ b/crates/jyc-channels/Cargo.toml
@@ -26,6 +26,8 @@ comrak = "0.37"
 regex = "1"
 base64 = "0.22"
 uuid = { version = "1", features = ["v4"] }
+tokio-tungstenite = "0.24"
+futures-util = "0.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/jyc-channels/src/lib.rs
+++ b/crates/jyc-channels/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod email;
 pub mod feishu;
 pub mod github;
+pub mod wechat;
 pub mod registry;

--- a/crates/jyc-channels/src/wechat/inbound.rs
+++ b/crates/jyc-channels/src/wechat/inbound.rs
@@ -158,8 +158,10 @@ pub struct WechatInboundAdapter {
     config: WechatConfig,
     /// Channel name from config (e.g., "wechat_bot")
     channel_name: String,
-    /// Pre-created WebSocket (shared with outbound adapter)
-    ws: Arc<Mutex<Option<WechatWebSocket>>>,
+    /// Shared sender Arc pointing to the same storage as WechatOutboundAdapter.
+    /// On each reconnection, a new WebSocket is created and its sender is pushed
+    /// here so the outbound adapter always has a live sender.
+    shared_sender: Option<Arc<Mutex<Option<mpsc::UnboundedSender<String>>>>>,
 }
 
 impl WechatInboundAdapter {
@@ -168,25 +170,25 @@ impl WechatInboundAdapter {
         Self {
             config: config.clone(),
             channel_name,
-            ws: Arc::new(Mutex::new(None)),
+            shared_sender: None,
         }
     }
 
-    /// Create the WebSocket handler and return its sender for outbound use.
+    /// Create a new WeChat inbound adapter with a shared sender.
     ///
-    /// This allows the monitor to share the same WebSocket connection
-    /// between inbound and outbound adapters. Call this before `start()`.
-    pub async fn create_and_get_sender(&self) -> mpsc::UnboundedSender<String> {
-        let ws = WechatWebSocket::new_with_config(
-            &self.config.base_url,
-            &self.config.token,
-            self.config.websocket.max_reconnect_attempts,
-            self.config.websocket.reconnect_delay_secs,
-        );
-        let sender = ws.sender();
-        let mut guard = self.ws.lock().await;
-        *guard = Some(ws);
-        sender
+    /// The `shared_sender` must point to the same `Arc<Mutex<Option<...>>>` as
+    /// the outbound adapter's sender storage. On each reconnect, a fresh
+    /// WebSocket is created and the new sender is written into this shared slot.
+    pub fn with_shared_sender(
+        config: &WechatConfig,
+        channel_name: String,
+        shared_sender: Arc<Mutex<Option<mpsc::UnboundedSender<String>>>>,
+    ) -> Self {
+        Self {
+            config: config.clone(),
+            channel_name,
+            shared_sender: Some(shared_sender),
+        }
     }
 }
 
@@ -227,23 +229,28 @@ impl InboundAdapter for WechatInboundAdapter {
             return Ok(());
         }
 
-        // Create WebSocket handler (use pre-created if available from monitor)
-        let mut ws = {
-            let mut guard = self.ws.lock().await;
-            guard.take().unwrap_or_else(|| {
-                WechatWebSocket::new_with_config(
-                    &self.config.base_url,
-                    &self.config.token,
-                    self.config.websocket.max_reconnect_attempts,
-                    self.config.websocket.reconnect_delay_secs,
-                )
-            })
-        };
-
         let channel_name = self.channel_name.clone();
+        let mut reconnect_count = 0usize;
 
         loop {
             tracing::info!("Starting WeChat WebSocket connection...");
+
+            // Create a FRESH WebSocket on every iteration.
+            // This avoids the `outbound_rx.take()` panic on re-run and ensures
+            // the outbound sender always has a live channel pair.
+            let mut ws = WechatWebSocket::new_with_config(
+                &self.config.base_url,
+                &self.config.token,
+                self.config.websocket.max_reconnect_attempts,
+                self.config.websocket.reconnect_delay_secs,
+            );
+
+            // Push the new WebSocket's sender into the shared slot so the
+            // outbound adapter always sends through the live connection.
+            if let Some(ref shared) = self.shared_sender {
+                let mut guard = shared.lock().await;
+                *guard = Some(ws.sender());
+            }
 
             match ws.run(&channel_name, &*options.on_message, &cancel).await {
                 Ok(()) => {
@@ -258,11 +265,27 @@ impl InboundAdapter for WechatInboundAdapter {
                     }
                     tracing::error!(error = %e, "WeChat WebSocket error");
 
-                    if !ws.handle_reconnection().await {
-                        tracing::error!("Max reconnection attempts reached, stopping WeChat channel");
+                    // Exponential backoff: reconnect_delay_secs * 2^attempt, capped at 60s
+                    let max_attempts = self.config.websocket.max_reconnect_attempts;
+                    if reconnect_count >= max_attempts {
+                        tracing::error!(max_attempts, "Max reconnection attempts reached, stopping WeChat channel");
                         break;
                     }
-                    // Loop continues → reconnect
+
+                    let delay_secs = std::cmp::min(
+                        self.config.websocket.reconnect_delay_secs << reconnect_count,
+                        60,
+                    );
+                    reconnect_count += 1;
+                    tracing::info!(
+                        attempt = reconnect_count,
+                        max_attempts,
+                        delay_secs,
+                        "Reconnecting to WeChat WebSocket"
+                    );
+
+                    tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+                    // Loop creates a fresh WS next iteration
                 }
             }
         }

--- a/crates/jyc-channels/src/wechat/inbound.rs
+++ b/crates/jyc-channels/src/wechat/inbound.rs
@@ -10,6 +10,8 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{mpsc, Mutex};
 use tokio_util::sync::CancellationToken;
 
 use jyc_types::{
@@ -156,6 +158,8 @@ pub struct WechatInboundAdapter {
     config: WechatConfig,
     /// Channel name from config (e.g., "wechat_bot")
     channel_name: String,
+    /// Pre-created WebSocket (shared with outbound adapter)
+    ws: Arc<Mutex<Option<WechatWebSocket>>>,
 }
 
 impl WechatInboundAdapter {
@@ -164,7 +168,24 @@ impl WechatInboundAdapter {
         Self {
             config: config.clone(),
             channel_name,
+            ws: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// Create the WebSocket handler and return its sender for outbound use.
+    ///
+    /// This allows the monitor to share the same WebSocket connection
+    /// between inbound and outbound adapters. Call this before `start()`.
+    pub async fn create_and_get_sender(&self) -> mpsc::UnboundedSender<String> {
+        let ws = WechatWebSocket::new_with_config(
+            &self.config.base_url,
+            &self.config.token,
+            self.config.websocket.max_reconnect_attempts,
+        );
+        let sender = ws.sender();
+        let mut guard = self.ws.lock().await;
+        *guard = Some(ws);
+        sender
     }
 }
 
@@ -205,12 +226,17 @@ impl InboundAdapter for WechatInboundAdapter {
             return Ok(());
         }
 
-        // Create WebSocket handler
-        let mut ws = WechatWebSocket::new_with_config(
-            &self.config.base_url,
-            &self.config.token,
-            self.config.websocket.max_reconnect_attempts,
-        );
+        // Create WebSocket handler (use pre-created if available from monitor)
+        let mut ws = {
+            let mut guard = self.ws.lock().await;
+            guard.take().unwrap_or_else(|| {
+                WechatWebSocket::new_with_config(
+                    &self.config.base_url,
+                    &self.config.token,
+                    self.config.websocket.max_reconnect_attempts,
+                )
+            })
+        };
 
         let channel_name = self.channel_name.clone();
 

--- a/crates/jyc-channels/src/wechat/inbound.rs
+++ b/crates/jyc-channels/src/wechat/inbound.rs
@@ -6,3 +6,433 @@
 //! Unlike Feishu which supports multiple chats/threads, WeChat in this implementation
 //! uses one bot = one fixed thread. The thread name is derived directly from the channel
 //! configuration name (e.g., "wechat_bot").
+
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use tokio_util::sync::CancellationToken;
+
+use jyc_types::{
+    ChannelMatcher, ChannelPattern, InboundAdapter, InboundAdapterOptions, InboundMessage,
+    PatternMatch,
+};
+
+use super::websocket::WechatWebSocket;
+use jyc_types::WechatConfig;
+
+/// WeChat channel matcher — stateless pattern matching.
+///
+/// Supports:
+/// - `keywords`: match messages containing specific words (case-insensitive)
+/// - `sender`: match sender by exact address (shared with email/feishu)
+///
+/// All present rules use AND logic. Empty rules match all messages.
+/// One bot = one fixed thread: thread name is the channel name.
+pub struct WechatMatcher;
+
+impl ChannelMatcher for WechatMatcher {
+    fn channel_type(&self) -> &str {
+        "wechat"
+    }
+
+    fn derive_thread_name(
+        &self,
+        _message: &InboundMessage,
+        _patterns: &[ChannelPattern],
+        _pattern_match: Option<&PatternMatch>,
+    ) -> String {
+        // WeChat uses one bot = one fixed thread.
+        // The thread name is derived from the channel name by the inbound adapter.
+        // This method is called by the router as a fallback when no channel-level
+        // override is available.
+        "wechat".to_string()
+    }
+
+    fn match_message(
+        &self,
+        message: &InboundMessage,
+        patterns: &[ChannelPattern],
+    ) -> Option<PatternMatch> {
+        wechat_match_message(message, patterns)
+    }
+}
+
+/// Match a message against WeChat-specific patterns.
+///
+/// Rules within a pattern use AND logic — all present rules must match.
+/// Within each rule, sub-values use OR logic.
+/// Returns the first matching pattern.
+pub fn wechat_match_message(
+    message: &InboundMessage,
+    patterns: &[ChannelPattern],
+) -> Option<PatternMatch> {
+    for pattern in patterns {
+        if !pattern.enabled {
+            continue;
+        }
+
+        let mut matches = true;
+        let mut match_details = HashMap::new();
+
+        // --- Keywords rule ---
+        // Check if the message body contains any of the configured keywords
+        if let Some(ref keywords) = pattern.rules.keywords {
+            let body = message
+                .content
+                .text
+                .as_deref()
+                .unwrap_or("")
+                .to_lowercase();
+
+            let keyword_matches = keywords
+                .iter()
+                .any(|kw| body.contains(&kw.to_lowercase()));
+
+            if !keyword_matches {
+                matches = false;
+            } else {
+                let matched_kw: Vec<&str> = keywords
+                    .iter()
+                    .filter(|kw| body.contains(&kw.to_lowercase()))
+                    .map(|s| s.as_str())
+                    .collect();
+                match_details.insert(
+                    "keywords".to_string(),
+                    matched_kw.join(","),
+                );
+            }
+        }
+
+        // --- Sender rule (shared) ---
+        if matches {
+            if let Some(ref sender_rule) = pattern.rules.sender {
+                let addr = message.sender_address.to_lowercase();
+
+                let sender_matches = {
+                    let mut any_rule_present = false;
+                    let mut any_rule_matched = false;
+
+                    if let Some(ref exact_addrs) = sender_rule.exact {
+                        any_rule_present = true;
+                        if exact_addrs.iter().any(|e| e.to_lowercase() == addr) {
+                            any_rule_matched = true;
+                            match_details.insert("sender.exact".to_string(), addr.clone());
+                        }
+                    }
+
+                    if let Some(ref regex_str) = sender_rule.regex {
+                        any_rule_present = true;
+                        if let Ok(re) = regex::Regex::new(regex_str) {
+                            if re.is_match(&addr) {
+                                any_rule_matched = true;
+                                match_details.insert("sender.regex".to_string(), addr.clone());
+                            }
+                        }
+                    }
+
+                    !any_rule_present || any_rule_matched
+                };
+
+                if !sender_matches {
+                    matches = false;
+                }
+            }
+        }
+
+        if matches {
+            return Some(PatternMatch {
+                pattern_name: pattern.name.clone(),
+                channel: "wechat".to_string(),
+                matches: match_details,
+            });
+        }
+    }
+
+    None
+}
+
+/// WeChat inbound adapter for receiving messages via WebSocket.
+pub struct WechatInboundAdapter {
+    config: WechatConfig,
+    /// Channel name from config (e.g., "wechat_bot")
+    channel_name: String,
+}
+
+impl WechatInboundAdapter {
+    /// Create a new WeChat inbound adapter.
+    pub fn new(config: &WechatConfig, channel_name: String) -> Self {
+        Self {
+            config: config.clone(),
+            channel_name,
+        }
+    }
+}
+
+impl ChannelMatcher for WechatInboundAdapter {
+    fn channel_type(&self) -> &str {
+        "wechat"
+    }
+
+    fn derive_thread_name(
+        &self,
+        _message: &InboundMessage,
+        _patterns: &[ChannelPattern],
+        _pattern_match: Option<&PatternMatch>,
+    ) -> String {
+        // WeChat uses the channel name as the fixed thread name
+        self.channel_name.clone()
+    }
+
+    fn match_message(
+        &self,
+        message: &InboundMessage,
+        patterns: &[ChannelPattern],
+    ) -> Option<PatternMatch> {
+        wechat_match_message(message, patterns)
+    }
+}
+
+#[async_trait]
+impl InboundAdapter for WechatInboundAdapter {
+    async fn start(
+        &self,
+        options: InboundAdapterOptions,
+        cancel: CancellationToken,
+    ) -> Result<()> {
+        if !self.config.websocket.enabled {
+            tracing::info!("WeChat WebSocket disabled, holding channel alive until cancel");
+            cancel.cancelled().await;
+            return Ok(());
+        }
+
+        // Create WebSocket handler
+        let mut ws = WechatWebSocket::new_with_config(
+            &self.config.base_url,
+            &self.config.token,
+            self.config.websocket.max_reconnect_attempts,
+        );
+
+        let channel_name = self.channel_name.clone();
+
+        loop {
+            tracing::info!("Starting WeChat WebSocket connection...");
+
+            match ws.run(&channel_name, &*options.on_message, &cancel).await {
+                Ok(()) => {
+                    // Clean exit (cancelled)
+                    tracing::info!("WeChat WebSocket stopped cleanly");
+                    break;
+                }
+                Err(e) => {
+                    if cancel.is_cancelled() {
+                        tracing::info!("WeChat WebSocket shutting down (cancelled)");
+                        break;
+                    }
+                    tracing::error!(error = %e, "WeChat WebSocket error");
+
+                    if !ws.handle_reconnection().await {
+                        tracing::error!("Max reconnection attempts reached, stopping WeChat channel");
+                        break;
+                    }
+                    // Loop continues → reconnect
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jyc_types::{MessageContent, PatternRules, SenderRule};
+    use chrono::Utc;
+
+    fn make_wechat_message(
+        sender_addr: &str,
+        body: &str,
+    ) -> InboundMessage {
+        InboundMessage {
+            id: "test".to_string(),
+            channel: "wechat".to_string(),
+            channel_uid: "msg_001".to_string(),
+            sender: "Test User".to_string(),
+            sender_address: sender_addr.to_string(),
+            recipients: vec![],
+            topic: "".to_string(),
+            content: MessageContent {
+                text: Some(body.to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata: HashMap::new(),
+            matched_pattern: None,
+        }
+    }
+
+    fn make_wechat_pattern(
+        name: &str,
+        keywords: Option<Vec<String>>,
+        sender: Option<SenderRule>,
+    ) -> ChannelPattern {
+        ChannelPattern {
+            name: name.to_string(),
+            channel: "wechat".to_string(),
+            enabled: true,
+            rules: PatternRules {
+                sender,
+                keywords,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_match_by_keywords() {
+        let msg = make_wechat_message("user1", "I need 帮助 with this");
+        let patterns = vec![make_wechat_pattern(
+            "help_pattern",
+            Some(vec!["帮助".to_string(), "help".to_string()]),
+            None,
+        )];
+
+        let result = wechat_match_message(&msg, &patterns);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().pattern_name, "help_pattern");
+    }
+
+    #[test]
+    fn test_match_keywords_case_insensitive() {
+        let msg = make_wechat_message("user1", "I need HELP");
+        let patterns = vec![make_wechat_pattern(
+            "help_pattern",
+            Some(vec!["help".to_string()]),
+            None,
+        )];
+
+        assert!(wechat_match_message(&msg, &patterns).is_some());
+    }
+
+    #[test]
+    fn test_no_match_wrong_keywords() {
+        let msg = make_wechat_message("user1", "Just chatting");
+        let patterns = vec![make_wechat_pattern(
+            "help_pattern",
+            Some(vec!["帮助".to_string(), "help".to_string()]),
+            None,
+        )];
+
+        assert!(wechat_match_message(&msg, &patterns).is_none());
+    }
+
+    #[test]
+    fn test_empty_rules_matches_all() {
+        let msg = make_wechat_message("user1", "Hello");
+        let patterns = vec![make_wechat_pattern("catch_all", None, None)];
+
+        assert!(wechat_match_message(&msg, &patterns).is_some());
+    }
+
+    #[test]
+    fn test_match_by_sender() {
+        let msg = make_wechat_message("wx_abc123", "Hello");
+        let patterns = vec![make_wechat_pattern(
+            "vip_user",
+            None,
+            Some(SenderRule {
+                exact: Some(vec!["wx_abc123".to_string()]),
+                ..Default::default()
+            }),
+        )];
+
+        assert!(wechat_match_message(&msg, &patterns).is_some());
+    }
+
+    #[test]
+    fn test_no_match_wrong_sender() {
+        let msg = make_wechat_message("wx_other", "Hello");
+        let patterns = vec![make_wechat_pattern(
+            "vip_user",
+            None,
+            Some(SenderRule {
+                exact: Some(vec!["wx_abc123".to_string()]),
+                ..Default::default()
+            }),
+        )];
+
+        assert!(wechat_match_message(&msg, &patterns).is_none());
+    }
+
+    #[test]
+    fn test_match_keywords_and_sender_and_logic() {
+        let msg = make_wechat_message("wx_abc123", "Help me please");
+        let patterns = vec![make_wechat_pattern(
+            "both",
+            Some(vec!["help".to_string()]),
+            Some(SenderRule {
+                exact: Some(vec!["wx_abc123".to_string()]),
+                ..Default::default()
+            }),
+        )];
+
+        assert!(wechat_match_message(&msg, &patterns).is_some());
+
+        // Keywords match but sender doesn't → no match
+        let msg2 = make_wechat_message("wx_other", "Help me please");
+        assert!(wechat_match_message(&msg2, &patterns).is_none());
+
+        // Sender matches but keywords don't → no match
+        let msg3 = make_wechat_message("wx_abc123", "Random text");
+        assert!(wechat_match_message(&msg3, &patterns).is_none());
+    }
+
+    #[test]
+    fn test_disabled_pattern_skipped() {
+        let msg = make_wechat_message("user1", "Hello");
+        let mut pattern = make_wechat_pattern(
+            "catch_all",
+            None,
+            None,
+        );
+        pattern.enabled = false;
+
+        assert!(wechat_match_message(&msg, &[pattern]).is_none());
+    }
+
+    #[test]
+    fn test_first_pattern_wins() {
+        let msg = make_wechat_message("user1", "help me");
+        let patterns = vec![
+            make_wechat_pattern("first", None, None),
+            make_wechat_pattern("second", Some(vec!["help".to_string()]), None),
+        ];
+
+        let result = wechat_match_message(&msg, &patterns).unwrap();
+        assert_eq!(result.pattern_name, "first");
+    }
+
+    #[test]
+    fn test_derive_thread_name() {
+        let matcher = WechatMatcher;
+        let msg = make_wechat_message("user1", "Hello");
+        let name = matcher.derive_thread_name(&msg, &[], None);
+        assert_eq!(name, "wechat");
+    }
+
+    #[test]
+    fn test_channel_name_derived_via_adapter() {
+        let adapter = WechatInboundAdapter::new(
+            &WechatConfig::default(),
+            "my_wechat_bot".to_string(),
+        );
+        let msg = make_wechat_message("user1", "Hello");
+        let name = adapter.derive_thread_name(&msg, &[], None);
+        assert_eq!(name, "my_wechat_bot");
+    }
+}

--- a/crates/jyc-channels/src/wechat/inbound.rs
+++ b/crates/jyc-channels/src/wechat/inbound.rs
@@ -1,0 +1,8 @@
+//! WeChat inbound adapter and matcher implementation.
+//!
+//! This module handles receiving messages from WeChat via the OpenILink WebSocket Bridge
+//! and provides channel-specific pattern matching and thread name derivation.
+//!
+//! Unlike Feishu which supports multiple chats/threads, WeChat in this implementation
+//! uses one bot = one fixed thread. The thread name is derived directly from the channel
+//! configuration name (e.g., "wechat_bot").

--- a/crates/jyc-channels/src/wechat/inbound.rs
+++ b/crates/jyc-channels/src/wechat/inbound.rs
@@ -181,6 +181,7 @@ impl WechatInboundAdapter {
             &self.config.base_url,
             &self.config.token,
             self.config.websocket.max_reconnect_attempts,
+            self.config.websocket.reconnect_delay_secs,
         );
         let sender = ws.sender();
         let mut guard = self.ws.lock().await;
@@ -234,6 +235,7 @@ impl InboundAdapter for WechatInboundAdapter {
                     &self.config.base_url,
                     &self.config.token,
                     self.config.websocket.max_reconnect_attempts,
+                    self.config.websocket.reconnect_delay_secs,
                 )
             })
         };

--- a/crates/jyc-channels/src/wechat/mod.rs
+++ b/crates/jyc-channels/src/wechat/mod.rs
@@ -1,0 +1,14 @@
+//! WeChat channel implementation for JYC.
+//!
+//! This module provides inbound and outbound adapters for the WeChat messaging platform
+//! via the OpenILink WebSocket Bridge. Both inbound and outbound messages share the
+//! same WebSocket connection. One bot corresponds to one fixed thread.
+//!
+//! Architecture differs from Feishu:
+//! - Inbound + outbound share ONE WebSocket connection (vs Feishu's WS inbound + HTTP outbound)
+//! - One bot = one fixed thread (vs Feishu's multi-chat architecture)
+//! - Pure text messages only in v1 (rich media can be added later)
+
+pub mod inbound;
+pub mod outbound;
+pub mod websocket;

--- a/crates/jyc-channels/src/wechat/outbound.rs
+++ b/crates/jyc-channels/src/wechat/outbound.rs
@@ -226,3 +226,83 @@ impl OutboundAdapter for WechatOutboundAdapter {
         Ok(SendResult { message_id })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_send_reply_json_format() {
+        let json_msg = serde_json::json!({
+            "type": "send",
+            "content": "Hello, world!",
+        })
+        .to_string();
+
+        let parsed: serde_json::Value = serde_json::from_str(&json_msg).unwrap();
+        assert_eq!(parsed["type"], "send");
+        assert_eq!(parsed["content"], "Hello, world!");
+    }
+
+    #[test]
+    fn test_send_alert_json_format() {
+        let alert_text = "Alert: System down\n\nPlease check the server.";
+        let json_msg = serde_json::json!({
+            "type": "send",
+            "content": alert_text,
+        })
+        .to_string();
+
+        let parsed: serde_json::Value = serde_json::from_str(&json_msg).unwrap();
+        assert_eq!(parsed["type"], "send");
+        assert_eq!(parsed["content"], alert_text);
+    }
+
+    #[test]
+    fn test_outbound_adapter_creation() {
+        let storage = Arc::new(MessageStorage::new(
+            &std::path::PathBuf::from("/tmp/test_wechat"),
+        ));
+        let adapter = WechatOutboundAdapter::new_with_attachments(
+            storage,
+            None,
+            true,
+        );
+        assert_eq!(adapter.channel_type(), "wechat");
+    }
+
+    #[test]
+    fn test_sender_set_and_connect() {
+        let storage = Arc::new(MessageStorage::new(
+            &std::path::PathBuf::from("/tmp/test_wechat"),
+        ));
+        let adapter = WechatOutboundAdapter::new_with_attachments(
+            storage,
+            None,
+            true,
+        );
+
+        // Initially no sender
+        let guard = adapter.sender.blocking_lock();
+        assert!(guard.is_none());
+        drop(guard);
+
+        // Create a channel and set it
+        let (tx, _rx) = mpsc::unbounded_channel();
+        adapter.sender.blocking_lock().replace(tx);
+
+        let guard = adapter.sender.blocking_lock();
+        assert!(guard.is_some());
+    }
+
+    #[test]
+    fn test_clean_body() {
+        let storage = Arc::new(MessageStorage::new(
+            &std::path::PathBuf::from("/tmp/test_wechat"),
+        ));
+        let adapter = WechatOutboundAdapter::new(storage);
+        assert_eq!(adapter.clean_body("  hello  "), "hello");
+        assert_eq!(adapter.clean_body("hello\n\nworld"), "hello\n\nworld");
+        assert_eq!(adapter.clean_body("trimmed  "), "trimmed");
+    }
+}

--- a/crates/jyc-channels/src/wechat/outbound.rs
+++ b/crates/jyc-channels/src/wechat/outbound.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex};
 
 use jyc_core::email_parser;
 use jyc_core::message_storage::MessageStorage;
@@ -20,10 +20,12 @@ use jyc_types::OutboundAttachmentConfig;
 /// WeChat outbound adapter for sending messages via WebSocket.
 ///
 /// Uses an `mpsc::UnboundedSender<String>` to push messages into the shared
-/// WebSocket connection established by the inbound adapter.
+/// WebSocket connection established by the inbound adapter. The sender is
+/// stored behind `Arc<Mutex<Option<...>>>` so it can be set after construction
+/// (the outbound adapter is created before the WebSocket is initialized).
 pub struct WechatOutboundAdapter {
     /// Sender to push outbound messages through the WebSocket
-    sender: Option<mpsc::UnboundedSender<String>>,
+    sender: Arc<Mutex<Option<mpsc::UnboundedSender<String>>>>,
     /// Message storage for logging replies
     storage: Arc<MessageStorage>,
     /// Attachment configuration
@@ -40,7 +42,7 @@ impl WechatOutboundAdapter {
     /// WebSocket connection. Use `set_sender()` to set it before sending.
     pub fn new(storage: Arc<MessageStorage>) -> Self {
         Self {
-            sender: None,
+            sender: Arc::new(Mutex::new(None)),
             storage,
             attachment_config: None,
             footer_enabled: true,
@@ -54,24 +56,31 @@ impl WechatOutboundAdapter {
         footer_enabled: bool,
     ) -> Self {
         Self {
-            sender: None,
+            sender: Arc::new(Mutex::new(None)),
             storage,
             attachment_config,
             footer_enabled,
         }
     }
 
+    /// Get the shared sender Arc so the monitor can set it after WebSocket creation.
+    pub fn sender_arc(&self) -> Arc<Mutex<Option<mpsc::UnboundedSender<String>>>> {
+        self.sender.clone()
+    }
+
     /// Set the WebSocket sender after the WebSocket connection is established.
     ///
     /// This is called by the monitor after creating the `WechatWebSocket` instance,
     /// allowing the inbound and outbound adapters to share the same connection.
-    pub fn set_sender(&mut self, sender: mpsc::UnboundedSender<String>) {
-        self.sender = Some(sender);
+    pub async fn set_sender(&self, sender: mpsc::UnboundedSender<String>) {
+        let mut guard = self.sender.lock().await;
+        *guard = Some(sender);
     }
 
     /// Send a JSON-formatted message through the WebSocket.
-    fn send_internal(&self, json_msg: &str) -> Result<()> {
-        match &self.sender {
+    async fn send_internal(&self, json_msg: &str) -> Result<()> {
+        let guard = self.sender.lock().await;
+        match guard.as_ref() {
             Some(sender) => sender
                 .send(json_msg.to_string())
                 .map_err(|e| anyhow::anyhow!("Failed to send WeChat outbound message: {}", e)),
@@ -91,7 +100,8 @@ impl OutboundAdapter for WechatOutboundAdapter {
     async fn connect(&self) -> Result<()> {
         // WebSocket connection is managed by the inbound adapter.
         // The sender must be set via `set_sender()` before sending.
-        if self.sender.is_some() {
+        let guard = self.sender.lock().await;
+        if guard.is_some() {
             tracing::info!("WeChat outbound adapter connected (sender available)");
         } else {
             tracing::warn!("WeChat outbound adapter: no sender set yet (WebSocket may not be connected)");
@@ -159,7 +169,7 @@ impl OutboundAdapter for WechatOutboundAdapter {
 
         let message_id = uuid::Uuid::new_v4().to_string();
 
-        self.send_internal(&json_msg)
+        self.send_internal(&json_msg).await
             .context("Failed to send WeChat reply through WebSocket")?;
 
         tracing::info!(
@@ -208,7 +218,7 @@ impl OutboundAdapter for WechatOutboundAdapter {
         })
         .to_string();
 
-        self.send_internal(&json_msg)
+        self.send_internal(&json_msg).await
             .context("Failed to send WeChat alert through WebSocket")?;
 
         tracing::info!("WeChat alert sent to {}: {}", recipient, subject);

--- a/crates/jyc-channels/src/wechat/outbound.rs
+++ b/crates/jyc-channels/src/wechat/outbound.rs
@@ -1,0 +1,6 @@
+//! WeChat outbound adapter implementation.
+//!
+//! This module handles sending messages to WeChat via the OpenILink WebSocket Bridge.
+//! Unlike Feishu which uses HTTP API calls, WeChat sends messages through the same
+//! WebSocket connection used for receiving messages. The outbound adapter holds a
+//! `mpsc::UnboundedSender<String>` to push JSON-formatted messages into the WebSocket.

--- a/crates/jyc-channels/src/wechat/outbound.rs
+++ b/crates/jyc-channels/src/wechat/outbound.rs
@@ -4,3 +4,215 @@
 //! Unlike Feishu which uses HTTP API calls, WeChat sends messages through the same
 //! WebSocket connection used for receiving messages. The outbound adapter holds a
 //! `mpsc::UnboundedSender<String>` to push JSON-formatted messages into the WebSocket.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+
+use jyc_core::email_parser;
+use jyc_core::message_storage::MessageStorage;
+use jyc_types::{InboundMessage, OutboundAdapter, OutboundAttachment, SendResult};
+use jyc_types::OutboundAttachmentConfig;
+
+/// WeChat outbound adapter for sending messages via WebSocket.
+///
+/// Uses an `mpsc::UnboundedSender<String>` to push messages into the shared
+/// WebSocket connection established by the inbound adapter.
+pub struct WechatOutboundAdapter {
+    /// Sender to push outbound messages through the WebSocket
+    sender: Option<mpsc::UnboundedSender<String>>,
+    /// Message storage for logging replies
+    storage: Arc<MessageStorage>,
+    /// Attachment configuration
+    #[allow(dead_code)]
+    attachment_config: Option<OutboundAttachmentConfig>,
+    /// Whether footer is enabled
+    footer_enabled: bool,
+}
+
+impl WechatOutboundAdapter {
+    /// Create a new WeChat outbound adapter.
+    ///
+    /// The `sender` is not available until the inbound adapter creates the
+    /// WebSocket connection. Use `set_sender()` to set it before sending.
+    pub fn new(storage: Arc<MessageStorage>) -> Self {
+        Self {
+            sender: None,
+            storage,
+            attachment_config: None,
+            footer_enabled: true,
+        }
+    }
+
+    /// Create a new WeChat outbound adapter with attachment config.
+    pub fn new_with_attachments(
+        storage: Arc<MessageStorage>,
+        attachment_config: Option<OutboundAttachmentConfig>,
+        footer_enabled: bool,
+    ) -> Self {
+        Self {
+            sender: None,
+            storage,
+            attachment_config,
+            footer_enabled,
+        }
+    }
+
+    /// Set the WebSocket sender after the WebSocket connection is established.
+    ///
+    /// This is called by the monitor after creating the `WechatWebSocket` instance,
+    /// allowing the inbound and outbound adapters to share the same connection.
+    pub fn set_sender(&mut self, sender: mpsc::UnboundedSender<String>) {
+        self.sender = Some(sender);
+    }
+
+    /// Send a JSON-formatted message through the WebSocket.
+    fn send_internal(&self, json_msg: &str) -> Result<()> {
+        match &self.sender {
+            Some(sender) => sender
+                .send(json_msg.to_string())
+                .map_err(|e| anyhow::anyhow!("Failed to send WeChat outbound message: {}", e)),
+            None => Err(anyhow::anyhow!(
+                "WeChat outbound sender not set (WebSocket not initialized)"
+            )),
+        }
+    }
+}
+
+#[async_trait]
+impl OutboundAdapter for WechatOutboundAdapter {
+    fn channel_type(&self) -> &str {
+        "wechat"
+    }
+
+    async fn connect(&self) -> Result<()> {
+        // WebSocket connection is managed by the inbound adapter.
+        // The sender must be set via `set_sender()` before sending.
+        if self.sender.is_some() {
+            tracing::info!("WeChat outbound adapter connected (sender available)");
+        } else {
+            tracing::warn!("WeChat outbound adapter: no sender set yet (WebSocket may not be connected)");
+        }
+        Ok(())
+    }
+
+    async fn disconnect(&self) -> Result<()> {
+        tracing::info!("WeChat outbound adapter disconnected");
+        Ok(())
+    }
+
+    fn clean_body(&self, raw_body: &str) -> String {
+        // WeChat messages don't have quoted reply history like email.
+        // Just trim whitespace for now.
+        raw_body.trim().to_string()
+    }
+
+    async fn send_reply(
+        &self,
+        _original: &InboundMessage,
+        reply_text: &str,
+        thread_path: &Path,
+        message_dir: &str,
+        attachments: Option<&[OutboundAttachment]>,
+    ) -> Result<SendResult> {
+        // 1. Read model/mode from reply context file (if available)
+        let reply_ctx = jyc_mcp::context::load_reply_context(thread_path).await.ok();
+        let model = reply_ctx.as_ref().and_then(|c| c.model.as_deref());
+        let mode = reply_ctx.as_ref().and_then(|c| c.mode.as_deref());
+
+        // Read current input tokens from session state
+        let (input_tokens, max_tokens) =
+            jyc_core::session_state::read_input_tokens(thread_path).await;
+
+        // 2. Build footer with model/mode/tokens information
+        let footer = email_parser::build_footer(
+            model,
+            mode,
+            input_tokens,
+            max_tokens,
+            self.footer_enabled,
+        );
+
+        // 3. Clean reply text to remove any trailing `---` separators
+        let clean_reply = email_parser::strip_trailing_separators(reply_text);
+
+        // 4. Combine cleaned reply text with footer
+        let full_reply = if footer.is_empty() {
+            clean_reply
+        } else {
+            format!("{}\n\n{}", clean_reply, footer)
+        };
+
+        // 5. Skip attachment validation for v1 (text-only)
+        // Attachments will be supported in future versions.
+
+        // 6. Send the reply through WebSocket
+        // Format: {"type":"send","content":"..."}
+        let json_msg = serde_json::json!({
+            "type": "send",
+            "content": full_reply,
+        })
+        .to_string();
+
+        let message_id = uuid::Uuid::new_v4().to_string();
+
+        self.send_internal(&json_msg)
+            .context("Failed to send WeChat reply through WebSocket")?;
+
+        tracing::info!(
+            text_len = full_reply.len(),
+            message_id = %message_id,
+            "WeChat reply sent"
+        );
+
+        // 7. Handle attachments (WeChat v1: text-only, log a warning)
+        if let Some(atts) = attachments {
+            if !atts.is_empty() {
+                tracing::warn!(
+                    count = atts.len(),
+                    "WeChat v1 does not support attachments, skipping"
+                );
+            }
+        }
+
+        // 8. Store reply to chat log
+        self.storage
+            .store_reply(thread_path, &full_reply, message_dir)
+            .await?;
+
+        tracing::debug!(
+            message_dir = %message_dir,
+            "Reply stored"
+        );
+
+        Ok(SendResult { message_id })
+    }
+
+    async fn send_alert(
+        &self,
+        recipient: &str,
+        subject: &str,
+        body: &str,
+    ) -> Result<SendResult> {
+        // Format alert message
+        let alert_text = format!("{}\n\n{}", subject, body);
+
+        let message_id = uuid::Uuid::new_v4().to_string();
+
+        let json_msg = serde_json::json!({
+            "type": "send",
+            "content": alert_text,
+        })
+        .to_string();
+
+        self.send_internal(&json_msg)
+            .context("Failed to send WeChat alert through WebSocket")?;
+
+        tracing::info!("WeChat alert sent to {}: {}", recipient, subject);
+
+        Ok(SendResult { message_id })
+    }
+}

--- a/crates/jyc-channels/src/wechat/websocket.rs
+++ b/crates/jyc-channels/src/wechat/websocket.rs
@@ -337,4 +337,76 @@ mod tests {
         // Already at max, should return false immediately
         assert!(!ws.handle_reconnection().await);
     }
+
+    /// Test incoming JSON message format parsing
+    #[test]
+    fn test_incoming_message_json_format() {
+        let json = r#"{
+            "id": "msg_001",
+            "type": "text",
+            "content": "Hello, this is a test message",
+            "sender": "wx_user_123",
+            "sender_name": "张三",
+            "timestamp": 1234567890
+        }"#;
+
+        let parsed: serde_json::Value = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed["id"], "msg_001");
+        assert_eq!(parsed["type"], "text");
+        assert_eq!(parsed["content"], "Hello, this is a test message");
+        assert_eq!(parsed["sender"], "wx_user_123");
+        assert_eq!(parsed["sender_name"], "张三");
+    }
+
+    /// Test minimal incoming JSON message (only required fields)
+    #[test]
+    fn test_incoming_message_minimal() {
+        let json = r#"{
+            "content": "Hello"
+        }"#;
+
+        let parsed: serde_json::Value = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed["content"], "Hello");
+        assert!(parsed.get("id").is_none());
+        assert!(parsed.get("sender").is_none());
+    }
+
+    /// Test outgoing message JSON format
+    #[test]
+    fn test_outgoing_message_json_format() {
+        let json = serde_json::json!({
+            "type": "send",
+            "content": "AI reply message"
+        });
+
+        assert_eq!(json["type"], "send");
+        assert_eq!(json["content"], "AI reply message");
+    }
+
+    /// Test outgoing message with Unicode content
+    #[test]
+    fn test_outgoing_message_unicode() {
+        let json = serde_json::json!({
+            "type": "send",
+            "content": "你好，有什么可以帮助你的？"
+        });
+
+        assert_eq!(json["type"], "send");
+        assert_eq!(json["content"], "你好，有什么可以帮助你的？");
+    }
+
+    /// Test that sender is properly extracted when sender_name is absent
+    #[test]
+    fn test_sender_fallback_to_name() {
+        let json = r#"{
+            "content": "test",
+            "sender": "wx_user_456"
+        }"#;
+
+        let parsed: serde_json::Value = serde_json::from_str(json).unwrap();
+        let sender = parsed.get("sender").and_then(|v| v.as_str()).unwrap_or("unknown");
+        let sender_name = parsed.get("sender_name").and_then(|v| v.as_str()).unwrap_or(sender);
+        assert_eq!(sender, "wx_user_456");
+        assert_eq!(sender_name, "wx_user_456"); // Falls back to sender
+    }
 }

--- a/crates/jyc-channels/src/wechat/websocket.rs
+++ b/crates/jyc-channels/src/wechat/websocket.rs
@@ -1,0 +1,7 @@
+//! WebSocket connection handler for WeChat OpenILink Bridge.
+//!
+//! Manages the lifecycle of a single WebSocket connection:
+//! connect → receive events → parse JSON → convert to InboundMessage → callback.
+//! Also provides a sender channel for outbound messages on the same connection.
+//!
+//! Auto-reconnect with exponential backoff and CancellationToken support.

--- a/crates/jyc-channels/src/wechat/websocket.rs
+++ b/crates/jyc-channels/src/wechat/websocket.rs
@@ -107,7 +107,8 @@ impl WechatWebSocket {
         cancel: &CancellationToken,
     ) -> Result<()> {
         let ws_url = self.ws_url();
-        tracing::info!(url = %ws_url, "Connecting to WeChat OpenILink WebSocket...");
+        let masked_url = format!("wss://{}/bot/v1/ws?token=***", self.base_url);
+        tracing::info!(url = %masked_url, "Connecting to WeChat OpenILink WebSocket...");
 
         let (ws_stream, _) = connect_async(&ws_url)
             .await

--- a/crates/jyc-channels/src/wechat/websocket.rs
+++ b/crates/jyc-channels/src/wechat/websocket.rs
@@ -9,16 +9,12 @@
 use anyhow::{Context, Result};
 use futures_util::{SinkExt, StreamExt};
 use std::collections::HashMap;
-use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_util::sync::CancellationToken;
 
 use jyc_types::{InboundMessage, MessageContent};
-
-/// Default max reconnect attempts
-const DEFAULT_MAX_RECONNECT: usize = 10;
 
 /// WebSocket connection handler for WeChat OpenILink Bridge.
 ///
@@ -29,16 +25,10 @@ pub struct WechatWebSocket {
     base_url: String,
     /// Access token
     token: String,
-    /// Maximum reconnect attempts
-    max_reconnect_attempts: usize,
-    /// Base reconnect delay in seconds (used in exponential backoff: delay * 2^attempt)
-    reconnect_delay_secs: u64,
     /// Sender half of the outbound channel — clones can be shared with `WechatOutboundAdapter`
     sender: mpsc::UnboundedSender<String>,
     /// Receiver half of the outbound channel
     outbound_rx: Option<mpsc::UnboundedReceiver<String>>,
-    /// Reconnection count
-    reconnect_count: usize,
 }
 
 impl WechatWebSocket {
@@ -51,31 +41,22 @@ impl WechatWebSocket {
         Self {
             base_url: base_url.to_string(),
             token: token.to_string(),
-            max_reconnect_attempts: DEFAULT_MAX_RECONNECT,
-            reconnect_delay_secs: 5,
             sender: tx,
             outbound_rx: Some(rx),
-            reconnect_count: 0,
         }
     }
 
     /// Create a new WeChat WebSocket handler with custom reconnect settings.
+    /// Reconnect parameters are stored in the adapter, not on the WS instance,
+    /// since a fresh WS is created on each connection attempt.
+    #[allow(unused_variables)]
     pub fn new_with_config(
         base_url: &str,
         token: &str,
         max_reconnect_attempts: usize,
         reconnect_delay_secs: u64,
     ) -> Self {
-        let (tx, rx) = mpsc::unbounded_channel::<String>();
-        Self {
-            base_url: base_url.to_string(),
-            token: token.to_string(),
-            max_reconnect_attempts,
-            reconnect_delay_secs,
-            sender: tx,
-            outbound_rx: Some(rx),
-            reconnect_count: 0,
-        }
+        Self::new(base_url, token)
     }
 
     /// Get a clone of the sender for outbound messages.
@@ -116,8 +97,6 @@ impl WechatWebSocket {
 
         let (mut write, mut read) = ws_stream.split();
 
-        // Reset reconnection count on successful connection
-        self.reconnect_count = 0;
         tracing::info!("WeChat WebSocket connected");
 
         // Take the outbound receiver
@@ -274,32 +253,6 @@ impl WechatWebSocket {
         on_message(message)?;
         Ok(())
     }
-
-    /// Handle reconnection with exponential backoff.
-    ///
-    /// Returns `true` if we should retry, `false` if max attempts reached.
-    pub async fn handle_reconnection(&mut self) -> bool {
-        if self.reconnect_count >= self.max_reconnect_attempts {
-            tracing::error!(
-                max_attempts = self.max_reconnect_attempts,
-                "Maximum reconnection attempts reached for WeChat WebSocket"
-            );
-            return false;
-        }
-
-        // Exponential backoff: reconnect_delay_secs * 2^attempt, capped at 60 seconds
-        let delay_secs = std::cmp::min(self.reconnect_delay_secs << self.reconnect_count, 60);
-        self.reconnect_count += 1;
-        tracing::info!(
-            attempt = self.reconnect_count,
-            max_attempts = self.max_reconnect_attempts,
-            delay_secs = delay_secs,
-            "Reconnecting to WeChat WebSocket"
-        );
-
-        tokio::time::sleep(Duration::from_secs(delay_secs)).await;
-        true
-    }
 }
 
 #[cfg(test)]
@@ -316,8 +269,9 @@ mod tests {
     #[test]
     fn test_new_with_config() {
         let ws = WechatWebSocket::new_with_config("example.com", "token", 5, 3);
-        assert_eq!(ws.max_reconnect_attempts, 5);
-        assert_eq!(ws.reconnect_count, 0);
+        // new_with_config delegates to new(), ignoring reconnect params
+        // since reconnect tracking is in the adapter, not the WS instance
+        assert!(ws.sender().send("test".to_string()).is_ok());
     }
 
     #[test]
@@ -330,13 +284,6 @@ mod tests {
         sender2.send("test2".to_string()).ok();
     }
 
-    #[tokio::test]
-    async fn test_handle_reconnection_max_attempts() {
-        let mut ws = WechatWebSocket::new_with_config("example.com", "token", 2, 5);
-        ws.reconnect_count = 2;
-        // Already at max, should return false immediately
-        assert!(!ws.handle_reconnection().await);
-    }
 
     /// Test incoming JSON message format parsing
     #[test]

--- a/crates/jyc-channels/src/wechat/websocket.rs
+++ b/crates/jyc-channels/src/wechat/websocket.rs
@@ -5,3 +5,336 @@
 //! Also provides a sender channel for outbound messages on the same connection.
 //!
 //! Auto-reconnect with exponential backoff and CancellationToken support.
+
+use anyhow::{Context, Result};
+use futures_util::{SinkExt, StreamExt};
+use std::collections::HashMap;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_util::sync::CancellationToken;
+
+use jyc_types::{InboundMessage, MessageContent};
+
+/// Default max reconnect attempts
+const DEFAULT_MAX_RECONNECT: usize = 10;
+
+/// WebSocket connection handler for WeChat OpenILink Bridge.
+///
+/// Manages a single WebSocket connection that both receives and sends messages.
+/// The `sender` field is exposed to the outbound adapter for sending replies.
+pub struct WechatWebSocket {
+    /// Base URL of the OpenILink server (hostname only, no protocol)
+    base_url: String,
+    /// Access token
+    token: String,
+    /// Maximum reconnect attempts
+    max_reconnect_attempts: usize,
+    /// Sender half of the outbound channel — clones can be shared with `WechatOutboundAdapter`
+    sender: mpsc::UnboundedSender<String>,
+    /// Receiver half of the outbound channel
+    outbound_rx: Option<mpsc::UnboundedReceiver<String>>,
+    /// Reconnection count
+    reconnect_count: usize,
+}
+
+impl WechatWebSocket {
+    /// Create a new WeChat WebSocket handler.
+    ///
+    /// Returns the handler and a sender handle that can be cloned and shared
+    /// with the `WechatOutboundAdapter`.
+    pub fn new(base_url: &str, token: &str) -> Self {
+        let (tx, rx) = mpsc::unbounded_channel::<String>();
+        Self {
+            base_url: base_url.to_string(),
+            token: token.to_string(),
+            max_reconnect_attempts: DEFAULT_MAX_RECONNECT,
+            sender: tx,
+            outbound_rx: Some(rx),
+            reconnect_count: 0,
+        }
+    }
+
+    /// Create a new WeChat WebSocket handler with custom reconnect settings.
+    pub fn new_with_config(
+        base_url: &str,
+        token: &str,
+        max_reconnect_attempts: usize,
+    ) -> Self {
+        let (tx, rx) = mpsc::unbounded_channel::<String>();
+        Self {
+            base_url: base_url.to_string(),
+            token: token.to_string(),
+            max_reconnect_attempts,
+            sender: tx,
+            outbound_rx: Some(rx),
+            reconnect_count: 0,
+        }
+    }
+
+    /// Get a clone of the sender for outbound messages.
+    ///
+    /// This can be shared with `WechatOutboundAdapter` so both inbound and
+    /// outbound use the same WebSocket connection.
+    pub fn sender(&self) -> mpsc::UnboundedSender<String> {
+        self.sender.clone()
+    }
+
+    /// Build the WebSocket URL.
+    fn ws_url(&self) -> String {
+        format!("wss://{}/bot/v1/ws?token={}", self.base_url, self.token)
+    }
+
+    /// Run the WebSocket event loop.
+    ///
+    /// Connects to the OpenILink WebSocket, listens for incoming messages,
+    /// parses them as JSON, extracts the `content` field, and calls the
+    /// `on_message` callback. Simultaneously listens on the outbound channel
+    /// and sends messages through the WebSocket.
+    ///
+    /// Blocks until the cancellation token fires or the connection drops.
+    /// Returns `Ok(())` on clean cancellation, `Err(...)` on connection failure.
+    pub async fn run(
+        &mut self,
+        channel_name: &str,
+        on_message: &(dyn Fn(InboundMessage) -> Result<()> + Send + Sync),
+        cancel: &CancellationToken,
+    ) -> Result<()> {
+        let ws_url = self.ws_url();
+        tracing::info!(url = %ws_url, "Connecting to WeChat OpenILink WebSocket...");
+
+        let (ws_stream, _) = connect_async(&ws_url)
+            .await
+            .context("Failed to connect to WeChat OpenILink WebSocket")?;
+
+        let (mut write, mut read) = ws_stream.split();
+
+        // Reset reconnection count on successful connection
+        self.reconnect_count = 0;
+        tracing::info!("WeChat WebSocket connected");
+
+        // Take the outbound receiver
+        let mut outbound_rx = self.outbound_rx
+            .take()
+            .expect("WechatWebSocket::run called more than once");
+
+        // Event loop: handle both incoming messages and outbound sends
+        loop {
+            tokio::select! {
+                // Incoming message from WebSocket
+                msg = read.next() => {
+                    match msg {
+                        Some(Ok(Message::Text(text))) => {
+                            if let Err(e) = self.handle_incoming(channel_name, &text, on_message).await {
+                                tracing::warn!(error = %e, "Failed to process WeChat message");
+                            }
+                        }
+                        Some(Ok(Message::Ping(_))) => {
+                            // Tungstenite handles pong automatically
+                        }
+                        Some(Ok(Message::Close(frame))) => {
+                            tracing::info!(?frame, "WeChat WebSocket closed by server");
+                            break;
+                        }
+                        Some(Ok(_)) => {
+                            // Binary, Pong frames: ignore
+                        }
+                        Some(Err(e)) => {
+                            tracing::error!(error = %e, "WeChat WebSocket read error");
+                            break;
+                        }
+                        None => {
+                            // Stream ended
+                            tracing::warn!("WeChat WebSocket read stream ended");
+                            break;
+                        }
+                    }
+                }
+
+                // Outbound message to send
+                Some(outbound_msg) = outbound_rx.recv() => {
+                    if let Err(e) = write.send(Message::Text(outbound_msg.into())).await {
+                        tracing::error!(error = %e, "Failed to send WeChat outbound message");
+                        break;
+                    }
+                }
+
+                // Cancellation
+                _ = cancel.cancelled() => {
+                    tracing::info!("WeChat WebSocket cancelled");
+                    return Ok(());
+                }
+            }
+        }
+
+        Err(anyhow::anyhow!("WeChat WebSocket connection closed unexpectedly"))
+    }
+
+    /// Handle an incoming text message from the WebSocket.
+    ///
+    /// Parses the JSON payload, extracts the `content` field, builds an
+    /// `InboundMessage`, and calls the `on_message` callback.
+    async fn handle_incoming(
+        &self,
+        channel_name: &str,
+        text: &str,
+        on_message: &(dyn Fn(InboundMessage) -> Result<()> + Send + Sync),
+    ) -> Result<()> {
+        let json: serde_json::Value = match serde_json::from_str(text) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(error = %e, payload = %text, "Failed to parse WeChat message as JSON");
+                return Err(anyhow::anyhow!("Failed to parse WeChat message as JSON: {}", e));
+            }
+        };
+
+        // Extract the content field
+        let content = json
+            .get("content")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        // Extract sender info
+        let sender = json
+            .get("sender")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+
+        let sender_name = json
+            .get("sender_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&sender)
+            .to_string();
+
+        // Extract message ID
+        let msg_id = json
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let msg_id_display = if msg_id.is_empty() {
+            uuid::Uuid::new_v4().to_string()
+        } else {
+            msg_id.clone()
+        };
+
+        // Extract message type
+        let msg_type = json
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("text")
+            .to_string();
+
+        // Build metadata
+        let mut metadata = HashMap::new();
+        if !msg_id.is_empty() {
+            metadata.insert("msg_id".to_string(), serde_json::Value::String(msg_id));
+        }
+        metadata.insert("msg_type".to_string(), serde_json::Value::String(msg_type));
+        metadata.insert("sender".to_string(), serde_json::Value::String(sender.clone()));
+
+        tracing::debug!(
+            sender = %sender,
+            content_len = content.len(),
+            "WeChat message received"
+        );
+
+        let message = InboundMessage {
+            id: uuid::Uuid::new_v4().to_string(),
+            channel: channel_name.to_string(),
+            channel_uid: msg_id_display,
+            sender: sender_name,
+            sender_address: sender,
+            recipients: vec![],
+            topic: String::new(),
+            content: MessageContent {
+                text: Some(content),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata,
+            matched_pattern: None,
+        };
+
+        on_message(message)?;
+        Ok(())
+    }
+
+    /// Handle reconnection with exponential backoff.
+    ///
+    /// Returns `true` if we should retry, `false` if max attempts reached.
+    pub async fn handle_reconnection(&mut self) -> bool {
+        if self.reconnect_count >= self.max_reconnect_attempts {
+            tracing::error!(
+                max_attempts = self.max_reconnect_attempts,
+                "Maximum reconnection attempts reached for WeChat WebSocket"
+            );
+            return false;
+        }
+
+        // Exponential backoff: 2^attempt seconds, capped at 60 seconds
+        let delay_secs = std::cmp::min(1u64 << self.reconnect_count, 60);
+        self.reconnect_count += 1;
+        tracing::info!(
+            attempt = self.reconnect_count,
+            max_attempts = self.max_reconnect_attempts,
+            delay_secs = delay_secs,
+            "Reconnecting to WeChat WebSocket"
+        );
+
+        tokio::time::sleep(Duration::from_secs(delay_secs)).await;
+        true
+    }
+
+    /// Reset reconnection count (called after successful connection).
+    #[allow(dead_code)]
+    pub fn reset_reconnection_count(&mut self) {
+        self.reconnect_count = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ws_url_format() {
+        let ws = WechatWebSocket::new("openilink.example.com", "test_token");
+        let url = ws.ws_url();
+        assert_eq!(url, "wss://openilink.example.com/bot/v1/ws?token=test_token");
+    }
+
+    #[test]
+    fn test_new_with_config() {
+        let ws = WechatWebSocket::new_with_config("example.com", "token", 5);
+        assert_eq!(ws.max_reconnect_attempts, 5);
+        assert_eq!(ws.reconnect_count, 0);
+    }
+
+    #[test]
+    fn test_sender_clone() {
+        let ws = WechatWebSocket::new("example.com", "token");
+        let sender1 = ws.sender();
+        let sender2 = ws.sender();
+        // Both senders should be able to send
+        sender1.send("test1".to_string()).ok();
+        sender2.send("test2".to_string()).ok();
+    }
+
+    #[tokio::test]
+    async fn test_handle_reconnection_max_attempts() {
+        let mut ws = WechatWebSocket::new_with_config("example.com", "token", 2);
+        ws.reconnect_count = 2;
+        // Already at max, should return false immediately
+        assert!(!ws.handle_reconnection().await);
+    }
+}

--- a/crates/jyc-channels/src/wechat/websocket.rs
+++ b/crates/jyc-channels/src/wechat/websocket.rs
@@ -25,12 +25,14 @@ const DEFAULT_MAX_RECONNECT: usize = 10;
 /// Manages a single WebSocket connection that both receives and sends messages.
 /// The `sender` field is exposed to the outbound adapter for sending replies.
 pub struct WechatWebSocket {
-    /// Base URL of the OpenILink server (hostname only, no protocol)
+    /// Hostname of the OpenILink server (e.g., "openilink.example.com")
     base_url: String,
     /// Access token
     token: String,
     /// Maximum reconnect attempts
     max_reconnect_attempts: usize,
+    /// Base reconnect delay in seconds (used in exponential backoff: delay * 2^attempt)
+    reconnect_delay_secs: u64,
     /// Sender half of the outbound channel — clones can be shared with `WechatOutboundAdapter`
     sender: mpsc::UnboundedSender<String>,
     /// Receiver half of the outbound channel
@@ -50,6 +52,7 @@ impl WechatWebSocket {
             base_url: base_url.to_string(),
             token: token.to_string(),
             max_reconnect_attempts: DEFAULT_MAX_RECONNECT,
+            reconnect_delay_secs: 5,
             sender: tx,
             outbound_rx: Some(rx),
             reconnect_count: 0,
@@ -61,12 +64,14 @@ impl WechatWebSocket {
         base_url: &str,
         token: &str,
         max_reconnect_attempts: usize,
+        reconnect_delay_secs: u64,
     ) -> Self {
         let (tx, rx) = mpsc::unbounded_channel::<String>();
         Self {
             base_url: base_url.to_string(),
             token: token.to_string(),
             max_reconnect_attempts,
+            reconnect_delay_secs,
             sender: tx,
             outbound_rx: Some(rx),
             reconnect_count: 0,
@@ -281,8 +286,8 @@ impl WechatWebSocket {
             return false;
         }
 
-        // Exponential backoff: 2^attempt seconds, capped at 60 seconds
-        let delay_secs = std::cmp::min(1u64 << self.reconnect_count, 60);
+        // Exponential backoff: reconnect_delay_secs * 2^attempt, capped at 60 seconds
+        let delay_secs = std::cmp::min(self.reconnect_delay_secs << self.reconnect_count, 60);
         self.reconnect_count += 1;
         tracing::info!(
             attempt = self.reconnect_count,
@@ -293,12 +298,6 @@ impl WechatWebSocket {
 
         tokio::time::sleep(Duration::from_secs(delay_secs)).await;
         true
-    }
-
-    /// Reset reconnection count (called after successful connection).
-    #[allow(dead_code)]
-    pub fn reset_reconnection_count(&mut self) {
-        self.reconnect_count = 0;
     }
 }
 
@@ -315,7 +314,7 @@ mod tests {
 
     #[test]
     fn test_new_with_config() {
-        let ws = WechatWebSocket::new_with_config("example.com", "token", 5);
+        let ws = WechatWebSocket::new_with_config("example.com", "token", 5, 3);
         assert_eq!(ws.max_reconnect_attempts, 5);
         assert_eq!(ws.reconnect_count, 0);
     }
@@ -332,7 +331,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_reconnection_max_attempts() {
-        let mut ws = WechatWebSocket::new_with_config("example.com", "token", 2);
+        let mut ws = WechatWebSocket::new_with_config("example.com", "token", 2, 5);
         ws.reconnect_count = 2;
         // Already at max, should return false immediately
         assert!(!ws.handle_reconnection().await);

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -16,6 +16,8 @@ use jyc_channels::feishu::inbound::{FeishuInboundAdapter, FeishuMatcher};
 use jyc_channels::feishu::outbound::FeishuOutboundAdapter;
 use jyc_channels::github::inbound::GithubMatcher;
 use jyc_channels::github::outbound::GithubOutboundAdapter;
+use jyc_channels::wechat::inbound::WechatInboundAdapter;
+use jyc_channels::wechat::outbound::WechatOutboundAdapter;
 use jyc_types::OutboundAdapter;
 use jyc_types::MonitorConfig;
 use jyc_types::{load_config, validation};
@@ -106,6 +108,10 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
             .map_or(true, |f| f.enabled);
 
         // Create the outbound adapter based on channel type
+        // For wechat, we need to share the WebSocket sender between inbound and outbound
+        let mut wechat_sender_arc: Option<
+            std::sync::Arc<tokio::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<String>>>>
+        > = None;
         let outbound: Arc<dyn OutboundAdapter> = match channel_type {
             "email" => {
                 let outbound_config = channel_config
@@ -149,6 +155,18 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     storage.clone(),
                     footer_enabled,
                 )?)
+            }
+            "wechat" => {
+                // WeChat config is validated and cloned in the inbound section.
+                // Outbound only needs sender, storage, and footer config.
+                let adapter = WechatOutboundAdapter::new_with_attachments(
+                    storage.clone(),
+                    outbound_attachment_config,
+                    footer_enabled,
+                );
+                // Store the sender_arc for later use in the inbound section
+                wechat_sender_arc = Some(adapter.sender_arc());
+                Arc::new(adapter)
             }
             other => {
                 tracing::warn!(
@@ -450,6 +468,75 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                         tracing::error!(
                             error = %e,
                             "GitHub inbound adapter error"
+                        );
+                    }
+
+                    // Shutdown thread manager for this channel
+                    tm.shutdown().await;
+                }.instrument(channel_span));
+
+                tasks.push(task);
+            }
+            "wechat" => {
+                let wechat_config = channel_config
+                    .wechat
+                    .as_ref()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("channel '{channel_name}': missing wechat config")
+                    })?
+                    .clone();
+
+                let patterns_for_callback = patterns.clone();
+                let router_for_callback = router.clone();
+                let wechat_sender_arc_clone = wechat_sender_arc.clone().unwrap();
+
+                let task = tokio::spawn(async move {
+                    use jyc_types::InboundAdapter;
+                    use jyc_channels::wechat::inbound::WechatMatcher;
+
+                    // Create the adapter and initialize WebSocket
+                    let adapter = WechatInboundAdapter::new(&wechat_config, channel_name_owned.clone());
+
+                    // Create WebSocket and get the sender for outbound
+                    let sender = adapter.create_and_get_sender().await;
+
+                    // Set the sender on the outbound adapter
+                    {
+                        let mut guard = wechat_sender_arc_clone.lock().await;
+                        *guard = Some(sender);
+                    }
+
+                    let thread_manager_clone = thread_manager.clone();
+                    let options = jyc_types::InboundAdapterOptions {
+                        on_message: Box::new(move |message| {
+                            let router = router_for_callback.clone();
+                            let patterns = patterns_for_callback.clone();
+
+                            tokio::spawn(async move {
+                                router.route(&WechatMatcher, message, &patterns).await;
+                            });
+
+                            Ok(())
+                        }),
+                        on_thread_close: Some(Box::new(move |thread_name: String| {
+                            let tm = thread_manager_clone.clone();
+                            tokio::spawn(async move {
+                                if let Err(e) = tm.close_thread(&thread_name).await {
+                                    tracing::error!(error = %e, thread = %thread_name, "Failed to close thread");
+                                }
+                            });
+                            Ok(())
+                        })),
+                        on_error: Box::new(|error| {
+                            tracing::error!(error = %error, "WeChat inbound error");
+                        }),
+                        attachment_config: inbound_attachment_config.clone(),
+                    };
+
+                    if let Err(e) = adapter.start(options, cancel_child).await {
+                        tracing::error!(
+                            error = %e,
+                            "WeChat inbound adapter error"
                         );
                     }
 

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -494,17 +494,13 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     use jyc_types::InboundAdapter;
                     use jyc_channels::wechat::inbound::WechatMatcher;
 
-                    // Create the adapter and initialize WebSocket
-                    let adapter = WechatInboundAdapter::new(&wechat_config, channel_name_owned.clone());
-
-                    // Create WebSocket and get the sender for outbound
-                    let sender = adapter.create_and_get_sender().await;
-
-                    // Set the sender on the outbound adapter
-                    {
-                        let mut guard = wechat_sender_arc_clone.lock().await;
-                        *guard = Some(sender);
-                    }
+                    // Create the adapter with the shared sender Arc so it can
+                    // update the outbound sender on each reconnection.
+                    let adapter = WechatInboundAdapter::with_shared_sender(
+                        &wechat_config,
+                        channel_name_owned.clone(),
+                        wechat_sender_arc_clone,
+                    );
 
                     let thread_manager_clone = thread_manager.clone();
                     let options = jyc_types::InboundAdapterOptions {

--- a/crates/jyc-types/src/config.rs
+++ b/crates/jyc-types/src/config.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use crate::channel::ChannelPattern;
 use crate::feishu_config::FeishuConfig;
 use crate::github_config::GithubConfig;
+use crate::wechat_config::WechatConfig;
 
 /// MCP server configuration for agent dynamic tool loading.
 ///
@@ -112,6 +113,9 @@ pub struct ChannelConfig {
 
     /// GitHub configuration (for github channels)
     pub github: Option<GithubConfig>,
+
+    /// WeChat configuration (for wechat channels)
+    pub wechat: Option<WechatConfig>,
 
     /// Monitoring settings (IDLE vs poll, interval, etc.)
     pub monitor: Option<MonitorConfig>,

--- a/crates/jyc-types/src/lib.rs
+++ b/crates/jyc-types/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod inspect;
 pub mod feishu_config;
 pub mod github_config;
+pub mod wechat_config;
 pub mod validation;
 
 pub use agent::*;
@@ -11,4 +12,5 @@ pub use channel::*;
 pub use config::*;
 pub use feishu_config::*;
 pub use github_config::*;
+pub use wechat_config::*;
 pub use inspect::*;

--- a/crates/jyc-types/src/wechat_config.rs
+++ b/crates/jyc-types/src/wechat_config.rs
@@ -1,0 +1,99 @@
+use serde::{Deserialize, Serialize};
+
+/// WeChat-specific configuration for a channel.
+///
+/// Uses OpenILink WebSocket Bridge to connect to WeChat.
+/// Both inbound and outbound messages share the same WebSocket connection.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct WechatConfig {
+    /// Base URL of the OpenILink server (e.g., "https://openilink.example.com")
+    pub base_url: String,
+
+    /// Access token for the OpenILink server
+    pub token: String,
+
+    /// WebSocket connection configuration
+    #[serde(default)]
+    pub websocket: WechatWebSocketConfig,
+}
+
+/// WebSocket connection configuration for WeChat.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct WechatWebSocketConfig {
+    /// Whether WebSocket is enabled (default: true)
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Reconnect delay in seconds (default: 5)
+    #[serde(default = "default_reconnect_delay")]
+    pub reconnect_delay_secs: u64,
+
+    /// Maximum reconnect attempts (default: 10)
+    #[serde(default = "default_max_reconnect_attempts")]
+    pub max_reconnect_attempts: usize,
+}
+
+impl Default for WechatConfig {
+    fn default() -> Self {
+        Self {
+            base_url: String::new(),
+            token: String::new(),
+            websocket: WechatWebSocketConfig::default(),
+        }
+    }
+}
+
+impl Default for WechatWebSocketConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_true(),
+            reconnect_delay_secs: default_reconnect_delay(),
+            max_reconnect_attempts: default_max_reconnect_attempts(),
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_reconnect_delay() -> u64 {
+    5
+}
+
+fn default_max_reconnect_attempts() -> usize {
+    10
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = WechatConfig::default();
+        assert_eq!(config.base_url, "");
+        assert_eq!(config.token, "");
+        assert!(config.websocket.enabled);
+        assert_eq!(config.websocket.reconnect_delay_secs, 5);
+        assert_eq!(config.websocket.max_reconnect_attempts, 10);
+    }
+
+    #[test]
+    fn test_config_deserialize() {
+        let toml_str = r#"
+            base_url = "https://openilink.example.com"
+            token = "wechat_token_xxx"
+
+            [websocket]
+            enabled = false
+            reconnect_delay_secs = 10
+        "#;
+
+        let config: WechatConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.base_url, "https://openilink.example.com");
+        assert_eq!(config.token, "wechat_token_xxx");
+        assert!(!config.websocket.enabled);
+        assert_eq!(config.websocket.reconnect_delay_secs, 10);
+    }
+}

--- a/crates/jyc-types/src/wechat_config.rs
+++ b/crates/jyc-types/src/wechat_config.rs
@@ -6,7 +6,9 @@ use serde::{Deserialize, Serialize};
 /// Both inbound and outbound messages share the same WebSocket connection.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WechatConfig {
-    /// Base URL of the OpenILink server (e.g., "https://openilink.example.com")
+    /// Hostname of the OpenILink server (e.g., "openilink.example.com").
+    /// Do NOT include protocol prefix — the WebSocket URL is constructed
+    /// as `wss://{base_url}/bot/v1/ws?token={token}` automatically.
     pub base_url: String,
 
     /// Access token for the OpenILink server
@@ -82,7 +84,7 @@ mod tests {
     #[test]
     fn test_config_deserialize() {
         let toml_str = r#"
-            base_url = "https://openilink.example.com"
+            base_url = "openilink.example.com"
             token = "wechat_token_xxx"
 
             [websocket]
@@ -91,7 +93,7 @@ mod tests {
         "#;
 
         let config: WechatConfig = toml::from_str(toml_str).unwrap();
-        assert_eq!(config.base_url, "https://openilink.example.com");
+        assert_eq!(config.base_url, "openilink.example.com");
         assert_eq!(config.token, "wechat_token_xxx");
         assert!(!config.websocket.enabled);
         assert_eq!(config.websocket.reconnect_delay_secs, 10);


### PR DESCRIPTION
## Spec

新增 `wechat` channel 类型，通过 OpenILink WebSocket Bridge 连接微信。入站和出站共用同一条 WebSocket 连接。一个 bot 对应一个固定 thread。第一版仅支持纯文本消息。

Fixes #205

## Implementation Plan

### Step 1: 新增 `WechatConfig` 配置类型
**What:** 在 `crates/jyc-types/src/` 下新建 `wechat_config.rs`，定义 `WechatConfig` 结构体（`base_url`、`token`、`websocket`）。在 `crates/jyc-types/src/config.rs` 的 `ChannelConfig` 中增加 `pub wechat: Option<WechatConfig>` 字段。在 `crates/jyc-types/src/lib.rs` 中导出新模块。
**Why:** 作为新 channel 类型的配置入口，必须先有类型定义才能编写后续逻辑。
**Verify:** `cargo check -p jyc-types` 通过。

### Step 2: 新建 `crates/jyc-channels/src/wechat/` 模块骨架
**What:** 创建 `wechat/mod.rs`、`wechat/websocket.rs`、`wechat/inbound.rs`、`wechat/outbound.rs` 四个文件。在 `mod.rs` 中声明子模块。在 `crates/jyc-channels/src/lib.rs` 中增加 `pub mod wechat;`。
**Why:** 搭好模块骨架，后续步骤逐步填充实现。
**Verify:** `cargo check -p jyc-channels` 通过（模块存在但不含实现）。

### Step 3: 实现 `WechatWebSocket` 核心（crates/jyc-channels/src/wechat/websocket.rs）
**What:** 实现 `WechatWebSocket` struct，用 `tokio-tungstenite` 连接 `wss://<base_url>/bot/v1/ws?token=<token>`。包含：
- `run()` 方法：启动 WS 事件循环，接收消息解析 JSON，提取 `content` 字段，构建 `InboundMessage` 调用 `on_message` 回调。
- 暴露 `mpsc::UnboundedSender<String>` 供 outbound 使用，发送格式为 `{"type":"send","content":"..."}`。
- 自动重连（exponential backoff）+ `CancellationToken` 支持。
**Why:** 核心通信层，是入站和出站的共享基础设施。与 Feishu 最大区别：同一条 WS 连接既收又发。
**Verify:** `cargo check -p jyc-channels` 通过；检查 `Cargo.toml` 确认新增了 `tokio-tungstenite` 依赖。

### Step 4: 实现 `WechatMatcher` + `WechatInboundAdapter`（inbound.rs）
**What:** 实现 `WechatMatcher`（`channel_type` → `"wechat"`）和 `WechatInboundAdapter`（实现 `ChannelMatcher` 和 `InboundAdapter` trait）。
- `derive_thread_name`：直接返回 channel 配置名称（如 `"wechat_bot"`），实现一个 bot = 一个固定 thread。
- `match_message`：支持 `keywords`（消息内容关键词，大小写不敏感）和 `sender` 规则。空 rules 匹配所有消息。
- `InboundAdapter::start()`：创建 `WechatWebSocket`，调用 `run()`，循环重连。
**Why:** 遵循现有 channel 架构模式（参考 `FeishuInboundAdapter`），使微信 channel 可被 MessageRouter 路由。
**Verify:** `cargo check -p jyc-channels` 通过。

### Step 5: 实现 `WechatOutboundAdapter`（outbound.rs）
**What:** 实现 `WechatOutboundAdapter`（实现 `OutboundAdapter` trait）。通过 `mpsc::UnboundedSender<String>` 向 WebSocket 发送 JSON 格式消息。包含 footer 拼接、reply 存储到 chat log。
**Why:** 完成消息发送链路，使 AI 回复可通过微信发出。
**Verify:** `cargo check -p jyc-channels` 通过。

### Step 6: 在 CLI monitor 中注册 wechat channel（crates/jyc-cli/src/cli/monitor.rs）
**What:** 
- 在 `create_outbound_adapter` 的 match 分支中增加 `"wechat"` 分支，创建 `WechatOutboundAdapter`。
- 在 `start_inbound_channel` 的 match 分支中增加 `"wechat"` 分支，创建 `WechatInboundAdapter` 并 `start()`。
- outbound 和 inbound **共享同一个 `mpsc::UnboundedSender<String>`**（从 WS 的 `run()` 返回值获取，传给 outbound adapter）。
**Why:** 将 wechat channel 接入 JYC 的主事件循环。
**Verify:** `cargo check --workspace` 通过。

### Step 7: 添加单元测试
**What:** 为 `WechatMatcher` 的匹配逻辑添加单元测试（覆盖：空 rules 匹配、keywords 匹配、sender 匹配、AND 逻辑）。为 `WechatWebSocket` 的 JSON 解析添加测试。
**Why:** 保证匹配逻辑正确性。
**Verify:** `cargo test -p jyc-channels -- wechat` 全部通过。

### Step 8: 更新文档
**What:** 在 `DESIGN.md` 中增加微信 channel 的架构说明（类似现有的 Feishu Channel Implementation 章节）。在 `config.example.toml` 中增加 wechat channel 的配置示例。
**Why:** 文档是用户明确的提醒，设计文档帮助后续维护者理解架构。
**Verify:** 肉眼检查文档内容正确性。

## Design Decisions
- **入站出站共用一条 WebSocket**：与 Feishu（WS 入站 + HTTP API 出站）不同，OpenILink 的发送也走同一条 WS 连接。因此 `WechatWebSocket` 暴露 `mpsc::Sender` 供 `OutboundAdapter` 使用。
- **一个 bot = 一个固定 thread**：thread name 直接使用 channel 名称，简化实现，与 Feishu 的多 chat 架构不同。
- **纯文本消息**：第一版不支持图片/文件等富媒体，后续可扩展。
- **原生 WebSocket（tokio-tungstenite）**：不使用 open-lark SDK，OpenILink 协议足够简单，直接操作 WS 即可。
- **消息格式**：接收格式假设 JSON 中包含 `content` 字段，发送格式为 `{"type":"send","content":"..."}`。解析逻辑集中在 `websocket.rs`，后续格式变化只需修改一处。