### PR TITLE
feat: read_image dual-mode with vision model fallback (DeepSeek-OCR)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -201,6 +201,22 @@ system_prompt = "You are an AI assistant. Respond professionally and concisely."
 # [agent.providers.anthropic.models."claude-opus-4-7"]
 # supports_images = true
 
+# --- Agent Vision Fallback ---
+#
+# When the primary model does not support images (supports_images = false),
+# the `read_image` tool can fall back to a separate vision model (e.g.,
+# DeepSeek-OCR) to analyze images and return text descriptions.
+#
+# The `provider` field references a named entry in `[agent.providers]` above
+# to reuse its `base_url` and `api_key_env`, avoiding duplicate credentials.
+#
+# [agent.vision]
+# enabled = true
+# provider = "deepseek"
+# model = "deepseek-ocr"
+# # Optional: custom prompt sent to the vision model alongside each image
+# # prompt = "请仔细识别并提取图片中的所有文字内容"
+
 
 [agent.attachments]
 enabled = true

--- a/crates/jyc-agent/src/agent_loop.rs
+++ b/crates/jyc-agent/src/agent_loop.rs
@@ -52,6 +52,11 @@ pub struct AgentLoopConfig<'a> {
     /// `working_dir`.
     #[allow(dead_code)]
     pub additional_read_roots: Vec<std::path::PathBuf>,
+    /// Whether the inbound-attachment pattern allows image injection.
+    /// Mirrors `inject_inbound_images`: when `false`, the `read_image`
+    /// tool should not use vision-fallback mode even if a `VisionClient`
+    /// is configured (consistent with `build_user_blocks` behavior).
+    pub pattern_inject_images: bool,
 }
 
 /// Run the agent loop to completion.
@@ -61,7 +66,7 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
     let AgentLoopConfig {
         provider, small_provider, tools, system_prompt, user_blocks,
         working_dir, cancel, thread_name, event_bus, prior_history, prior_raw_context,
-        max_iterations, additional_read_roots,
+        max_iterations, additional_read_roots, pattern_inject_images,
     } = config;
 
     // Provider used for the cycle-boundary progress summary. Falls back to
@@ -157,7 +162,8 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
             }).await;
 
             let tool_start = Instant::now();
-            let ctx = ToolContext::with_roots(working_dir, additional_read_roots.clone());
+            let mut ctx = ToolContext::with_roots(working_dir, additional_read_roots.clone());
+            ctx.pattern_inject_images = pattern_inject_images;
             let synthetic_input: serde_json::Value = serde_json::from_str(&synthetic_args)
                 .unwrap_or(serde_json::Value::Object(Default::default()));
             let synthetic_output = match tools.execute("jyc_reply_reply_message", synthetic_input, &ctx).await {
@@ -288,7 +294,8 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
             "Executing tool calls"
         );
 
-        let ctx = ToolContext::with_roots(working_dir, additional_read_roots.clone());
+        let mut ctx = ToolContext::with_roots(working_dir, additional_read_roots.clone());
+        ctx.pattern_inject_images = pattern_inject_images;
 
         for tool_call in &response.tool_calls {
             if cancel.is_cancelled() {

--- a/crates/jyc-agent/src/lib.rs
+++ b/crates/jyc-agent/src/lib.rs
@@ -95,6 +95,7 @@ mod integration_tests {
             prior_raw_context: Vec::new(),
             max_iterations: None,
             additional_read_roots: Vec::new(),
+            pattern_inject_images: false,
         }).await.unwrap();
 
         println!("Text: {}", result.text);

--- a/crates/jyc-agent/src/lib.rs
+++ b/crates/jyc-agent/src/lib.rs
@@ -8,6 +8,7 @@ pub mod types;
 pub mod agent_loop;
 pub mod session;
 pub mod service;
+pub mod vision;
 
 pub use service::JycAgentService;
 

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -404,17 +404,39 @@ impl JycAgentService {
                     .collect();
 
                 if !image_hints.is_empty() {
-                    // Extract existing text and append image hints
-                    let existing_text = match &blocks[0] {
-                        ContentBlock::Text { text } => text.clone(),
-                        _ => String::new(),
+                    // Append image path hints to the first Text block, or
+                    // insert a new one if none exists. Using `find` avoids
+                    // assuming the first block type.
+                    let hint_text = {
+                        let mut lines = String::new();
+                        lines.push_str("\n\nImage attachments available (use read_image tool to analyze):\n");
+                        for hint in &image_hints {
+                            lines.push_str(&format!("- {}\n", hint));
+                        }
+                        lines
                     };
-                    let mut new_text = existing_text;
-                    new_text.push_str("\n\nImage attachments available (use read_image tool to analyze):\n");
-                    for hint in &image_hints {
-                        new_text.push_str(&format!("- {}\n", hint));
+
+                    let found = blocks.iter_mut().find_map(|block| {
+                        if let ContentBlock::Text { text } = block {
+                            text.push_str(&hint_text);
+                            Some(())
+                        } else {
+                            None
+                        }
+                    });
+
+                    if found.is_none() {
+                        // No Text block found; prepend a new one
+                        blocks.insert(
+                            0,
+                            ContentBlock::Text {
+                                text: format!(
+                                    "Image attachments available (use read_image tool to analyze):\n{}",
+                                    image_hints.join("\n")
+                                ),
+                            },
+                        );
                     }
-                    blocks[0] = ContentBlock::Text { text: new_text };
                 }
             }
 

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -442,7 +442,7 @@ impl JycAgentService {
 
         // Image-loading built-in (only when the model accepts images).
         if supports_images {
-            crate::tools::builtin::register_read_image(&mut registry);
+            crate::tools::builtin::register_read_image(&mut registry, true, None);
         }
 
         // Add MCP bridge tools (reply_message, etc.)

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -649,6 +649,14 @@ impl AgentService for JycAgentService {
         // 6. Get event bus for this thread
         let event_bus = self.get_event_bus(thread_name).await;
 
+        // 6b. Determine per-pattern image injection flag for consistency
+        // between `build_user_blocks` and the `read_image` tool's
+        // vision-fallback decision.
+        let pattern_inject = message.matched_pattern.as_deref()
+            .and_then(|name| self.patterns.iter().find(|p| p.name == name))
+            .map(|p| p.inject_inbound_images)
+            .unwrap_or(false);
+
         // 7. Run agent loop
         let additional_read_roots = self.resolve_additional_read_roots(message, thread_path);
         let result = agent_loop::run(AgentLoopConfig {
@@ -665,6 +673,7 @@ impl AgentService for JycAgentService {
             prior_raw_context,
             max_iterations: Some(self.config.max_iterations),
             additional_read_roots,
+            pattern_inject_images: pattern_inject,
         })
         .await?;
 

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -19,6 +19,8 @@ use crate::provider;
 use crate::session;
 use crate::tools::registry::ToolRegistry;
 use crate::types::AgentConfig;
+use crate::vision::VisionClient;
+use std::sync::Arc;
 
 /// Metadata for a discovered skill.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -113,17 +115,21 @@ pub struct JycAgentService {
     /// Global `[attachments.inbound]` config (used as fallback when a matched
     /// pattern does not specify its own `attachments`).
     global_inbound_attachments: Option<jyc_types::InboundAttachmentConfig>,
+    /// Vision fallback client for text-only models to analyze images.
+    vision_client: Option<Arc<VisionClient>>,
 }
 
 impl JycAgentService {
     /// Create a new agent service with the given configuration, workdir,
-    /// MCP configs, channel patterns, and global inbound-attachment config.
+    /// MCP configs, channel patterns, global inbound-attachment config,
+    /// and optional vision fallback client.
     pub fn new(
         config: AgentConfig,
         workdir: PathBuf,
         mcp_configs: Vec<McpServerConfig>,
         patterns: Vec<ChannelPattern>,
         global_inbound_attachments: Option<jyc_types::InboundAttachmentConfig>,
+        vision_client: Option<Arc<VisionClient>>,
     ) -> Self {
         Self {
             config,
@@ -132,6 +138,7 @@ impl JycAgentService {
             mcp_configs,
             patterns,
             global_inbound_attachments,
+            vision_client,
         }
     }
 
@@ -465,10 +472,16 @@ impl JycAgentService {
         // Start with all built-in tools
         let mut registry = crate::tools::builtin::create_builtin_registry();
 
-        // Image-loading built-in (only when the model accepts images).
-        if supports_images {
-            crate::tools::builtin::register_read_image(&mut registry, true, None);
-        }
+        // Always register read_image. When the model supports images, images
+        // are queued for injection into the next user turn. When the model is
+        // text-only and a VisionClient is configured, the tool falls back to
+        // the vision model for analysis. When neither condition is met, the
+        // tool returns a helpful error message.
+        crate::tools::builtin::register_read_image(
+            &mut registry,
+            supports_images,
+            self.vision_client.clone(),
+        );
 
         // Add MCP bridge tools (reply_message, etc.)
         crate::tools::mcp_bridge::register_mcp_tools(&mut registry);

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -386,6 +386,31 @@ impl JycAgentService {
             .unwrap_or(false);
 
         if !(supports_images && pattern_inject) {
+            // For text-only models with inject_inbound_images enabled, append
+            // image file path hints so the LLM knows which images are available
+            // and can invoke `read_image` to analyze them via vision fallback.
+            if !supports_images && pattern_inject {
+                let image_hints: Vec<String> = message.attachments
+                    .iter()
+                    .filter(|a| a.content_type.starts_with("image/"))
+                    .filter_map(|a| a.saved_path.as_ref().map(|p| p.display().to_string()))
+                    .collect();
+
+                if !image_hints.is_empty() {
+                    // Extract existing text and append image hints
+                    let existing_text = match &blocks[0] {
+                        ContentBlock::Text { text } => text.clone(),
+                        _ => String::new(),
+                    };
+                    let mut new_text = existing_text;
+                    new_text.push_str("\n\nImage attachments available (use read_image tool to analyze):\n");
+                    for hint in &image_hints {
+                        new_text.push_str(&format!("- {}\n", hint));
+                    }
+                    blocks[0] = ContentBlock::Text { text: new_text };
+                }
+            }
+
             return blocks;
         }
 

--- a/crates/jyc-agent/src/tools/builtin/mod.rs
+++ b/crates/jyc-agent/src/tools/builtin/mod.rs
@@ -9,7 +9,10 @@ pub mod glob_tool;
 pub mod grep;
 pub mod webfetch;
 
+use std::sync::Arc;
+
 use super::registry::ToolRegistry;
+use crate::vision::VisionClient;
 
 /// Create a tool registry with all built-in tools.
 pub fn create_builtin_registry() -> ToolRegistry {
@@ -26,8 +29,12 @@ pub fn create_builtin_registry() -> ToolRegistry {
     registry
 }
 
-/// Register the `read_image` built-in tool. Call this only when the active
-/// model supports image content blocks.
-pub fn register_read_image(registry: &mut ToolRegistry) {
-    registry.register(Box::new(read_image::ReadImageTool));
+/// Register the `read_image` built-in tool.
+///
+/// `supports_images` controls the execution mode:
+/// - `true`: images are queued for injection into the next user turn.
+/// - `false`: `vision_client` (if configured) is used to analyze the image
+///   and return text. If both are false/unavailable, the tool returns an error.
+pub fn register_read_image(registry: &mut ToolRegistry, supports_images: bool, vision_client: Option<Arc<VisionClient>>) {
+    registry.register(Box::new(read_image::ReadImageTool::new(supports_images, vision_client)));
 }

--- a/crates/jyc-agent/src/tools/builtin/read_image.rs
+++ b/crates/jyc-agent/src/tools/builtin/read_image.rs
@@ -1,17 +1,34 @@
-//! `read_image` tool — load an image file or URL into the next user turn.
+//! `read_image` tool — the **single entry point** for all image analysis.
 //!
-//! Dual-mode operation:
+//! All images, whether loaded by the LLM on demand or auto-injected from
+//! inbound attachments, go through `read_image` for processing. The tool
+//! operates in one of two modes:
 //!
 //! 1. **Image injection mode** (when `supports_images = true`):
 //!    Pushes the loaded image onto `ToolContext.pending_images`; the agent loop
 //!    drains the queue after the tool batch completes and emits a synthetic
 //!    user-role message carrying the image content blocks. This is the original
-//!    behavior.
+//!    behavior for multimodal models.
 //!
 //! 2. **Vision fallback mode** (when `supports_images = false` + VisionClient):
 //!    Loads the image, sends it to an external vision model (e.g., DeepSeek-OCR)
 //!    via the VisionClient, and returns the textual analysis directly as the
-//!    tool output. No pending_images queue is used.
+//!    tool output. No pending_images queue is used. This mode is only active
+//!    when the current message's pattern has `inject_inbound_images = true`,
+//!    ensuring consistent behavior with the auto-injection path in
+//!    `build_user_blocks` (see `service.rs`).
+//!
+//! ## Design rationale
+//!
+//! - `read_image` is always registered regardless of model capabilities, so
+//!   the tool schema is stable and honest across sessions.
+//! - The execution mode (injection vs. fallback) is determined at runtime
+//!   based on `ToolContext.pattern_inject_images` (set from the per-message
+//!   pattern config) and the tool's own `supports_images` / `vision_client`
+//!   fields.
+//! - When neither condition is met, the tool returns a descriptive error
+//!   guiding the user to configure `[agent.vision]` or enable
+//!   `inject_inbound_images`.
 //!
 //! ## Why a side-channel instead of a tool-result block (mode 1 only)
 //!
@@ -297,8 +314,11 @@ impl ReadImageTool {
                 })
                 .to_string(),
             ))
-        } else if let Some(vc) = &self.vision_client {
-            // Mode 2: Vision fallback — send to vision model
+        } else if ctx.pattern_inject_images && self.vision_client.is_some() {
+            // Mode 2: Vision fallback — send to vision model (only when
+            // the pattern allows image handling, consistent with
+            // `build_user_blocks` in service.rs).
+            let vc = self.vision_client.as_ref().unwrap();
             let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
             match vc.analyze(media_type, &data).await {
                 Ok(text) => Ok(ToolOutput::success(
@@ -316,11 +336,17 @@ impl ReadImageTool {
             }
         } else {
             // No vision capability available
-            Ok(ToolOutput::error(
+            let msg = if !ctx.pattern_inject_images {
+                "The current pattern does not allow image handling \
+                 (inject_inbound_images is disabled). Enable it in \
+                 config.toml or use a different pattern to use the \
+                 read_image tool with vision fallback."
+            } else {
                 "The current model does not support images and no vision \
                  fallback model is configured. Set [agent.vision] in \
-                 config.toml to enable image analysis via a separate vision model.",
-            ))
+                 config.toml to enable image analysis via a separate vision model."
+            };
+            Ok(ToolOutput::error(msg))
         }
     }
 }

--- a/crates/jyc-agent/src/tools/builtin/read_image.rs
+++ b/crates/jyc-agent/src/tools/builtin/read_image.rs
@@ -1,11 +1,19 @@
 //! `read_image` tool — load an image file or URL into the next user turn.
 //!
-//! Registered only when the active provider has `supports_images() == true`.
-//! Pushes the loaded image onto `ToolContext.pending_images`; the agent loop
-//! drains the queue after the tool batch completes and emits a synthetic
-//! user-role message carrying the image content blocks.
+//! Dual-mode operation:
 //!
-//! ## Why a side-channel instead of a tool-result block
+//! 1. **Image injection mode** (when `supports_images = true`):
+//!    Pushes the loaded image onto `ToolContext.pending_images`; the agent loop
+//!    drains the queue after the tool batch completes and emits a synthetic
+//!    user-role message carrying the image content blocks. This is the original
+//!    behavior.
+//!
+//! 2. **Vision fallback mode** (when `supports_images = false` + VisionClient):
+//!    Loads the image, sends it to an external vision model (e.g., DeepSeek-OCR)
+//!    via the VisionClient, and returns the textual analysis directly as the
+//!    tool output. No pending_images queue is used.
+//!
+//! ## Why a side-channel instead of a tool-result block (mode 1 only)
 //!
 //! OpenAI-compatible Chat Completions defines `role: "tool"` content as a
 //! plain string on most servers, so we cannot embed images in the tool
@@ -21,16 +29,22 @@
 //!
 //! ## Output
 //!
-//! On success: a small JSON confirmation containing `loaded`, `bytes`, and
-//! `media_type`. The actual image content rides on the next user turn.
+//! Mode 1 (image injection): a small JSON confirmation containing `loaded`,
+//! `bytes`, and `media_type`. The actual image content rides on the next user
+//! turn.
+//!
+//! Mode 2 (vision fallback): a JSON object containing `loaded`, `media_type`,
+//! and `analysis` (the vision model's text response).
 
 use anyhow::Result;
 use async_trait::async_trait;
 use base64::Engine as _;
 use serde_json::{json, Value};
+use std::sync::Arc;
 
 use super::super::{Tool, ToolContext, ToolOutput};
 use crate::types::ImageSource;
+use crate::vision::VisionClient;
 
 /// Maximum image size accepted by the tool (in bytes). Conservative cap to
 /// avoid blowing past per-request size limits on most vision providers and
@@ -52,7 +66,23 @@ const ALLOWED_MIME: &[&str] = &[
 ];
 
 /// `read_image` tool.
-pub struct ReadImageTool;
+///
+/// Dual-mode: see module-level documentation.
+pub struct ReadImageTool {
+    /// Whether the primary model supports native image content blocks.
+    supports_images: bool,
+    /// Optional vision model client for text-only model fallback.
+    vision_client: Option<Arc<VisionClient>>,
+}
+
+impl ReadImageTool {
+    pub fn new(supports_images: bool, vision_client: Option<Arc<VisionClient>>) -> Self {
+        Self {
+            supports_images,
+            vision_client,
+        }
+    }
+}
 
 #[async_trait]
 impl Tool for ReadImageTool {
@@ -61,7 +91,8 @@ impl Tool for ReadImageTool {
     }
 
     fn description(&self) -> &str {
-        "Load an image into the next user turn so the model can see it. \
+        "Load an image into the next user turn so the model can see it, \
+         or (for text-only models) analyze it via a vision model and return text. \
          Provide either `path` (an absolute path inside the working directory \
          or the configured attachments directory) OR `url` (an http/https URL). \
          Supported MIME types: image/png, image/jpeg, image/gif, image/webp. \
@@ -90,8 +121,8 @@ impl Tool for ReadImageTool {
         let url = input.get("url").and_then(|v| v.as_str());
 
         match (path, url) {
-            (Some(p), None) => load_from_path(p, ctx),
-            (None, Some(u)) => load_from_url(u, ctx).await,
+            (Some(p), None) => self.load_from_path(p, ctx).await,
+            (None, Some(u)) => self.load_from_url(u, ctx).await,
             (Some(_), Some(_)) => Ok(ToolOutput::error(
                 "Provide either `path` or `url`, not both",
             )),
@@ -102,198 +133,196 @@ impl Tool for ReadImageTool {
     }
 }
 
-/// Load an image from a local filesystem path.
-fn load_from_path(path_str: &str, ctx: &ToolContext<'_>) -> Result<ToolOutput> {
-    let path = std::path::Path::new(path_str);
+impl ReadImageTool {
+    /// Load an image from a local filesystem path.
+    async fn load_from_path(&self, path_str: &str, ctx: &ToolContext<'_>) -> Result<ToolOutput> {
+        let path = std::path::Path::new(path_str);
 
-    if !path.is_absolute() {
-        return Ok(ToolOutput::error(format!(
-            "`path` must be absolute, got: {}",
-            path_str
-        )));
-    }
-
-    if !path.exists() {
-        return Ok(ToolOutput::error(format!("Path not found: {}", path_str)));
-    }
-    if !path.is_file() {
-        return Ok(ToolOutput::error(format!(
-            "Path is not a regular file: {}",
-            path_str
-        )));
-    }
-
-    // Boundary check: path must lie under working_dir or one of the
-    // additional_read_roots. Canonicalize both sides to defeat `..`-based
-    // escapes; tolerate non-canonical roots (defensive).
-    let canonical = path
-        .canonicalize()
-        .unwrap_or_else(|_| path.to_path_buf());
-    let working_canonical = ctx
-        .working_dir
-        .canonicalize()
-        .unwrap_or_else(|_| ctx.working_dir.to_path_buf());
-
-    let mut allowed = canonical.starts_with(&working_canonical);
-    if !allowed {
-        for root in &ctx.additional_read_roots {
-            let root_canonical = root.canonicalize().unwrap_or_else(|_| root.clone());
-            if canonical.starts_with(&root_canonical) {
-                allowed = true;
-                break;
-            }
-        }
-    }
-    if !allowed {
-        return Ok(ToolOutput::error(format!(
-            "Access denied: path '{}' is outside the working directory and configured attachment roots",
-            path_str
-        )));
-    }
-
-    // Detect MIME from extension. Keep it simple — we don't sniff content.
-    let media_type = match path
-        .extension()
-        .and_then(|e| e.to_str())
-        .map(|e| e.to_lowercase())
-    {
-        Some(ref e) if e == "png" => "image/png",
-        Some(ref e) if e == "jpg" || e == "jpeg" => "image/jpeg",
-        Some(ref e) if e == "gif" => "image/gif",
-        Some(ref e) if e == "webp" => "image/webp",
-        Some(ref e) => {
+        if !path.is_absolute() {
             return Ok(ToolOutput::error(format!(
-                "Unsupported image extension: .{}. Supported: png, jpg, jpeg, gif, webp",
-                e
-            )));
-        }
-        None => {
-            return Ok(ToolOutput::error(format!(
-                "File has no extension; cannot determine image type: {}",
+                "`path` must be absolute, got: {}",
                 path_str
             )));
         }
-    };
 
-    let bytes = match std::fs::read(path) {
-        Ok(b) => b,
-        Err(e) => return Ok(ToolOutput::error(format!("Failed to read file: {e}"))),
-    };
+        if !path.exists() {
+            return Ok(ToolOutput::error(format!("Path not found: {}", path_str)));
+        }
+        if !path.is_file() {
+            return Ok(ToolOutput::error(format!(
+                "Path is not a regular file: {}",
+                path_str
+            )));
+        }
 
-    if bytes.len() > MAX_IMAGE_BYTES {
-        return Ok(ToolOutput::error(format!(
-            "Image too large: {} bytes (max {} bytes)",
-            bytes.len(),
-            MAX_IMAGE_BYTES
-        )));
+        // Boundary check: path must lie under working_dir or one of the
+        // additional_read_roots.
+        let canonical = path
+            .canonicalize()
+            .unwrap_or_else(|_| path.to_path_buf());
+        let working_canonical = ctx
+            .working_dir
+            .canonicalize()
+            .unwrap_or_else(|_| ctx.working_dir.to_path_buf());
+
+        let mut allowed = canonical.starts_with(&working_canonical);
+        if !allowed {
+            for root in &ctx.additional_read_roots {
+                let root_canonical = root.canonicalize().unwrap_or_else(|_| root.clone());
+                if canonical.starts_with(&root_canonical) {
+                    allowed = true;
+                    break;
+                }
+            }
+        }
+        if !allowed {
+            return Ok(ToolOutput::error(format!(
+                "Access denied: path '{}' is outside the working directory and configured attachment roots",
+                path_str
+            )));
+        }
+
+        // Detect MIME from extension.
+        let media_type = match path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_lowercase())
+        {
+            Some(ref e) if e == "png" => "image/png",
+            Some(ref e) if e == "jpg" || e == "jpeg" => "image/jpeg",
+            Some(ref e) if e == "gif" => "image/gif",
+            Some(ref e) if e == "webp" => "image/webp",
+            Some(ref e) => {
+                return Ok(ToolOutput::error(format!(
+                    "Unsupported image extension: .{}. Supported: png, jpg, jpeg, gif, webp",
+                    e
+                )));
+            }
+            None => {
+                return Ok(ToolOutput::error(format!(
+                    "File has no extension; cannot determine image type: {}",
+                    path_str
+                )));
+            }
+        };
+
+        let bytes = match std::fs::read(path) {
+            Ok(b) => b,
+            Err(e) => return Ok(ToolOutput::error(format!("Failed to read file: {e}"))),
+        };
+
+        self.process_image(media_type, bytes, path_str, ctx).await
     }
 
-    let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
-    let size = bytes.len();
+    /// Fetch an image from an http(s) URL and process it.
+    async fn load_from_url(&self, url: &str, ctx: &ToolContext<'_>) -> Result<ToolOutput> {
+        if !(url.starts_with("http://") || url.starts_with("https://")) {
+            return Ok(ToolOutput::error(format!(
+                "URL must be http or https, got: {}",
+                url
+            )));
+        }
 
-    push_pending(
-        ctx,
-        ImageSource::Base64 {
-            media_type: media_type.to_string(),
-            data,
-        },
-    );
+        let client = match reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+        {
+            Ok(c) => c,
+            Err(e) => return Ok(ToolOutput::error(format!("HTTP client init failed: {e}"))),
+        };
 
-    Ok(ToolOutput::success(
-        json!({
-            "loaded": path_str,
-            "bytes": size,
-            "media_type": media_type,
-            "note": "Image queued for next user turn",
-        })
-        .to_string(),
-    ))
-}
+        let resp = match client.get(url).send().await {
+            Ok(r) => r,
+            Err(e) => return Ok(ToolOutput::error(format!("Failed to GET {url}: {e}"))),
+        };
+        if !resp.status().is_success() {
+            return Ok(ToolOutput::error(format!(
+                "HTTP {} fetching {url}",
+                resp.status()
+            )));
+        }
 
-/// Fetch an image from an http(s) URL and queue it.
-///
-/// Two transmission modes:
-/// - For providers that natively accept remote URLs (Anthropic, OpenAI), we
-///   could pass the URL through verbatim. But not every URL is reachable
-///   from the provider's network and some providers strip data:URLs from
-///   `image_url`. To keep behavior consistent and offline-friendly, we
-///   fetch + base64 here.
-async fn load_from_url(url: &str, ctx: &ToolContext<'_>) -> Result<ToolOutput> {
-    if !(url.starts_with("http://") || url.starts_with("https://")) {
-        return Ok(ToolOutput::error(format!(
-            "URL must be http or https, got: {}",
-            url
-        )));
+        // Use Content-Type for media_type
+        let media_type = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.split(';').next().unwrap_or(s).trim().to_string())
+            .unwrap_or_else(|| "application/octet-stream".to_string());
+
+        if !ALLOWED_MIME.iter().any(|m| *m == media_type) {
+            return Ok(ToolOutput::error(format!(
+                "Unsupported Content-Type: {media_type}. Supported: {}",
+                ALLOWED_MIME.join(", ")
+            )));
+        }
+
+        let bytes = match resp.bytes().await {
+            Ok(b) => b.to_vec(),
+            Err(e) => return Ok(ToolOutput::error(format!("Failed to read response body: {e}"))),
+        };
+
+        self.process_image(&media_type, bytes, url, ctx).await
     }
 
-    let client = match reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-    {
-        Ok(c) => c,
-        Err(e) => return Ok(ToolOutput::error(format!("HTTP client init failed: {e}"))),
-    };
+    /// Process loaded image bytes according to the current mode.
+    ///
+    /// `input_str` is the original path or URL for display in the response.
+    async fn process_image(&self, media_type: &str, bytes: Vec<u8>, input_str: &str, ctx: &ToolContext<'_>) -> Result<ToolOutput> {
+        if bytes.len() > MAX_IMAGE_BYTES {
+            return Ok(ToolOutput::error(format!(
+                "Image too large: {} bytes (max {} bytes)",
+                bytes.len(),
+                MAX_IMAGE_BYTES
+            )));
+        }
 
-    let resp = match client.get(url).send().await {
-        Ok(r) => r,
-        Err(e) => return Ok(ToolOutput::error(format!("Failed to GET {url}: {e}"))),
-    };
-    if !resp.status().is_success() {
-        return Ok(ToolOutput::error(format!(
-            "HTTP {} fetching {url}",
-            resp.status()
-        )));
+        if self.supports_images {
+            // Mode 1: Image injection — queue for next user turn
+            let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
+            let size = bytes.len();
+            push_pending(
+                ctx,
+                ImageSource::Base64 {
+                    media_type: media_type.to_string(),
+                    data,
+                },
+            );
+            Ok(ToolOutput::success(
+                json!({
+                    "loaded": input_str,
+                    "bytes": size,
+                    "media_type": media_type,
+                    "note": "Image queued for next user turn",
+                })
+                .to_string(),
+            ))
+        } else if let Some(vc) = &self.vision_client {
+            // Mode 2: Vision fallback — send to vision model
+            let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
+            match vc.analyze(media_type, &data).await {
+                Ok(text) => Ok(ToolOutput::success(
+                    json!({
+                        "loaded": input_str,
+                        "media_type": media_type,
+                        "analysis": text,
+                        "note": "Image analyzed via vision model",
+                    })
+                    .to_string(),
+                )),
+                Err(e) => Ok(ToolOutput::error(format!(
+                    "Vision analysis failed: {e}"
+                ))),
+            }
+        } else {
+            // No vision capability available
+            Ok(ToolOutput::error(
+                "The current model does not support images and no vision \
+                 fallback model is configured. Set [agent.vision] in \
+                 config.toml to enable image analysis via a separate vision model.",
+            ))
+        }
     }
-
-    // Use Content-Type for media_type — required by both Anthropic base64 and
-    // OpenAI data: URL forms. Sniff is intentionally avoided (extra deps,
-    // marginal value over server-declared type).
-    let media_type = resp
-        .headers()
-        .get(reqwest::header::CONTENT_TYPE)
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.split(';').next().unwrap_or(s).trim().to_string())
-        .unwrap_or_else(|| "application/octet-stream".to_string());
-
-    if !ALLOWED_MIME.iter().any(|m| *m == media_type) {
-        return Ok(ToolOutput::error(format!(
-            "Unsupported Content-Type: {media_type}. Supported: {}",
-            ALLOWED_MIME.join(", ")
-        )));
-    }
-
-    let bytes = match resp.bytes().await {
-        Ok(b) => b,
-        Err(e) => return Ok(ToolOutput::error(format!("Failed to read response body: {e}"))),
-    };
-    if bytes.len() > MAX_IMAGE_BYTES {
-        return Ok(ToolOutput::error(format!(
-            "Image too large: {} bytes (max {} bytes)",
-            bytes.len(),
-            MAX_IMAGE_BYTES
-        )));
-    }
-
-    let data = base64::engine::general_purpose::STANDARD.encode(&bytes);
-    let size = bytes.len();
-
-    push_pending(
-        ctx,
-        ImageSource::Base64 {
-            media_type: media_type.clone(),
-            data,
-        },
-    );
-
-    Ok(ToolOutput::success(
-        json!({
-            "loaded": url,
-            "bytes": size,
-            "media_type": media_type,
-            "note": "Image queued for next user turn",
-        })
-        .to_string(),
-    ))
 }
 
 fn push_pending(ctx: &ToolContext<'_>, src: ImageSource) {

--- a/crates/jyc-agent/src/tools/mod.rs
+++ b/crates/jyc-agent/src/tools/mod.rs
@@ -32,6 +32,13 @@ pub struct ToolContext<'a> {
     /// images. `Mutex<Vec<_>>` to allow tools with `&self` execution to
     /// push without requiring `&mut ToolContext`.
     pub pending_images: Mutex<Vec<ImageSource>>,
+    /// Whether the active pattern allows image handling. Mirrors the
+    /// `inject_inbound_images` flag that `build_user_blocks` checks in
+    /// `service.rs`. When `false`, `read_image` should refuse to process
+    /// images even if a `VisionClient` is configured, ensuring consistent
+    /// behavior between auto-injection and tool-driven image analysis.
+    /// Default: `false` (opt-in for safety).
+    pub pattern_inject_images: bool,
 }
 
 impl<'a> ToolContext<'a> {
@@ -41,6 +48,7 @@ impl<'a> ToolContext<'a> {
             working_dir,
             additional_read_roots: Vec::new(),
             pending_images: Mutex::new(Vec::new()),
+            pattern_inject_images: false,
         }
     }
 
@@ -50,9 +58,9 @@ impl<'a> ToolContext<'a> {
             working_dir,
             additional_read_roots,
             pending_images: Mutex::new(Vec::new()),
+            pattern_inject_images: false,
         }
     }
-
     /// Drain and return any pending image sources accumulated during the
     /// current tool-execution batch. Called by the agent loop after the
     /// batch completes.

--- a/crates/jyc-agent/src/types.rs
+++ b/crates/jyc-agent/src/types.rs
@@ -215,6 +215,27 @@ pub struct ModelConfig {
     pub params: Option<serde_json::Value>,
 }
 
+/// Vision model configuration for the `read_image` tool fallback.
+///
+/// When the primary model does not support images (`supports_images = false`),
+/// the `read_image` tool uses this configuration to call an independent vision
+/// model (e.g., DeepSeek-OCR) to analyze images and return text descriptions.
+///
+/// The `provider` field references a named entry in `[agent.providers.xxx]`
+/// to reuse its `base_url` and `api_key_env`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VisionConfig {
+    /// Whether vision fallback is enabled (default: false)
+    #[serde(default)]
+    pub enabled: bool,
+    /// Name of the provider in `[agent.providers]` to use for vision calls
+    pub provider: String,
+    /// Model identifier (e.g., "deepseek-ocr")
+    pub model: String,
+    /// Optional custom prompt for the vision model
+    pub prompt: Option<String>,
+}
+
 /// Agent configuration section from config.toml.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentConfig {
@@ -234,6 +255,9 @@ pub struct AgentConfig {
     /// When exceeded, agent sends progress reply, resets counter, and continues.
     #[serde(default = "default_max_iterations")]
     pub max_iterations: usize,
+    /// Vision fallback configuration for text-only models to use an external
+    /// vision model (e.g., DeepSeek-OCR) for image analysis via `read_image`.
+    pub vision: Option<VisionConfig>,
 }
 
 impl Default for AgentConfig {
@@ -243,6 +267,7 @@ impl Default for AgentConfig {
             small_model: None,
             providers: std::collections::HashMap::new(),
             max_iterations: default_max_iterations(),
+            vision: None,
         }
     }
 }

--- a/crates/jyc-agent/src/vision.rs
+++ b/crates/jyc-agent/src/vision.rs
@@ -1,0 +1,212 @@
+//! Vision model client for the `read_image` tool fallback.
+//!
+//! When the primary model does not support images, the `read_image` tool
+//! uses `VisionClient` to call an external vision model (e.g., DeepSeek-OCR)
+//! via an OpenAI-compatible `/chat/completions` endpoint. The raw text result
+//! is returned to the primary model as a tool output.
+//!
+//! ## Design
+//!
+//! - Single-shot, non-streaming HTTP request — no streaming, no tool calls,
+//!   no session management.
+//! - Uses the OpenAI-compatible `image_url` content block format.
+//! - Reuses provider `base_url` and `api_key` from the main provider config,
+//!   so users don't duplicate credentials.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+/// A lightweight, stateless client that sends images to a vision model and
+/// returns the textual analysis.
+pub struct VisionClient {
+    /// API base URL (e.g., "https://api.deepseek.com")
+    base_url: String,
+    /// API key for authentication
+    api_key: String,
+    /// Model identifier (e.g., "deepseek-ocr")
+    model: String,
+    /// Optional custom prompt sent alongside the image
+    prompt: String,
+    /// HTTP client with timeout
+    client: reqwest::Client,
+}
+
+impl VisionClient {
+    /// Create a new `VisionClient`.
+    ///
+    /// `base_url`, `api_key`, and `model` are resolved from the provider
+    /// referenced by `VisionConfig.provider`. `prompt` falls back to a
+    /// sensible default if not configured.
+    pub fn new(base_url: String, api_key: String, model: String, prompt: Option<String>) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(120))
+            .build()
+            .expect("VisionClient: failed to build reqwest::Client");
+
+        Self {
+            base_url,
+            api_key,
+            model,
+            prompt: prompt.unwrap_or_else(|| {
+                "Please carefully examine this image and describe its contents \
+                 in detail. If there is any text, extract it verbatim."
+                    .to_string()
+            }),
+            client,
+        }
+    }
+
+    /// Analyze an image by sending it to the vision model.
+    ///
+    /// `media_type` is the MIME type (e.g., "image/png") and `base64_data`
+    /// is the raw base64-encoded image bytes (without `data:` prefix).
+    ///
+    /// Returns the model's text response.
+    pub async fn analyze(&self, media_type: &str, base64_data: &str) -> Result<String> {
+        let url = format!(
+            "{}/chat/completions",
+            self.base_url.trim_end_matches('/')
+        );
+
+        let data_url = format!("data:{};base64,{}", media_type, base64_data);
+
+        let body = ChatCompletionRequest {
+            model: self.model.clone(),
+            messages: vec![Message {
+                role: "user".to_string(),
+                content: vec![ContentPart {
+                    r#type: "text".to_string(),
+                    text: Some(self.prompt.clone()),
+                    image_url: None,
+                }],
+            }],
+        };
+
+        // Build request with image_url as a separate content part
+        let request_body = serde_json::json!({
+            "model": self.model,
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": self.prompt},
+                    {"type": "image_url", "image_url": {"url": data_url}}
+                ]
+            }],
+            "stream": false
+        });
+
+        let resp = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Content-Type", "application/json")
+            .json(&request_body)
+            .send()
+            .await
+            .context("VisionClient: HTTP request failed")?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body_text = resp.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "VisionClient: HTTP {} from {}: {}",
+                status,
+                url,
+                body_text
+            );
+        }
+
+        let chat_resp: ChatCompletionResponse = resp
+            .json()
+            .await
+            .context("VisionClient: failed to parse response JSON")?;
+
+        let content = chat_resp
+            .choices
+            .first()
+            .and_then(|c| c.message.content.as_deref())
+            .unwrap_or("")
+            .to_string();
+
+        Ok(content)
+    }
+}
+
+// ── OpenAI-compatible chat completion types ──
+
+#[derive(Debug, Serialize)]
+struct ChatCompletionRequest {
+    model: String,
+    messages: Vec<Message>,
+}
+
+#[derive(Debug, Serialize)]
+struct Message {
+    role: String,
+    content: Vec<ContentPart>,
+}
+
+#[derive(Debug, Serialize)]
+struct ContentPart {
+    #[serde(rename = "type")]
+    r#type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    image_url: Option<ImageUrl>,
+}
+
+#[derive(Debug, Serialize)]
+struct ImageUrl {
+    url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionResponse {
+    choices: Vec<Choice>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Choice {
+    message: ResponseMessage,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResponseMessage {
+    content: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verify that the request body is serialized as expected.
+    #[test]
+    fn test_request_body_format() {
+        let body = serde_json::json!({
+            "model": "deepseek-ocr",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe this image"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw0KGgo="}}
+                ]
+            }],
+            "stream": false
+        });
+
+        let parsed = body.as_object().unwrap();
+        assert_eq!(parsed["model"], "deepseek-ocr");
+        assert_eq!(parsed["stream"], false);
+
+        let msg = &parsed["messages"].as_array().unwrap()[0];
+        assert_eq!(msg["role"], "user");
+
+        let content = msg["content"].as_array().unwrap();
+        assert_eq!(content[0]["type"], "text");
+        assert_eq!(content[0]["text"], "describe this image");
+        assert_eq!(content[1]["type"], "image_url");
+        assert!(content[1]["image_url"]["url"].as_str().unwrap().starts_with("data:image/png;base64,"));
+    }
+}

--- a/crates/jyc-agent/src/vision.rs
+++ b/crates/jyc-agent/src/vision.rs
@@ -14,7 +14,7 @@
 //!   so users don't duplicate credentials.
 
 use anyhow::{Context, Result};
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::time::Duration;
 
 /// A lightweight, stateless client that sends images to a vision model and
@@ -71,19 +71,7 @@ impl VisionClient {
 
         let data_url = format!("data:{};base64,{}", media_type, base64_data);
 
-        let body = ChatCompletionRequest {
-            model: self.model.clone(),
-            messages: vec![Message {
-                role: "user".to_string(),
-                content: vec![ContentPart {
-                    r#type: "text".to_string(),
-                    text: Some(self.prompt.clone()),
-                    image_url: None,
-                }],
-            }],
-        };
-
-        // Build request with image_url as a separate content part
+        // Build request with text prompt + image_url content blocks
         let request_body = serde_json::json!({
             "model": self.model,
             "messages": [{
@@ -133,34 +121,7 @@ impl VisionClient {
     }
 }
 
-// ── OpenAI-compatible chat completion types ──
-
-#[derive(Debug, Serialize)]
-struct ChatCompletionRequest {
-    model: String,
-    messages: Vec<Message>,
-}
-
-#[derive(Debug, Serialize)]
-struct Message {
-    role: String,
-    content: Vec<ContentPart>,
-}
-
-#[derive(Debug, Serialize)]
-struct ContentPart {
-    #[serde(rename = "type")]
-    r#type: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    text: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    image_url: Option<ImageUrl>,
-}
-
-#[derive(Debug, Serialize)]
-struct ImageUrl {
-    url: String,
-}
+// ── OpenAI-compatible chat completion response types ──
 
 #[derive(Debug, Deserialize)]
 struct ChatCompletionResponse {

--- a/crates/jyc-agent/tests/unit_tests.rs
+++ b/crates/jyc-agent/tests/unit_tests.rs
@@ -656,6 +656,7 @@ mod skills {
             vec![],
             vec![],
             None,
+            None,
         )
     }
 

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -232,12 +232,42 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     .filter_map(|c| c.patterns.clone())
                     .flatten()
                     .collect();
+                // Build optional VisionClient for vision fallback
+                let vision_client: Option<std::sync::Arc<jyc_agent::vision::VisionClient>> = {
+                    agent_config.vision.as_ref()
+                        .filter(|v| v.enabled)
+                        .and_then(|v| {
+                            let provider_def = agent_config.providers.get(&v.provider)?;
+                            let base_url = provider_def.base_url.clone()
+                                .unwrap_or_else(|| "https://api.deepseek.com".to_string());
+                            let api_key_env = provider_def.api_key_env.clone()
+                                .unwrap_or_else(|| "DEEPSEEK_API_KEY".to_string());
+                            let api_key = std::env::var(&api_key_env).unwrap_or_default();
+                            if api_key.is_empty() {
+                                tracing::warn!(
+                                    provider = %v.provider,
+                                    api_key_env = %api_key_env,
+                                    "Vision fallback: API key not found in environment"
+                                );
+                                return None;
+                            }
+                            Some(std::sync::Arc::new(
+                                jyc_agent::vision::VisionClient::new(
+                                    base_url,
+                                    api_key,
+                                    v.model.clone(),
+                                    v.prompt.clone(),
+                                )
+                            ))
+                        })
+                };
                 Arc::new(JycAgentService::new(
                     agent_cfg,
                     workdir.to_path_buf(),
                     config_snapshot.mcps.clone(),
                     all_patterns,
                     inbound_attachment_config.clone(),
+                    vision_client,
                 ))
             }
             "static" => {

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -217,6 +217,12 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     small_model: agent_config.small_model.clone(),
                     providers,
                     max_iterations: agent_config.max_iterations,
+                    vision: agent_config.vision.clone().map(|v| jyc_agent::types::VisionConfig {
+                        enabled: v.enabled,
+                        provider: v.provider,
+                        model: v.model,
+                        prompt: v.prompt,
+                    }),
                 };
                 // Flatten patterns from all channels so the agent can look up
                 // per-pattern flags (e.g. inject_inbound_images) by

--- a/crates/jyc-types/src/config.rs
+++ b/crates/jyc-types/src/config.rs
@@ -190,6 +190,27 @@ impl Default for MonitorConfig {
     }
 }
 
+/// Vision model configuration for the `read_image` tool fallback.
+///
+/// When the primary model does not support images (`supports_images = false`),
+/// the `read_image` tool uses this configuration to call an independent vision
+/// model (e.g., DeepSeek-OCR) to analyze images and return text descriptions.
+///
+/// The `provider` field references a named entry in `[agent.providers.xxx]`
+/// to reuse its `base_url` and `api_key_env`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct VisionConfig {
+    /// Whether vision fallback is enabled (default: false)
+    #[serde(default)]
+    pub enabled: bool,
+    /// Name of the provider in `[agent.providers]` to use for vision calls
+    pub provider: String,
+    /// Model identifier (e.g., "deepseek-ocr")
+    pub model: String,
+    /// Optional custom prompt for the vision model (e.g., "请仔细识别并提取图片中的所有文字内容")
+    pub prompt: Option<String>,
+}
+
 /// Agent configuration — how the AI responds to messages.
 #[derive(Debug, Clone, Deserialize)]
 pub struct AgentConfig {
@@ -232,6 +253,9 @@ pub struct AgentConfig {
     #[serde(default)]
     pub providers: std::collections::HashMap<String, ProviderDef>,
 
+    /// Vision fallback configuration for text-only models to use an external
+    /// vision model (e.g., DeepSeek-OCR) for image analysis via `read_image`.
+    pub vision: Option<VisionConfig>,
 }
 
 /// Provider definition for the in-process agent.


### PR DESCRIPTION
## Spec

`read_image` 工具从"仅视觉模型可用"扩展为双模式：当主模型支持图片时直接多模态注入（现有行为）；当主模型不支持图片时，通过配置的独立视觉模型（如 DeepSeek-OCR）读取图片内容，以文本形式返回结果。同时在 prompt 中注入图片文件路径，让 LLM 知道有哪些图片可用。

**关键设计**：双模式判断发生在 `ReadImageTool::execute()` 内部，无论是初始注入还是 LLM 主动调用，都统一走同一条执行路径。

Fixes #207

## Implementation Plan

### Step 1: 新增 VisionConfig 配置结构（jyc-types + jyc-agent）
**What:** 
- `crates/jyc-types/src/config.rs`: `AgentConfig` 新增 `vision: Option<VisionConfig>` 字段，`VisionConfig` 包含 `enabled`, `provider`, `model`, `prompt`
- `crates/jyc-agent/src/types.rs`: 同步新增 `VisionConfig` 到 `AgentConfig`
- `crates/jyc-cli/src/cli/monitor.rs`: 转换 vision 配置从 `jyc_types` 到 `jyc_agent`
**Why:** 为 vision fallback 提供配置入口，`provider` 字段引用已有的 `[agent.providers.xxx]` 定义复用 base_url/api_key_env
**Verify:** `cargo check -p jyc-types -p jyc-agent -p jyc-cli`

### Step 2: 实现 VisionClient（新文件 jyc-agent/src/vision.rs）
**What:**
- 新建 `crates/jyc-agent/src/vision.rs`
- `VisionClient` 结构体：`base_url`, `api_key`, `model`, `prompt`
- `analyze(&self, media_type: &str, base64_data: &str) -> Result<String>` 方法
- 内部调用 OpenAI-compatible `/chat/completions`，非流式单次请求
- 请求 body：含 `image_url` content block + 文本 prompt
- 解析响应 `choices[0].message.content`
**Why:** 封装对视觉模型的 HTTP 调用，与主 provider 体系解耦，保持简单
**Verify:** `cargo check -p jyc-agent`，确认无编译错误

### Step 3: 修改 ReadImageTool 为双模式（read_image.rs + mod.rs）
**What:**
- `ReadImageTool` 增加两个字段：`supports_images: bool` 和 `vision_client: Option<Arc<VisionClient>>`
- `execute()` 方法根据 `supports_images` 分流：
  - `true` → 现有逻辑：加载图片 → base64 → 推入 `pending_images` → 返回确认
  - `false` + vision_client → 加载图片 → 调 `vision_client.analyze()` → 返回文本结果
  - `false` + 无 vision_client → 返回错误提示"未配置 vision model"
- `crates/jyc-agent/src/tools/builtin/mod.rs`: `register_read_image` 签名改为 `fn register_read_image(registry: &mut ToolRegistry, supports_images: bool, vision_client: Option<Arc<VisionClient>>)`
**Why:** 核心变更。`execute()` 是唯一入口，LLM 主动调用 `read_image` 工具时同样经过此判断，自然 fallback 到视觉模型
**Verify:** `cargo check -p jyc-agent`

### Step 4: 修改 build_user_blocks 为非视觉模型注入文件路径（service.rs）
**What:**
- `build_user_blocks()` 方法：当 `!supports_images && pattern_inject` 时，不再直接 return
- 改为在 text block 末尾追加图片文件路径列表
- 格式示例：
  ```
  Image attachments available (use read_image tool to analyze):
  - /path/to/img1.jpg
  - /path/to/img2.png
  ```
**Why:** 让 LLM 知道哪些图片文件可用，引导其调用 `read_image` 工具读取；LLM 调用时同样走 Step 3 的双模式逻辑
**Verify:** `cargo check -p jyc-agent`

### Step 5: 修改 build_tool_registry 始终注册 read_image（service.rs）
**What:**
- `build_tool_registry()`：移除 `if supports_images` 条件，始终调用 `register_read_image`
- 传入 `supports_images` 和 `vision_client` 参数
- `JycAgentService` 在构造函数中接收 `VisionClient`（从 monitor 传入）
**Why:** read_image 对文本模型也可用（通过 vision fallback），让 LLM 在 tool schema 中始终能看到此工具
**Verify:** `cargo check -p jyc-agent`

### Step 6: 更新 config.example.toml
**What:**
- 新增 `[agent.vision]` 配置段示例：
  ```toml
  [agent.vision]
  enabled = true
  provider = "deepseek"
  model = "deepseek-ocr"
  # prompt = "请仔细识别并提取图片中的所有文字内容"
  ```
- 更新 `read_image` 工具的注释说明
**Why:** 文档化新功能，用户参考即可配置
**Verify:** `cat config.example.toml` 确认格式正确

## Design Decisions
- **复用已有 provider 配置**：`[agent.vision].provider` 引用 `[agent.providers.xxx]` 获取 base_url 和 api_key，避免重复配置
- **VisionClient 轻量化**：不做流式、不做 tool call、不做 session 管理，仅做单次 HTTP 请求-响应，与主 provider 体系隔离
- **read_image 始终注册**：无论主模型是否支持图片，read_image 都注册。拒绝在运行时动态注册/注销工具（保持 tool schema 诚实性）
- **双模式判断发生在 execute() 而非注册时**：`supports_images` 通过 `ReadImageTool` 字段传入，运行时判断。LLM 通过工具调用 `read_image` 和初始注入走同一路径，行为和结果完全一致