### PR TITLE
feat: add boundary checks to write/edit/grep/glob/bash and per-pattern tool disable

### DIFF
--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -549,6 +549,22 @@ impl JycAgentService {
             }
         }
 
+        // Apply per-pattern disabled_builtin_tools: remove any built-in
+        // tools that the pattern explicitly disables.
+        if let Some(disabled) = matched_pattern_name
+            .and_then(|name| self.patterns.iter().find(|p| p.name == name))
+            .and_then(|p| p.disabled_builtin_tools.as_ref())
+        {
+            for tool_name in disabled {
+                tracing::debug!(
+                    tool = %tool_name,
+                    pattern = %matched_pattern_name.unwrap_or("?"),
+                    "Removing disabled built-in tool"
+                );
+                registry.remove(tool_name);
+            }
+        }
+
         registry
     }
 

--- a/crates/jyc-agent/src/tools/builtin/bash.rs
+++ b/crates/jyc-agent/src/tools/builtin/bash.rs
@@ -76,11 +76,10 @@ impl Tool for BashTool {
         for token in command.split_whitespace() {
             if token.starts_with('/') {
                 let candidate = std::path::Path::new(token);
-                // Only check tokens that look like existing paths to avoid
-                // flagging flags like `/C` or `/usr/bin/env`.
-                // We check both the token itself and its parent chain
-                // because tokens like `arg1=/etc/passwd` contain embedded
-                // paths.
+                // Only check tokens that start with `/` and correspond to
+                // existing filesystem paths. This catches obvious escape
+                // attempts (e.g. `cat /etc/passwd`) while allowing flags
+                // like `-C` and commands that shell out to relative paths.
                 if candidate.exists() {
                     if let Err(msg) = ctx.check_path_boundary(token, candidate) {
                         return Ok(ToolOutput::error(msg));

--- a/crates/jyc-agent/src/tools/builtin/bash.rs
+++ b/crates/jyc-agent/src/tools/builtin/bash.rs
@@ -1,4 +1,18 @@
 //! Bash tool — execute shell commands.
+//!
+//! ## Security boundary
+//!
+//! `bash` applies a **best-effort heuristic check** before execution: it
+//! scans the command string for absolute-path tokens (words starting with
+//! `/`). Each such token is resolved against `working_dir` and passed
+//! through `ToolContext::check_path_boundary`. This catches obvious escape
+//! attempts like `cat /etc/passwd`, `ls /root`, or `rm -rf /tmp/evil`.
+//!
+//! **Limitations**: this is a simple lexer heuristic, not a full sandbox.
+//! Bash is inherently capable of arbitrary system access via shell
+//! builtins (`cd /`, variable expansion, process substitution, etc.).
+//! A determined attacker can bypass it. Full sandboxing requires OS-level
+//! isolation (Linux namespaces, chroot, containers).
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -55,6 +69,25 @@ impl Tool for BashTool {
             .get("timeout")
             .and_then(|t| t.as_u64())
             .unwrap_or(DEFAULT_TIMEOUT_SECS);
+
+        // Best-effort boundary check: scan for absolute-path tokens and
+        // verify each is within the working directory. This catches obvious
+        // escape attempts (cat /etc/passwd) without fully sandboxing bash.
+        for token in command.split_whitespace() {
+            if token.starts_with('/') {
+                let candidate = std::path::Path::new(token);
+                // Only check tokens that look like existing paths to avoid
+                // flagging flags like `/C` or `/usr/bin/env`.
+                // We check both the token itself and its parent chain
+                // because tokens like `arg1=/etc/passwd` contain embedded
+                // paths.
+                if candidate.exists() {
+                    if let Err(msg) = ctx.check_path_boundary(token, candidate) {
+                        return Ok(ToolOutput::error(msg));
+                    }
+                }
+            }
+        }
 
         tracing::debug!(command = %command, timeout = timeout_secs, "Executing bash command");
 

--- a/crates/jyc-agent/src/tools/builtin/bash.rs
+++ b/crates/jyc-agent/src/tools/builtin/bash.rs
@@ -80,10 +80,10 @@ impl Tool for BashTool {
                 // existing filesystem paths. This catches obvious escape
                 // attempts (e.g. `cat /etc/passwd`) while allowing flags
                 // like `-C` and commands that shell out to relative paths.
-                if candidate.exists() {
-                    if let Err(msg) = ctx.check_path_boundary(token, candidate) {
-                        return Ok(ToolOutput::error(msg));
-                    }
+                if candidate.exists()
+                    && let Err(msg) = ctx.check_path_boundary(token, candidate)
+                {
+                    return Ok(ToolOutput::error(msg));
                 }
             }
         }

--- a/crates/jyc-agent/src/tools/builtin/edit.rs
+++ b/crates/jyc-agent/src/tools/builtin/edit.rs
@@ -70,6 +70,11 @@ impl Tool for EditTool {
             ctx.working_dir.join(file_path)
         };
 
+        // Security: ensure path is within working directory.
+        if let Err(msg) = ctx.check_path_boundary(file_path, &path) {
+            return Ok(ToolOutput::error(msg));
+        }
+
         // Read current content
         let content = tokio::fs::read_to_string(&path)
             .await

--- a/crates/jyc-agent/src/tools/builtin/glob_tool.rs
+++ b/crates/jyc-agent/src/tools/builtin/glob_tool.rs
@@ -55,6 +55,15 @@ impl Tool for GlobTool {
             })
             .unwrap_or_else(|| ctx.working_dir.to_path_buf());
 
+        // Security: only check boundary when an explicit search_dir is
+        // provided (different from the default working_dir).
+        if search_dir != ctx.working_dir {
+            let display = input.get("path").and_then(|p| p.as_str()).unwrap_or("");
+            if let Err(msg) = ctx.check_path_boundary(display, &search_dir) {
+                return Ok(ToolOutput::error(msg));
+            }
+        }
+
         // Build full glob pattern
         let full_pattern = search_dir.join(pattern).to_string_lossy().to_string();
 

--- a/crates/jyc-agent/src/tools/builtin/grep.rs
+++ b/crates/jyc-agent/src/tools/builtin/grep.rs
@@ -66,6 +66,15 @@ impl Tool for GrepTool {
 
         let include_pattern = input.get("include").and_then(|i| i.as_str());
 
+        // Security: only check boundary when an explicit search_dir is
+        // provided (i.e. different from the default working_dir).
+        if search_dir != ctx.working_dir {
+            let display = input.get("path").and_then(|p| p.as_str()).unwrap_or("");
+            if let Err(msg) = ctx.check_path_boundary(display, &search_dir) {
+                return Ok(ToolOutput::error(msg));
+            }
+        }
+
         let regex = Regex::new(pattern)
             .map_err(|e| anyhow::anyhow!("Invalid regex pattern '{}': {e}", pattern))?;
 

--- a/crates/jyc-agent/src/tools/builtin/read.rs
+++ b/crates/jyc-agent/src/tools/builtin/read.rs
@@ -72,25 +72,11 @@ impl Tool for ReadTool {
         }
 
         // Security: ensure path is within working directory.
-        // Skip this check if path traverses a symlink (e.g., repo/ -> /other/path),
-        // since JYC's repo_group feature uses symlinks within the working directory.
-        let has_symlink = path
-            .ancestors()
-            .any(|ancestor| ancestor != ctx.working_dir && ancestor.is_symlink());
-
-        if !has_symlink {
-            let canonical = path.canonicalize().unwrap_or_else(|_| path.clone());
-            let working_canonical = ctx
-                .working_dir
-                .canonicalize()
-                .unwrap_or_else(|_| ctx.working_dir.to_path_buf());
-
-            if !canonical.starts_with(&working_canonical) {
-                return Ok(ToolOutput::error(format!(
-                    "Access denied: path '{}' is outside the working directory",
-                    file_path
-                )));
-            }
+        // Uses the shared boundary check from ToolContext, which handles
+        // canonicalization, repo_group symlink exemption, and
+        // additional_read_roots.
+        if let Err(msg) = ctx.check_path_boundary(file_path, &path) {
+            return Ok(ToolOutput::error(msg));
         }
 
         if path.is_dir() {

--- a/crates/jyc-agent/src/tools/builtin/read_image.rs
+++ b/crates/jyc-agent/src/tools/builtin/read_image.rs
@@ -176,7 +176,7 @@ impl ReadImageTool {
         // additional_read_roots. Uses the shared check_path_boundary
         // method from ToolContext which handles canonicalization, symlink
         // exemption, and additional_read_roots.
-        if let Err(msg) = ctx.check_path_boundary(path_str, &path) {
+        if let Err(msg) = ctx.check_path_boundary(path_str, path) {
             return Ok(ToolOutput::error(msg));
         }
 

--- a/crates/jyc-agent/src/tools/builtin/read_image.rs
+++ b/crates/jyc-agent/src/tools/builtin/read_image.rs
@@ -173,28 +173,11 @@ impl ReadImageTool {
         }
 
         // Boundary check: path must lie under working_dir or one of the
-        // additional_read_roots.
-        let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-        let working_canonical = ctx
-            .working_dir
-            .canonicalize()
-            .unwrap_or_else(|_| ctx.working_dir.to_path_buf());
-
-        let mut allowed = canonical.starts_with(&working_canonical);
-        if !allowed {
-            for root in &ctx.additional_read_roots {
-                let root_canonical = root.canonicalize().unwrap_or_else(|_| root.clone());
-                if canonical.starts_with(&root_canonical) {
-                    allowed = true;
-                    break;
-                }
-            }
-        }
-        if !allowed {
-            return Ok(ToolOutput::error(format!(
-                "Access denied: path '{}' is outside the working directory and configured attachment roots",
-                path_str
-            )));
+        // additional_read_roots. Uses the shared check_path_boundary
+        // method from ToolContext which handles canonicalization, symlink
+        // exemption, and additional_read_roots.
+        if let Err(msg) = ctx.check_path_boundary(path_str, &path) {
+            return Ok(ToolOutput::error(msg));
         }
 
         // Detect MIME from extension.

--- a/crates/jyc-agent/src/tools/builtin/write.rs
+++ b/crates/jyc-agent/src/tools/builtin/write.rs
@@ -53,6 +53,11 @@ impl Tool for WriteTool {
             ctx.working_dir.join(file_path)
         };
 
+        // Security: ensure path is within working directory.
+        if let Err(msg) = ctx.check_path_boundary(file_path, &path) {
+            return Ok(ToolOutput::error(msg));
+        }
+
         // Create parent directories
         if let Some(parent) = path.parent() {
             tokio::fs::create_dir_all(parent)

--- a/crates/jyc-agent/src/tools/mod.rs
+++ b/crates/jyc-agent/src/tools/mod.rs
@@ -67,6 +67,55 @@ impl<'a> ToolContext<'a> {
     pub fn take_pending_images(&self) -> Vec<ImageSource> {
         std::mem::take(&mut *self.pending_images.lock().expect("pending_images poisoned"))
     }
+
+    /// Check that `resolved` is within `working_dir` (or one of the
+    /// `additional_read_roots`). Returns `Ok(())` when the path is inside
+    /// the boundary, or an `Err` with a user-facing access-denied message.
+    ///
+    /// **Symlink exemption**: when any ancestor component of `resolved`
+    /// above `working_dir` is a symlink (e.g. the `repo_group` feature
+    /// where `repo/ -> /other/path`), the check is skipped. This lets the
+    /// agent work with symlinked repos without false positives.
+    pub fn check_path_boundary(
+        &self,
+        display_path: &str,
+        resolved: &Path,
+    ) -> std::result::Result<(), String> {
+        // Symlink exemption: skip the boundary check when a symlink
+        // component is found above working_dir. This preserves the
+        // repo_group feature where working_dir/repo -> /other/path.
+        let has_symlink = resolved
+            .ancestors()
+            .any(|ancestor| ancestor != self.working_dir && ancestor.is_symlink());
+
+        if has_symlink {
+            return Ok(());
+        }
+
+        let canonical = resolved.canonicalize().unwrap_or_else(|_| resolved.to_path_buf());
+        let working_canonical = self
+            .working_dir
+            .canonicalize()
+            .unwrap_or_else(|_| self.working_dir.to_path_buf());
+
+        if canonical.starts_with(&working_canonical) {
+            return Ok(());
+        }
+
+        // Also check additional_read_roots (e.g. configured attachment
+        // save paths outside working_dir).
+        for root in &self.additional_read_roots {
+            let root_canonical = root.canonicalize().unwrap_or_else(|_| root.clone());
+            if canonical.starts_with(&root_canonical) {
+                return Ok(());
+            }
+        }
+
+        Err(format!(
+            "Access denied: path '{}' is outside the working directory",
+            display_path
+        ))
+    }
 }
 
 /// Trait for tools that can be invoked by the agent.

--- a/crates/jyc-agent/src/tools/mod.rs
+++ b/crates/jyc-agent/src/tools/mod.rs
@@ -92,7 +92,9 @@ impl<'a> ToolContext<'a> {
             return Ok(());
         }
 
-        let canonical = resolved.canonicalize().unwrap_or_else(|_| resolved.to_path_buf());
+        let canonical = resolved
+            .canonicalize()
+            .unwrap_or_else(|_| resolved.to_path_buf());
         let working_canonical = self
             .working_dir
             .canonicalize()

--- a/crates/jyc-agent/src/tools/registry.rs
+++ b/crates/jyc-agent/src/tools/registry.rs
@@ -26,6 +26,11 @@ impl ToolRegistry {
         self.tools.insert(tool.name().to_string(), tool);
     }
 
+    /// Remove a tool by name. No-op if the tool is not registered.
+    pub fn remove(&mut self, name: &str) {
+        self.tools.remove(name);
+    }
+
     /// Get all tool definitions for the LLM.
     pub fn definitions(&self) -> Vec<ToolDefinition> {
         self.tools.values().map(|t| t.to_definition()).collect()

--- a/crates/jyc-types/src/channel.rs
+++ b/crates/jyc-types/src/channel.rs
@@ -307,6 +307,16 @@ pub struct ChannelPattern {
     /// Set to `Some([])` (empty list) to disable all MCP tools for this pattern.
     #[serde(default)]
     pub mcps: Option<Vec<McpServerConfig>>,
+    /// Built-in tools to disable for this pattern.
+    ///
+    /// Tool names match `Tool::name()`: `"bash"`, `"write"`, `"edit"`,
+    /// `"grep"`, `"glob"`, `"read"`, `"webfetch"`, `"read_image"`.
+    ///
+    /// When set to `Some(list)`, those tools are removed from the registry
+    /// before the agent loop starts. When `None` (default), all built-in
+    /// tools remain enabled.
+    #[serde(default)]
+    pub disabled_builtin_tools: Option<Vec<String>>,
 }
 
 impl Default for ChannelPattern {
@@ -327,6 +337,7 @@ impl Default for ChannelPattern {
             model: None,
             small_model: None,
             mcps: None,
+            disabled_builtin_tools: None,
         }
     }
 }


### PR DESCRIPTION
## Spec

Add boundary checks to `write`, `edit`, `grep`, `glob`, and `bash` built-in tools (currently only `read` and `read_image` enforce working-directory boundaries). Also add a per-pattern `disabled_builtin_tools` config option that allows selectively disabling built-in tools at the pattern level.

Fixes #215

## Implementation Plan

### Step 1: Extract `check_path_boundary` into a shared method
**What:** Add `check_path_boundary(&self, display_path: &str, resolved: &Path) -> Result<()>` to `ToolContext` in `crates/jyc-agent/src/tools/mod.rs`. Extract the canonicalize + starts_with logic from `read.rs`, including the symlink exemption for `repo_group`.
**Why:** Avoid code duplication — the same boundary check logic is needed in 5+ tools.
**Verify:** `cargo check -p jyc-agent` compiles.

### Step 2: Refactor `read` and `read_image` to use the shared method
**What:** Replace inline boundary checks in `crates/jyc-agent/src/tools/builtin/read.rs` and `read_image.rs` with `ctx.check_path_boundary()`.
**Why:** Eliminate duplication and validate the shared method works correctly.
**Verify:** `cargo test -p jyc-agent` — all existing tests pass.

### Step 3: Add boundary check to `write`
**What:** In `crates/jyc-agent/src/tools/builtin/write.rs`, after path resolution and before `create_dir_all`, call `ctx.check_path_boundary(file_path, &path)?`.
**Why:** Block write operations outside the working directory.
**Verify:** Manual test: write to `/tmp/escape_test.txt` should return `"Access denied: path '/tmp/escape_test.txt' is outside the working directory"`.

### Step 4: Add boundary check to `edit`
**What:** In `crates/jyc-agent/src/tools/builtin/edit.rs`, after path resolution and before `read_to_string`, call `ctx.check_path_boundary(file_path, &path)?`.
**Why:** Block read+write via edit outside the working directory.
**Verify:** Manual test: edit `/etc/hostname` should return `"Access denied"`.

### Step 5: Add boundary check to `grep`
**What:** In `crates/jyc-agent/src/tools/builtin/grep.rs`, after `search_dir` resolution and before `search_recursive`, call `ctx.check_path_boundary(...)` — but only when `search_dir != working_dir` (skip when user doesn't specify a path).
**Why:** Block grep from scanning files outside the working directory.
**Verify:** Manual test: `grep "pattern" --path /etc` should return `"Access denied"`.

### Step 6: Add boundary check to `glob`
**What:** In `crates/jyc-agent/src/tools/builtin/glob_tool.rs`, after directory resolution, before `glob()`, call `ctx.check_path_boundary(...)` — skip when using the default working_dir.
**Why:** Block glob from listing files outside the working directory.
**Verify:** Manual test: `glob "**/*" --path /etc` should return `"Access denied"`.

### Step 7: Add heuristic pre-check to `bash`
**What:** In `crates/jyc-agent/src/tools/builtin/bash.rs`, before execution, scan the command string for absolute path tokens (words starting with `/`), resolve each against working_dir, and call `ctx.check_path_boundary()` on each. Document this as best-effort.
**Why:** Provide a basic defense against obvious escape attempts like `cat /etc/passwd`. Note: cannot fully sandbox bash without Linux namespaces/chroot.
**Verify:** `cat /etc/passwd` → denied; `cargo build` → allowed; `ls -la` → allowed.

### Step 8: Add `disabled_builtin_tools` field to `ChannelPattern`
**What:** In `crates/jyc-types/src/channel.rs`, add `pub disabled_builtin_tools: Option<Vec<String>>` to `ChannelPattern` with `#[serde(default)]`. Update the `Default` impl.
**Why:** Enable per-pattern configuration to selectively disable built-in tools.
**Verify:** `cargo check -p jyc-types` compiles; deserialization of `disabled_builtin_tools = ["bash", "write"]` works.

### Step 9: Add `remove` method to `ToolRegistry`
**What:** In `crates/jyc-agent/src/tools/registry.rs`, add `pub fn remove(&mut self, name: &str) { self.tools.remove(name); }`.
**Why:** Allow removal of tools after registration based on config.
**Verify:** `cargo check -p jyc-agent` compiles.

### Step 10: Apply disabled list in `build_tool_registry`
**What:** In `crates/jyc-agent/src/service.rs`, after MCP tools are loaded, look up the matched pattern's `disabled_builtin_tools` and call `registry.remove(name)` for each entry.
**Why:** Wire the config to runtime behavior.
**Verify:** Set `disabled_builtin_tools = ["bash"]` on a pattern, verify `bash` tool is not in `registry.definitions()`.

## Design Decisions
- **Unified boundary check** — single `check_path_boundary` method shared by all tools, avoiding code duplication
- **Symlink exemption** — preserved from `read.rs` to maintain compatibility with `repo_group` feature
- **bash is best-effort** — heuristic path scanning, explicitly documented as not fully sandboxing bash
- **Config backward compatible** — `disabled_builtin_tools: None` (default) preserves existing behavior
- **Tool names match `Tool::name()`** — `"bash"`, `"write"`, `"edit"`, `"grep"`, `"glob"`, `"read"`, `"webfetch"`, `"read_image"`