### PR TITLE
docs: add testing harness, documentation, and workflow requirements to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,11 +31,44 @@ and uses OpenCode to generate AI replies.
 - 测试间不得共享可变状态；如必须串行，使用 `#[serial]` 标记并在 CI 中串行执行
 - 资源泄漏（如端口占用）的测试必须实现 `Drop` 或使用 `TempDir` 自动清理
 
-## Development Workflow
-- Always create a feature branch: `git checkout -b feat/<name>`
-- After changes, run tests: `cargo test`
-- Commit with clear messages describing what changed and why
-- Push immediately after committing
+## 工作流约定
+
+### 分支命名
+- 功能分支：`feat/issue-{N}`（如 `feat/issue-220`）
+- 修复分支：`fix/issue-{N}`（如 `fix/issue-42`）
+- 使用下划线分隔多词，禁止大写字母
+
+### PR 前检查清单
+提交 PR 前必须在本地通过以下四步检查：
+
+1. **格式化检查**
+   ```bash
+   cargo fmt && cargo fmt --check
+   ```
+2. **Clippy 静态检查**
+   ```bash
+   cargo clippy --workspace -- -D warnings
+   ```
+3. **测试**
+   ```bash
+   cargo test --workspace
+   ```
+   默认并行执行，确保所有测试稳定通过。
+4. **文档确认** — 根据变更类型检查是否需要更新相关文档（参见「文档约定」章节）
+
+### 提交信息格式
+遵循 [Conventional Commits](https://www.conventionalcommits.org/) 格式：
+
+| 类型 | 用途 |
+|------|------|
+| `feat:` | 新功能 |
+| `fix:` | 错误修复 |
+| `refactor:` | 重构（无功能变更） |
+| `docs:` | 文档变更 |
+| `test:` | 测试相关 |
+| `chore:` | 构建、CI、依赖等杂务 |
+
+示例：`feat: add IMAP idle support for real-time email monitoring`
 
 ## References
 - See DESIGN.md for architecture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,18 @@ and uses OpenCode to generate AI replies.
 - NEVER run `git config user.name` or `git config user.email` (local or global)
 - NEVER run `git config --global` for any setting
 
+## 测试要求
+
+### 测试隔离
+- 使用 `tempfile::TempDir` 创建临时目录，测试后自动清理
+- 禁止使用 `unsafe { std::env::set_var() }` 修改环境变量，避免污染全局状态
+- 测试用例不得依赖外部服务（网络、文件系统固定路径），使用 mock 或 test fixture
+
+### 并行安全
+- `cargo test --workspace` 默认并行模式必须稳定通过
+- 测试间不得共享可变状态；如必须串行，使用 `#[serial]` 标记并在 CI 中串行执行
+- 资源泄漏（如端口占用）的测试必须实现 `Drop` 或使用 `TempDir` 自动清理
+
 ## Development Workflow
 - Always create a feature branch: `git checkout -b feat/<name>`
 - After changes, run tests: `cargo test`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,3 +106,4 @@ and uses OpenCode to generate AI replies.
 - See CHANGELOG.md for version history
 - See IMPLEMENTATION.md for implementation phases
 - OpenCode Server API: https://opencode.ai/docs/server/
+- jin AGENTS.md (约束来源参考): https://github.com/kingye/jin/blob/main/AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,37 @@ and uses OpenCode to generate AI replies.
 
 示例：`feat: add IMAP idle support for real-time email monitoring`
 
+## 文档约定
+
+### 文件用途映射
+| 文件 | 定位 |
+|------|------|
+| `DESIGN.md` | 系统架构设计文档，记录设计决策和 trade-off |
+| `CHANGELOG.md` | 面向用户的版本变更记录 |
+| `docs/` | 专题文档目录（API 文档、配置指南等） |
+| `AGENTS.md` | AI agent 行为约束规则，使用精简、断言式语言编写 |
+
+> **AGENTS.md 编写规则**：使用断言式语言（"必须……" / "禁止……"），避免冗长描述，每条规则可直接作为判断依据。
+
+### 文档更新触发规则
+| 变更类型 | 需更新文档 |
+|----------|------------|
+| 架构变更、新 crate、模块拆分/合并 | `DESIGN.md` |
+| 新增配置项或环境变量 | `config.example.toml` 及 `README.md` |
+| 新增 channel 类型 | `docs/channels/` 对应文档 |
+| 功能变更（新增/修改/移除） | `CHANGELOG.md` |
+| Agent 行为规则变更 | `AGENTS.md` |
+
+### CHANGELOG 格式约束
+遵循 [Keep a Changelog](https://keepachangelog.com/) 规范，按以下顺序组织：
+
+1. **Added** — 新增功能
+2. **Changed** — 已变更的功能
+3. **Fixed** — 已修复的 bug
+4. **Removed** — 已移除的功能
+
+每项使用 `-` 列表，格式：`- {简短描述} (#{issue/PR 编号})`
+
 ## References
 - See DESIGN.md for architecture
 - See CHANGELOG.md for version history


### PR DESCRIPTION
## Spec

参照 `kingye/jin` 仓库的 AGENTS.md，在 JYC 项目的 AGENTS.md 中新增以下约束章节：

1. **测试要求** — 测试隔离（`TempDir`，禁止 `unsafe { std::env::set_var }`）、并行安全
2. **工作流约定** — 分支命名、PR 前检查清单、Conventional Commits 提交格式
3. **文档约定** — 文件用途映射、文档更新触发规则、CHANGELOG 格式约束

Fixes #220

## Implementation Plan

### Step 1: 在 AGENTS.md "Development Workflow" 之后新增「测试要求」章节
**What:** 在 `AGENTS.md` 中，紧跟 `## Development Workflow` 区块之后，新增 `## 测试要求` 章节。包含两个子节：`### 测试隔离`（要求 `tempfile::TempDir`，禁止 `unsafe { std::env::set_var }`）和 `### 并行安全`（要求 `cargo test --workspace` 默认并行模式稳定通过）。
**Why:** 参照 jin AGENTS.md 的 harness 约束，为 jyc 项目建立测试基础设施规范。现有代码中 `crates/jyc-agent/tests/unit_tests.rs` 和 `crates/jyc-types/src/config.rs` 已存在 `unsafe { std::env::set_var }` 违规，此规则为后续修复提供依据。
**Verify:** 阅读 `AGENTS.md`，确认新增章节存在且内容与讨论一致。

### Step 2: 将 "Development Workflow" 重构为「工作流约定」章节
**What:** 将现有 `## Development Workflow` 章节替换为 `## 工作流约定`，新增三个子节：
- `### 分支命名` — `feat/issue-{N}` / `fix/issue-{N}`，下划线分隔，禁止大写
- `### PR 前检查清单` — 四步检查：`cargo fmt && cargo fmt --check` → `cargo clippy --workspace -- -D warnings` → `cargo test --workspace`（默认并行） → 文档确认
- `### 提交信息格式` — Conventional Commits（`feat:` / `fix:` / `refactor:` / `docs:` / `test:` / `chore:`）

保留原有的 `## References` 章节不变。
**Why:** jin 的工作流约定更完整，包含分支命名规范、CI 检查清单、提交格式要求，jyc 应统一。
**Verify:** 阅读 `AGENTS.md`，确认旧 `## Development Workflow` 已被替换为 `## 工作流约定`，三个子节内容完整。

### Step 3: 新增「文档约定」章节
**What:** 在 `## 工作流约定` 之后新增 `## 文档约定` 章节，包含三个子节：
- `### 文件用途映射` — 列出 DESIGN.md、docs/ 目录、AGENTS.md 的定位，声明 AGENTS.md 的编写规则（精简、断言式语言）
- `### 文档更新触发规则` — 表格：架构变更 → DESIGN.md，新增配置项 → config.example.toml，新增 channel → 对应文档，功能变更 → CHANGELOG.md
- `### CHANGELOG 格式约束` — 遵循 Keep a Changelog，Added → Changed → Fixed → Removed 顺序
**Why:** jin 的文档约定确保每次代码变更都有对应的文档更新，提高项目可维护性。CHANGELOG 已有但缺少格式约束。
**Verify:** 阅读 `AGENTS.md`，确认 `## 文档约定` 章节存在，三个子节内容完整。

### Step 4: 更新 "References" 章节
**What:** 在 `## References` 章节末尾追加 jin AGENTS.md 的引用链接。
**Why:** 记录 jyc AGENTS.md 的约束来源，方便后续维护时追溯。
**Verify:** 检查 `## References` 包含指向 kingye/jin 的 AGENTS.md 引用。
