### PR TITLE
feat: per-pattern MCP 配置 (channel.x.patterns.mcps)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,6 +1502,7 @@ dependencies = [
  "chrono",
  "futures",
  "glob",
+ "http",
  "jyc-core",
  "jyc-mcp",
  "jyc-types",

--- a/config.example.toml
+++ b/config.example.toml
@@ -304,6 +304,22 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # type = "remote"
 # url = "https://mcp.example.com/handler"
 # enabled = true
+# # auth_header = "sk-..."    # Bearer token (sent as Authorization: Bearer <token>)
+# # [mcps.custom_headers]
+# # "X-API-Key" = "your-api-key"
+# # "X-Organization" = "my-org"
+#
+# # --- Per-Pattern MCP Configuration ---
+# # You can also configure MCP servers per pattern, overriding the global `[[mcps]]`
+# # list for threads matching that pattern. This allows different patterns to use
+# # different tools, credentials, and remote endpoints.
+# #
+# # When a pattern has `mcps` set, only those MCP servers are loaded for threads
+# # matching that pattern. When `mcps` is not set (default), the global `[[mcps]]`
+# # list is used for backward compatibility. Set `mcps = []` to disable all MCP
+# # tools for a specific pattern.
+# #
+# # Example — see the GitHub channel patterns section below for a complete example.
 
 # --- Channel: GitHub Repository ---
 # Enables multi-agent workflow on GitHub issues and PRs.
@@ -416,6 +432,60 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # github_type = ["pull_request"]
 # labels = ["ready-for-review"]
 # assignees = ["alice"]
+#
+# # --- Per-Pattern MCP Examples ---
+# # Each pattern can declare its own `mcps` list to use different MCP tools,
+# # different credentials, or different remote endpoints. When set, only these
+# # MCP servers are loaded for threads matching this pattern.
+#
+# # Pattern: Invoice processing with dedicated local MCP
+# # [[channels.my_repo.patterns]]
+# # name = "invoice-processor"
+# # enabled = true
+# # template = "github-developer"
+# #
+# # [channels.my_repo.patterns.rules]
+# # github_type = ["issue"]
+# # labels = ["invoice"]
+# #
+# # # Per-pattern MCP: only the invoice MCP is available for this pattern
+# # [[channels.my_repo.patterns.mcps]]
+# # name = "invoice"
+# # type = "local"
+# # command = ["invoice", "mcp"]
+#
+# # Pattern: Code review with remote MCP service + auth
+# # [[channels.my_repo.patterns]]
+# # name = "ai-reviewer"
+# # enabled = true
+# # template = "github-reviewer"
+# #
+# # [channels.my_repo.patterns.rules]
+# # github_type = ["pull_request"]
+# # labels = ["ai-review"]
+# #
+# # # Remote MCP with Bearer token authentication
+# # [[channels.my_repo.patterns.mcps]]
+# # name = "code-review-mcp"
+# # type = "remote"
+# # url = "https://review.example.com/mcp"
+# # enabled = true
+# # auth_header = "sk-xxx-review-token"
+# #
+# # # Remote MCP with custom headers
+# # [channels.my_repo.patterns.mcps.custom_headers]
+# # "X-API-Key" = "abc123"
+# # "X-Organization" = "my-org"
+#
+# # Pattern: No MCP tools at all (empty mcps list)
+# # [[channels.my_repo.patterns]]
+# # name = "simple-reply"
+# # enabled = true
+# # template = "github-developer"
+# # mcps = []  # Disable all MCP tools for this pattern
+# #
+# # [channels.my_repo.patterns.rules]
+# # github_type = ["issue"]
 #
 # # --- Channel: my_wechat_bot ---
 # # WeChat channel via OpenILink WebSocket Bridge

--- a/crates/jyc-agent/Cargo.toml
+++ b/crates/jyc-agent/Cargo.toml
@@ -38,6 +38,7 @@ glob = "0.3"
 regex = "1"
 base64 = "0.22"
 rmcp = { version = "1.3", features = ["client", "transport-child-process", "transport-streamable-http-client-reqwest"] }
+http = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -490,7 +490,17 @@ impl JycAgentService {
     /// local files or URLs into subsequent user turns. When the model is
     /// text-only, the tool is omitted to keep the schema honest (no point
     /// advertising a capability the model can't act on).
-    async fn build_tool_registry(&self, _thread_path: &Path, supports_images: bool) -> ToolRegistry {
+    ///
+    /// `matched_pattern_name` optionally selects per-pattern MCP configurations.
+    /// When the matched pattern has `mcps: Some(list)`, only those MCP servers
+    /// are loaded. When `None`, the global `[[mcps]]` list is used (backward
+    /// compatible fallback).
+    async fn build_tool_registry(
+        &self,
+        _thread_path: &Path,
+        supports_images: bool,
+        matched_pattern_name: Option<&str>,
+    ) -> ToolRegistry {
         // Start with all built-in tools
         let mut registry = crate::tools::builtin::create_builtin_registry();
 
@@ -508,13 +518,20 @@ impl JycAgentService {
         // Add MCP bridge tools (reply_message, etc.)
         crate::tools::mcp_bridge::register_mcp_tools(&mut registry);
 
-        // Load external MCP tools from config.toml [[mcps]]
-        if !self.mcp_configs.is_empty() {
+        // Resolve MCP configs: per-pattern first, global fallback
+        let mcp_configs: &[McpServerConfig] = matched_pattern_name
+            .and_then(|name| self.patterns.iter().find(|p| p.name == name))
+            .and_then(|p| p.mcps.as_ref())
+            .map(|mcps| mcps.as_slice())
+            .unwrap_or_else(|| self.mcp_configs.as_slice());
+
+        // Load external MCP tools from resolved configs
+        if !mcp_configs.is_empty() {
             tracing::info!(
-                mcp_count = self.mcp_configs.len(),
+                mcp_count = mcp_configs.len(),
                 "Loading external MCP tools"
             );
-            let mcp_tools = crate::tools::mcp_client::load_mcp_tools(&self.mcp_configs).await;
+            let mcp_tools = crate::tools::mcp_client::load_mcp_tools(mcp_configs).await;
             for tool in mcp_tools {
                 registry.register(tool);
             }
@@ -681,7 +698,9 @@ impl AgentService for JycAgentService {
         let user_blocks = self.build_user_blocks(message, provider.supports_images());
 
         // 5. Build tool registry
-        let tools = self.build_tool_registry(thread_path, provider.supports_images()).await;
+        let tools = self
+            .build_tool_registry(thread_path, provider.supports_images(), message.matched_pattern.as_deref())
+            .await;
 
         // 6. Get event bus for this thread
         let event_bus = self.get_event_bus(thread_name).await;

--- a/crates/jyc-agent/src/tools/mcp_client.rs
+++ b/crates/jyc-agent/src/tools/mcp_client.rs
@@ -4,10 +4,13 @@
 //! protocol, calls `list_tools()`, and wraps each discovered tool as a
 //! jyc-agent `Tool` implementation for the agent loop.
 
+use std::collections::HashMap;
+use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use http::{HeaderName, HeaderValue};
 use serde_json::Value;
 use tracing;
 
@@ -15,7 +18,7 @@ use jyc_types::McpServerConfig;
 use rmcp::model::CallToolRequestParams;
 use rmcp::service::{RoleClient, RunningService, serve_client};
 use rmcp::transport::child_process::TokioChildProcess;
-use rmcp::transport::streamable_http_client::StreamableHttpClientTransport;
+use rmcp::transport::streamable_http_client::{StreamableHttpClientTransport, StreamableHttpClientTransportConfig};
 
 use crate::tools::{Tool, ToolContext, ToolOutput};
 
@@ -76,12 +79,35 @@ async fn connect_and_list_tools(cfg: &McpServerConfig) -> Result<Vec<Box<dyn Too
                 .await
                 .map_err(|e| anyhow::anyhow!("failed to connect to MCP server via stdio: {}", e))?
         }
-        jyc_types::McpServerKind::Remote { url, enabled } => {
+        jyc_types::McpServerKind::Remote {
+            url,
+            enabled,
+            auth_header,
+            custom_headers,
+        } => {
             if !enabled {
                 anyhow::bail!("remote MCP '{}' is disabled", cfg.name);
             }
 
-            let transport = StreamableHttpClientTransport::from_uri(url.as_str());
+            let mut config = StreamableHttpClientTransportConfig::with_uri(url.as_str());
+            if let Some(token) = auth_header {
+                config = config.auth_header(token.clone());
+            }
+            if !custom_headers.is_empty() {
+                let headers: Result<HashMap<HeaderName, HeaderValue>> = custom_headers
+                    .iter()
+                    .map(|(k, v)| {
+                        let name = HeaderName::from_str(k)
+                            .map_err(|e| anyhow::anyhow!("invalid header name '{}': {}", k, e))?;
+                        let value = HeaderValue::from_str(v)
+                            .map_err(|e| anyhow::anyhow!("invalid header value '{}': {}", v, e))?;
+                        Ok((name, value))
+                    })
+                    .collect();
+                config = config.custom_headers(headers?);
+            }
+
+            let transport = StreamableHttpClientTransport::from_config(config);
 
             serve_client((), transport)
                 .await

--- a/crates/jyc-types/src/channel.rs
+++ b/crates/jyc-types/src/channel.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use tokio_util::sync::CancellationToken;
 
 use crate::config::InboundAttachmentConfig;
+use crate::config::McpServerConfig;
 
 /// Channel type identifier (e.g., "email", "feishu", "slack")
 pub type ChannelType = String;
@@ -306,6 +307,15 @@ pub struct ChannelPattern {
     /// but below the runtime `.jyc/model-override` file.
     #[serde(default)]
     pub small_model: Option<String>,
+    /// Per-pattern MCP server configurations.
+    ///
+    /// When set to `Some(list)`, only these MCP servers are loaded for threads
+    /// matching this pattern. When `None` (default), the global `[[mcps]]` list
+    /// is used for backward compatibility.
+    ///
+    /// Set to `Some([])` (empty list) to disable all MCP tools for this pattern.
+    #[serde(default)]
+    pub mcps: Option<Vec<McpServerConfig>>,
 }
 
 impl Default for ChannelPattern {
@@ -325,6 +335,7 @@ impl Default for ChannelPattern {
             inject_inbound_images: false,
             model: None,
             small_model: None,
+            mcps: None,
         }
     }
 }

--- a/crates/jyc-types/src/config.rs
+++ b/crates/jyc-types/src/config.rs
@@ -33,6 +33,14 @@ pub enum McpServerKind {
         url: String,
         #[serde(default = "default_true")]
         enabled: bool,
+        /// Bearer token for authentication (without "Bearer " prefix).
+        /// Sent as `Authorization: Bearer <token>` header with every request.
+        #[serde(default)]
+        auth_header: Option<String>,
+        /// Custom HTTP headers to include with every request.
+        /// Keys are header names, values are header values.
+        #[serde(default)]
+        custom_headers: HashMap<String, String>,
     },
 }
 
@@ -649,9 +657,16 @@ enabled = true
         let remote = &config.mcps[1];
         assert_eq!(remote.name, "remote_mcp");
         match &remote.kind {
-            super::McpServerKind::Remote { url, enabled } => {
+            super::McpServerKind::Remote {
+                url,
+                enabled,
+                auth_header,
+                custom_headers,
+            } => {
                 assert_eq!(url, "https://mcp.example.com/handler");
                 assert!(*enabled);
+                assert!(auth_header.is_none());
+                assert!(custom_headers.is_empty());
             }
             _ => panic!("Expected Remote variant for remote_mcp"),
         }

--- a/crates/jyc-types/src/validation.rs
+++ b/crates/jyc-types/src/validation.rs
@@ -307,6 +307,37 @@ fn validate_pattern(prefix: &str, pattern: &ChannelPattern, errors: &mut Vec<Val
     if let Some(ref att) = pattern.attachments {
         validate_inbound_attachment_config(&format!("{prefix}.attachments"), att, errors);
     }
+
+    // Validate per-pattern MCP configs if present
+    if let Some(ref mcps) = pattern.mcps {
+        for (j, mcp) in mcps.iter().enumerate() {
+            let mcp_prefix = format!("{prefix}.mcps[{j}]");
+            if mcp.name.is_empty() {
+                errors.push(ValidationError {
+                    path: format!("{mcp_prefix}.name"),
+                    message: "MCP server name is required".into(),
+                });
+            }
+            match &mcp.kind {
+                crate::config::McpServerKind::Local { command, .. } => {
+                    if command.is_empty() {
+                        errors.push(ValidationError {
+                            path: format!("{mcp_prefix}.command"),
+                            message: format!("MCP '{}' local command is required", mcp.name),
+                        });
+                    }
+                }
+                crate::config::McpServerKind::Remote { url, .. } => {
+                    if url.is_empty() {
+                        errors.push(ValidationError {
+                            path: format!("{mcp_prefix}.url"),
+                            message: format!("MCP '{}' remote url is required", mcp.name),
+                        });
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Validate inbound attachment configuration.
@@ -525,6 +556,163 @@ mode = "static"
         let config = load_config_from_str(toml).unwrap();
         let errors = validate_config(&config);
         assert!(errors.iter().any(|e| e.path == "agent.text"));
+    }
+
+    #[test]
+    fn test_invalid_mcp_in_pattern() {
+        let toml = r#"
+[general]
+[channels.work]
+type = "email"
+[channels.work.inbound]
+host = "h"
+port = 993
+username = "u"
+password = "p"
+[channels.work.outbound]
+host = "h"
+port = 465
+username = "u"
+password = "p"
+
+[[channels.work.patterns]]
+name = "mcp-test"
+[channels.work.patterns.rules]
+
+[[channels.work.patterns.mcps]]
+name = ""
+type = "local"
+command = []
+
+[agent]
+enabled = true
+mode = "agent"
+"#;
+        let config = load_config_from_str(toml).unwrap();
+        let errors = validate_config(&config);
+        assert!(
+            errors.iter().any(|e| e.path.contains("mcps[0].name")),
+            "expected mcps[0].name error, got: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn test_invalid_mcp_local_no_command() {
+        let toml = r#"
+[general]
+[channels.work]
+type = "email"
+[channels.work.inbound]
+host = "h"
+port = 993
+username = "u"
+password = "p"
+[channels.work.outbound]
+host = "h"
+port = 465
+username = "u"
+password = "p"
+
+[[channels.work.patterns]]
+name = "mcp-test"
+[channels.work.patterns.rules]
+
+[[channels.work.patterns.mcps]]
+name = "my-mcp"
+type = "local"
+command = []
+
+[agent]
+enabled = true
+mode = "agent"
+"#;
+        let config = load_config_from_str(toml).unwrap();
+        let errors = validate_config(&config);
+        assert!(
+            errors.iter().any(|e| e.path.contains("mcps[0].command")),
+            "expected mcps[0].command error, got: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn test_invalid_mcp_remote_no_url() {
+        let toml = r#"
+[general]
+[channels.work]
+type = "email"
+[channels.work.inbound]
+host = "h"
+port = 993
+username = "u"
+password = "p"
+[channels.work.outbound]
+host = "h"
+port = 465
+username = "u"
+password = "p"
+
+[[channels.work.patterns]]
+name = "mcp-test"
+[channels.work.patterns.rules]
+
+[[channels.work.patterns.mcps]]
+name = "my-remote"
+type = "remote"
+url = ""
+
+[agent]
+enabled = true
+mode = "agent"
+"#;
+        let config = load_config_from_str(toml).unwrap();
+        let errors = validate_config(&config);
+        assert!(
+            errors.iter().any(|e| e.path.contains("mcps[0].url")),
+            "expected mcps[0].url error, got: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn test_valid_mcp_in_pattern_passes() {
+        let toml = r#"
+[general]
+[channels.work]
+type = "email"
+[channels.work.inbound]
+host = "h"
+port = 993
+username = "u"
+password = "p"
+[channels.work.outbound]
+host = "h"
+port = 465
+username = "u"
+password = "p"
+
+[[channels.work.patterns]]
+name = "mcp-test"
+[channels.work.patterns.rules]
+
+[[channels.work.patterns.mcps]]
+name = "my-local"
+type = "local"
+command = ["npx", "-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+
+[agent]
+enabled = true
+mode = "agent"
+"#;
+        let config = load_config_from_str(toml).unwrap();
+        let errors = validate_config(&config);
+        let mcp_errors: Vec<_> = errors.iter().filter(|e| e.path.contains("mcps")).collect();
+        assert!(
+            mcp_errors.is_empty(),
+            "expected no mcp errors, got: {:?}",
+            mcp_errors
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Spec

支持在 `channel.x.patterns` 层面配置 MCP 服务器，允许不同 pattern 使用不同的 MCP 工具、不同的 API key/token、不同的 remote 端点。

同时扩展 `McpServerKind::Remote`，新增 `auth_header`（Bearer token）和 `custom_headers`（自定义 HTTP headers）字段，与 rmcp 库的 `StreamableHttpClientTransportConfig` 对齐。

Fixes #212

## Implementation Plan

### Step 1: 扩展 `McpServerKind::Remote` 支持 auth 和 headers
**What:** 在 `crates/jyc-types/src/config.rs` 的 `McpServerKind::Remote` 变体中新增两个可选字段：
- `auth_header: Option<String>` — Bearer token（不带 "Bearer " 前缀）
- `custom_headers: HashMap<String, String>` — 自定义 HTTP headers

更新对应的测试（`test_load_config_with_mcps`）。

**Why:** rmcp 的 `StreamableHttpClientTransportConfig` 已支持 `auth_header` 和 `custom_headers`，但 jyc 的 `McpServerConfig` 没有暴露这些字段，导致 remote MCP 无法配置认证。

**Verify:** `cargo test -p jyc-types test_load_config_with_mcps` 通过。

### Step 2: 修改 `mcp_client.rs` 传递 auth/headers
**What:** 在 `crates/jyc-agent/src/tools/mcp_client.rs` 的 `connect_and_list_tools` 中，针对 `Remote` 变体：
- 使用 `StreamableHttpClientTransportConfig::with_uri()` 替代 `StreamableHttpClientTransport::from_uri()`
- 若有 `auth_header`，调用 `.auth_header(token)`
- 若有 `custom_headers`，将 `HashMap<String, String>` 转换为 `HashMap<HeaderName, HeaderValue>` 后调用 `.custom_headers(headers)`
- 使用 `StreamableHttpClientTransport::new(reqwest::Client::new(), config)` 创建 transport

**Why:** 当前 `from_uri()` 不传递任何 auth 信息，token 和 headers 都丢失了。

**Verify:** `cargo check -p jyc-agent` 编译通过。可手动配置一个带 `auth_header` 的 remote MCP 验证连接。

### Step 3: `ChannelPattern` 新增 `mcps` 字段
**What:** 在 `crates/jyc-types/src/channel.rs`：
- `ChannelPattern` 新增 `mcps: Option<Vec<McpServerConfig>>` 字段
- 在 `Default` 实现中设为 `None`
- 添加文档注释说明优先级逻辑

**Why:** 这是 per-pattern MCP 配置的核心——允许每个 pattern 定义自己需要的 MCP 工具集。

**Verify:** `cargo check -p jyc-types` 编译通过。

### Step 4: 修改 `build_tool_registry()` 按 pattern 选择 MCP
**What:** 在 `crates/jyc-agent/src/service.rs`：
- `build_tool_registry()` 增加 `matched_pattern_name: Option<&str>` 参数
- 若有 matched pattern 且其 `mcps` 为 `Some(list)`，使用该 list
- 否则回退到 `self.mcp_configs`（全局 `[[mcps]]`，向后兼容）
- 调用处（`process` 方法）传入 `message.matched_pattern.as_deref()`

**Why:** 实现 per-pattern MCP 过滤的核心逻辑，pattern 有则用自己的，无则回退全局。

**Verify:** `cargo check -p jyc-agent` 编译通过。运行时不同 pattern 应加载不同 MCP 工具。

### Step 5: 配置校验
**What:** 在 `crates/jyc-types/src/validation.rs` 的 `validate_pattern` 中：
- 若 pattern 有 `mcps`，校验每个 MCP 配置的基本完整性（name 不为空、type 有效等）
- 复用已有的 MCP 校验逻辑（如有）

**Why:** 配置错误应在启动时捕获，而非运行时加载 MCP 时才失败。

**Verify:** `cargo test -p jyc-types` 通过。可构造无效配置验证报错。

### Step 6: 更新配置示例
**What:** 在 `config.example.toml` 添加 per-pattern `mcps` 的完整示例，包括：
- Local MCP + 不同 environment
- Remote MCP + auth_header
- Remote MCP + custom_headers
- 混合 local + remote
- 不配 mcps 的 pattern（向后兼容）

**Why:** 用户参考文档。

**Verify:** 目视检查 `config.example.toml`，确认 TOML 语法正确。

## Design Decisions

- **`Option<Vec<McpServerConfig>>` 而非引用名称列表**：用户需要 per-pattern 覆盖 credential（不同的 api key/token），仅按名称引用全局 MCP 无法满足。直接复用 `McpServerConfig` 类型最灵活。
- **`None` = 回退全局，`Some([])` = 不使用任何 MCP**：向后兼容。现有配置不配 `mcps` 的 pattern 行为不变。
- **`custom_headers` 用 `HashMap<String, String>` 而非 `HashMap<HeaderName, HeaderValue>`**：TOML 反序列化友好。在 `mcp_client.rs` 中转换。
- **`auth_header` 存储不带 "Bearer " 前缀的 token**：与 rmcp 的 `StreamableHttpClientTransportConfig::auth_header()` 一致，由 rmcp 自动添加 "Bearer " 前缀。