### PR TITLE
feat: per-pattern and per-channel model configuration

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -36,9 +36,20 @@ folder = "INBOX"
 # [channels.jiny283.footer]
 # enabled = true
 
+# Per-channel model override: takes priority over global [agent].model,
+# but below per-pattern model override.
+# model = "anthropic/claude-opus-4-6"
+# small_model = "deepseek/deepseek-v4-flash"
+
 [[channels.jiny283.patterns]]
 name = "xxx"
 enabled = true
+
+# Per-pattern model override: takes priority over channel-level and global
+# [agent].model, but below the runtime .jyc/model-override file.
+# model = "anthropic/claude-opus-4-6"
+# small_model = "deepseek/deepseek-v4-flash"
+
 # Live message injection: when true (default), follow-up messages arriving
 # while AI is processing are injected into the active session immediately.
 # When false, messages queue and are processed sequentially (one at a time).
@@ -158,7 +169,9 @@ mode = "agent"
 # mode = "static"
 # text = "Thank you for your message."
 
-# Model identifier (e.g., "SiliconFlow/Pro/zai-org/GLM-4.7")
+# Model identifier (e.g., "SiliconFlow/Pro/zai-org/GLM-4.7").
+# This is the lowest-priority fallback in the resolution chain:
+#   .jyc/model-override > pattern-level model > channel-level model > global [agent].model
 # model = "ark/deepseek-v3.2"
 
 # Optional: a smaller / faster model used for ancillary LLM work, currently:
@@ -167,6 +180,7 @@ mode = "agent"
 #     the model's context window)
 # Falls back to `model` if unset, or if provider construction fails (logged
 # as a warning, the agent continues).
+# Resolution chain: pattern-level small_model > channel-level small_model > global [agent].small_model
 # small_model = "deepseek/deepseek-v4-flash"
 
 system_prompt = "You are an AI assistant. Respond professionally and concisely."

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -604,9 +604,12 @@ impl AgentService for JycAgentService {
             "Processing message with in-process agent"
         );
 
-        // 1. Read model override if present
+        // 1. Read model override with priority:
+        //    a) .jyc/model-override file (highest priority, manual runtime override)
+        //    b) Pattern-level model (from matched pattern config)
+        //    c) Config-level model (from self.config.model, i.e. global or channel-level)
         let model_override_path = thread_path.join(".jyc").join("model-override");
-        let model_override = if model_override_path.exists() {
+        let file_override = if model_override_path.exists() {
             tokio::fs::read_to_string(&model_override_path)
                 .await
                 .ok()
@@ -615,6 +618,12 @@ impl AgentService for JycAgentService {
         } else {
             None
         };
+        let pattern_override = message.matched_pattern.as_deref()
+            .and_then(|name| self.patterns.iter().find(|p| p.name == name))
+            .and_then(|p| p.model.as_deref());
+        let model_override = file_override.clone()
+            .or_else(|| pattern_override.map(|s| s.to_string()))
+            .or_else(|| self.config.model.clone());
 
         // 2. Create provider
         let provider = self.create_provider(model_override.as_deref())
@@ -626,11 +635,17 @@ impl AgentService for JycAgentService {
             "Using provider"
         );
 
-        // 2b. Optionally create the small provider for ancillary calls
-        //     (cycle-boundary progress summary, between-message context
-        //     reset). Construction failures are non-fatal — log a warning
-        //     and fall back to the main provider for those calls.
-        let small_provider: Option<Box<dyn provider::Provider>> = self.config.small_model
+        // 2b. Resolve small_model with priority:
+        //     1. Pattern-level small_model (from matched pattern config)
+        //     2. Config-level small_model (from self.config.small_model, already
+        //        channel-resolved or global fallback)
+        //     Falls back to main model at call site if unset or construction fails.
+        let pattern_small_model = message.matched_pattern.as_deref()
+            .and_then(|name| self.patterns.iter().find(|p| p.name == name))
+            .and_then(|p| p.small_model.as_deref());
+        let small_model_resolved = pattern_small_model
+            .or(self.config.small_model.as_deref());
+        let small_provider: Option<Box<dyn provider::Provider>> = small_model_resolved
             .as_deref()
             .and_then(|m| match provider::create_provider(m, &self.config.providers) {
                 Ok(p) => {
@@ -713,7 +728,6 @@ impl AgentService for JycAgentService {
         // 9. Update session token tracking
         // Resolve context_window: per-model override > provider default
         let model_str = model_override.as_deref()
-            .or(self.config.model.as_deref())
             .unwrap_or("");
         let context_window = if let Some((provider_name, model_id)) = model_str.split_once('/') {
             self.config.providers.get(provider_name).and_then(|p| {

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -185,10 +185,15 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
         tracing::info!(channel = %channel_name, channel_type = %channel_type, "Outbound connected");
 
         // Create agent based on configured mode
+        // Resolve effective model per-channel: channel-level override beats global
+        let effective_model = channel_config.model.clone()
+            .or_else(|| agent_config.model.clone());
+        let effective_small_model = channel_config.small_model.clone()
+            .or_else(|| agent_config.small_model.clone());
         let agent: Arc<dyn AgentService> = match agent_config.mode.as_str() {
             "agent" => {
                 // In-process agent
-                let model = agent_config.model.clone();
+                let model = effective_model;
                 tracing::info!(channel = %channel_name, model = ?model, "Using agent: jyc-agent (in-process)");
                 let providers = agent_config.providers.iter()
                     .map(|(name, def)| {
@@ -214,7 +219,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     .collect();
                 let agent_cfg = jyc_agent::types::AgentConfig {
                     model,
-                    small_model: agent_config.small_model.clone(),
+                    small_model: effective_small_model.clone(),
                     providers,
                     max_iterations: agent_config.max_iterations,
                     vision: agent_config.vision.clone().map(|v| jyc_agent::types::VisionConfig {

--- a/crates/jyc-types/src/channel.rs
+++ b/crates/jyc-types/src/channel.rs
@@ -296,6 +296,16 @@ pub struct ChannelPattern {
     /// must use the `read_image` built-in tool to load them on demand.
     #[serde(default)]
     pub inject_inbound_images: bool,
+    /// Override model for this pattern's thread (e.g., "anthropic/claude-opus-4-6").
+    /// Takes priority over channel-level model and global [agent].model,
+    /// but below the runtime `.jyc/model-override` file.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Override small_model for this pattern's thread.
+    /// Takes priority over channel-level small_model and global [agent].small_model,
+    /// but below the runtime `.jyc/model-override` file.
+    #[serde(default)]
+    pub small_model: Option<String>,
 }
 
 impl Default for ChannelPattern {
@@ -313,6 +323,8 @@ impl Default for ChannelPattern {
             live_injection: true,
             repo_group: None,
             inject_inbound_images: false,
+            model: None,
+            small_model: None,
         }
     }
 }

--- a/crates/jyc-types/src/config.rs
+++ b/crates/jyc-types/src/config.rs
@@ -126,6 +126,15 @@ pub struct ChannelConfig {
     /// Channel-specific agent config override
     pub agent: Option<AgentConfig>,
 
+    /// Override model for this channel (e.g., "anthropic/claude-opus-4-6").
+    /// Takes priority over global [agent].model, but below pattern-level model.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// Override small_model for this channel.
+    /// Takes priority over global [agent].small_model, but below pattern-level small_model.
+    #[serde(default)]
+    pub small_model: Option<String>,
+
     /// Footer display configuration (omit for default: footer enabled)
     pub footer: Option<FooterConfig>,
 }


### PR DESCRIPTION
## Spec

Allow configuring `model` and `small_model` at the channel level and pattern (thread) level in `config.toml`. Currently only the global `[agent].model` is used; the channel-level `agent` override is declared but not wired up, and pattern-level model configuration does not exist. This PR wires up the full resolution chain with a clear priority.

**Model resolution priority (highest to lowest):**
1. `.jyc/model-override` file in thread directory (runtime manual override, already exists)
2. Pattern-level `model` / `small_model` (NEW)
3. Channel-level `model` / `small_model` (NEW — channel `agent` override fixed + extended)
4. Global `[agent].model` / `[agent].small_model` (existing fallback)

Fixes #209

## Implementation Plan

### Step 1: Add `model` and `small_model` fields to `ChannelPattern`
**What:** In `crates/jyc-types/src/channel.rs`, add two optional fields to `ChannelPattern`:
```rust
/// Override model for this pattern's thread (e.g., "anthropic/claude-opus-4-6")
pub model: Option<String>,
/// Override small_model for this pattern's thread
pub small_model: Option<String>,
```
Also add `#[serde(default)]` to both fields and initialize them to `None` in `Default` impl.
**Why:** This is the data model for pattern-level model override — the core of the feature.
**Verify:** `cargo build -p jyc-types` compiles. Unit tests still pass: `cargo test -p jyc-types`.

### Step 2: Add `model` and `small_model` to channel-level config and wire up in monitor
**What:** In `crates/jyc-types/src/config.rs`, add `model` and `small_model` fields to `ChannelConfig`:
```rust
pub model: Option<String>,
pub small_model: Option<String>,
```
Then in `crates/jyc-cli/src/cli/monitor.rs`, modify the agent creation section (around lines 83-226) to resolve the effective model per-channel: if `channel_config.model` is set, use it; otherwise fall back to global `agent_config.model`. Similarly for `small_model`. Pass this resolved model to `JycAgentService::new()`.

Currently `agent_config` is built once at line 83 from global config. The change should happen in the per-channel loop (line 85+), so each channel can have its own agent model override.
**Why:** Fixes the channel-level `agent` override that was declared but never wired up, and extends it with `small_model`.
**Verify:** `cargo build -p jyc-cli` compiles. Write a small TOML config test to confirm channel model override is parsed correctly.

### Step 3: Pass pattern model overrides to `JycAgentService` and resolve in `process()`
**What:** In `crates/jyc-agent/src/service.rs`, modify the `process()` method (around lines 607-618) to:
1. Look up the matched pattern from `self.patterns` using `message.matched_pattern`
2. If the pattern has `model` set, use it as the model override (taking priority over the config-level model but still below `.jyc/model-override`)
3. Similarly for `small_model`

The current model override resolution is:
```rust
let model_override_path = thread_path.join(".jyc").join("model-override");
let model_override = /* read file */;
let provider = self.create_provider(model_override.as_deref())?;
```

Change it to:
```rust
// 1. file-based override (highest priority)
let file_override = /* read .jyc/model-override */;
// 2. pattern-based override
let pattern_override = message.matched_pattern.as_deref()
    .and_then(|name| self.patterns.iter().find(|p| p.name == name))
    .and_then(|p| p.model.as_deref());
// 3. config-level model (already stored in self.config.model)
let model_override = file_override.or(pattern_override);
let provider = self.create_provider(model_override.as_deref())?;
```

Similarly for `small_model` — read pattern `small_model` override and use if set, falling back to `self.config.small_model`.
**Why:** This is where the model is actually resolved and the provider created. Without this step, the config fields are ignored.
**Verify:** `cargo build -p jyc-agent` compiles. Existing tests pass: `cargo test -p jyc-agent`.

### Step 4: Update config validation if needed
**What:** Check `crates/jyc-types/src/validation.rs` — no changes needed since `model`/`small_model` are optional strings with no validation requirements.
**Why:** Ensure no validation errors on the new optional fields.
**Verify:** `cargo check` for the entire workspace.

### Step 5: Update `config.example.toml` with documentation
**What:** In `config.example.toml`, add commented examples showing:
- Channel-level model override under `[channels.xxx]`
- Pattern-level model override under `[[channels.xxx.patterns]]`
**Why:** Users need to know the feature exists and how to use it.
**Verify:** `cargo test -p jyc-types` (the config loader tests use `config.example.toml`-like TOML).

## Design Decisions
- **Only `model` and `small_model` are configurable per-pattern/channel** (per user request), not other `AgentConfig` fields like `max_iterations`, `providers`, etc.
- **Channel-level override reuses existing `ChannelConfig.agent` field shape** but expands it — simpler to add flat `model`/`small_model` fields to `ChannelConfig` rather than nesting under `agent` since we only need two fields
- **Priority chain is transparent**: file override > pattern > channel > global, matching the existing `.jyc/model-override` design