### PR TITLE
fix: update branch naming rules to include description

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,9 +34,9 @@ and uses OpenCode to generate AI replies.
 ## 工作流约定
 
 ### 分支命名
-- 功能分支：`feat/issue-{N}`（如 `feat/issue-220`）
-- 修复分支：`fix/issue-{N}`（如 `fix/issue-42`）
-- 使用下划线分隔多词，禁止大写字母
+- 功能分支：`feat/issue-{N}-<简短描述>`（如 `feat/issue-220-add-imap-idle`）
+- 修复分支：`fix/issue-{N}-<简短描述>`（如 `fix/issue-42-fix-timeout-panic`）
+- 使用连字符（`-`）分隔单词，禁止大写字母
 
 ### PR 前检查清单
 提交 PR 前必须在本地通过以下四步检查：


### PR DESCRIPTION
## Spec

将 AGENTS.md 中的分支命名规则从纯 Issue 编号格式（`feat/issue-{N}`）改为同时包含 Issue 编号和简短描述的格式（`feat/issue-{N}-<short-description>`），使分支名能直观反映其内容。同时修正「使用下划线分隔多词」的描述为「使用连字符」，保持与 Conventional Commits 前缀风格一致。

Fixes #223

## Implementation Plan

### Step 1: 更新 AGENTS.md 分支命名规则
**What:** 修改 `AGENTS.md` 第 36-39 行的「分支命名」章节，将：
```
- 功能分支：`feat/issue-{N}`（如 `feat/issue-220`）
- 修复分支：`fix/issue-{N}`（如 `fix/issue-42`）
- 使用下划线分隔多词，禁止大写字母
```
改为：
```
- 功能分支：`feat/issue-{N}-<简短描述>`（如 `feat/issue-220-add-imap-idle`）
- 修复分支：`fix/issue-{N}-<简短描述>`（如 `fix/issue-42-fix-timeout-panic`）
- 使用连字符（`-`）分隔单词，禁止大写字母
```
**Why:** 当前规则只有 Issue 编号，`git branch` 列表无法直接看出分支用途；新规则同时保留追溯性和可读性。
**Verify:** 肉眼确认 AGENTS.md 该章节内容与上述一致。

## Design Decisions
- 保留 Issue 编号（`issue-{N}`），确保与 GitHub issue 的 `Fixes #` 自动关联
- 新增简短描述部分，使用 kebab-case（连字符），与 git 分支命名惯例和 Conventional Commits 前缀（`feat:`, `fix:`）保持一致
- 将「下划线」改为「连字符」，修正原来与示例不符的问题（原来写了「下划线」，但示例 `feat/issue-220` 实际用的是连字符）