### PR TITLE
feat: 企业微信 (WeCom) webhook channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to JYC will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **WeCom (企业微信) Bot channel.** New channel type `wecom` supporting inbound
+  messages via shared axum HTTP server and outbound messages via Bot webhook
+  URL. Includes AES-256-CBC message decryption, SHA1 signature verification,
+  and auto-detection of text/markdown message types. (#225, #226)
+
 ## [0.3.9] - 2026-05-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "axum-macros",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1580,6 +1647,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "async-trait",
+ "axum",
  "base64",
  "cbc",
  "chrono",
@@ -1604,6 +1672,7 @@ dependencies = [
  "tokio-tungstenite 0.24.0",
  "tokio-util",
  "toml",
+ "tower",
  "tracing",
  "uuid",
  "wiremock",
@@ -1913,6 +1982,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
@@ -3227,6 +3302,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3886,6 +3972,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3924,6 +4011,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +279,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bon"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +355,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +407,16 @@ checksum = "8eebd66744a15ded14960ab4ccdbfb51ad3b81f51f3f04a80adac98c985396c9"
 dependencies = [
  "hashbrown 0.14.5",
  "stacker",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1415,6 +1454,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1527,13 +1576,16 @@ dependencies = [
 name = "jyc-channels"
 version = "0.3.9"
 dependencies = [
+ "aes",
  "anyhow",
  "arc-swap",
  "async-trait",
  "base64",
+ "cbc",
  "chrono",
  "comrak",
  "futures-util",
+ "hex",
  "jyc-core",
  "jyc-mcp",
  "jyc-services",
@@ -1545,6 +1597,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha1",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/config.example.toml
+++ b/config.example.toml
@@ -527,3 +527,34 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # #
 # # [channels.my_wechat_bot.patterns.rules]
 # # keywords = ["help", "support", "问题"]
+
+# # --- Channel: my_wecom_bot ---
+# # WeCom (企业微信) Bot channel.
+# # Receives messages via webhook callback (/webhook/{channel_name}) and
+# # sends replies via Bot webhook URL.
+# #
+# # Prerequisites:
+# # 1. Create a Bot in WeCom and configure the callback URL
+# #    (e.g., https://your-domain.com/webhook/my_wecom_bot)
+# # 2. Get the token, encoding_aes_key, and corp_id from WeCom callback settings
+# # 3. Get the Bot webhook URL from WeCom Bot settings
+# #
+# # Global HTTP server config (shared by all wecom channels):
+# [wecom]
+# bind_addr = "127.0.0.1:10001"
+#
+# [channels.my_wecom_bot]
+# type = "wecom"
+#
+# [channels.my_wecom_bot.wecom]
+# token = "your_wecom_token"
+# encoding_aes_key = "your_encoding_aes_key_43bytes"
+# corp_id = "ww1234567890abcdef"
+# webhook_url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx-xxx"
+#
+# # Define a catch-all pattern
+# [[channels.my_wecom_bot.patterns]]
+# name = "wecom_bot"
+#
+# [channels.my_wecom_bot.patterns.rules]
+# # keywords = ["help", "问题"]

--- a/crates/jyc-channels/Cargo.toml
+++ b/crates/jyc-channels/Cargo.toml
@@ -28,6 +28,10 @@ base64 = "0.22"
 uuid = { version = "1", features = ["v4"] }
 tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
 futures-util = "0.3"
+sha1 = "0.10"
+hex = "0.4"
+aes = "0.8"
+cbc = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/jyc-channels/Cargo.toml
+++ b/crates/jyc-channels/Cargo.toml
@@ -32,6 +32,8 @@ sha1 = "0.10"
 hex = "0.4"
 aes = "0.8"
 cbc = "0.1"
+axum = { version = "0.7", features = ["macros"] }
+tower = "0.5"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/jyc-channels/src/lib.rs
+++ b/crates/jyc-channels/src/lib.rs
@@ -3,3 +3,4 @@ pub mod feishu;
 pub mod github;
 pub mod registry;
 pub mod wechat;
+pub mod wecom;

--- a/crates/jyc-channels/src/wecom/crypto.rs
+++ b/crates/jyc-channels/src/wecom/crypto.rs
@@ -163,7 +163,7 @@ mod tests {
     fn test_decrypt_short_key() {
         // Key that decodes to less than 43 bytes
         let short_key =
-            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &[0u8; 20]);
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, [0u8; 20]);
         let result = decrypt_msg(&short_key, "dGVzdA==");
         assert!(result.is_err());
     }
@@ -172,7 +172,7 @@ mod tests {
     fn test_decrypt_invalid_encrypt() {
         // Invalid base64 in encrypt field
         let long_key =
-            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &[0u8; 43]);
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, [0u8; 43]);
         let result = decrypt_msg(&long_key, "not-base64!!!");
         assert!(result.is_err());
     }

--- a/crates/jyc-channels/src/wecom/crypto.rs
+++ b/crates/jyc-channels/src/wecom/crypto.rs
@@ -1,0 +1,195 @@
+//! WeCom (企业微信) message encryption/decryption.
+//!
+//! Implements the official WeCom callback message encryption protocol:
+//! - Signature verification: SHA1(token, timestamp, nonce, encrypt)
+//! - AES-256-CBC decryption with PKCS7 padding
+//!
+//! Reference: https://developer.work.weixin.qq.com/document/path/90968
+
+use aes::cipher::{block_padding::Pkcs7, BlockDecryptMut, KeyIvInit};
+use anyhow::{Context, Result};
+use sha1::{Digest, Sha1};
+
+type Aes256CbcDec = cbc::Decryptor<aes::Aes256>;
+
+/// Verify the callback signature.
+///
+/// The signature is computed as SHA1(token || timestamp || nonce || encrypt).
+/// Returns `true` if the computed signature matches the provided one.
+pub fn verify_signature(
+    token: &str,
+    timestamp: &str,
+    nonce: &str,
+    encrypt: &str,
+    msg_signature: &str,
+) -> bool {
+    let mut hasher = Sha1::new();
+    hasher.update(token.as_bytes());
+    hasher.update(timestamp.as_bytes());
+    hasher.update(nonce.as_bytes());
+    hasher.update(encrypt.as_bytes());
+    let computed = hex::encode(hasher.finalize());
+    computed == msg_signature
+}
+
+/// Decrypt AES-256-CBC encrypted message with PKCS7 padding.
+///
+/// The raw key is the Base64-decoded `encoding_aes_key` (with "=" padding).
+/// The AES key is the first 32 bytes of the decoded key.
+/// The IV is the last 16 bytes of the decoded key (after first 32 bytes).
+///
+/// The decrypted plaintext format is:
+/// ```text
+/// [4-byte network byte order content length][content][receiveid (corpid)]
+/// [padding]
+/// ```
+///
+/// Returns the decrypted content string (the inner XML).
+pub fn decrypt_msg(encoding_aes_key: &str, encrypt: &str) -> Result<String> {
+    let raw_key = base64::Engine::decode(
+        &base64::engine::general_purpose::STANDARD,
+        encoding_aes_key,
+    )
+    .context("failed to decode encoding_aes_key from base64")?;
+
+    if raw_key.len() != 43 {
+        anyhow::bail!(
+            "encoding_aes_key decoded length is {}, expected 43 bytes",
+            raw_key.len()
+        );
+    }
+
+    // The AES key is the first 32 bytes of the decoded encoding_aes_key
+    let aes_key = &raw_key[..32];
+    // The IV is the last 16 bytes (bytes 32..48, but raw_key is only 43 bytes;
+    // WeCom spec says the key is Base64-decoded to 43 bytes, of which:
+    // - first 32 bytes = AES key
+    // - remaining 11 bytes + 5 zero bytes = IV
+    let iv_partial = &raw_key[32..43];
+    let mut iv = [0u8; 16];
+    iv[..iv_partial.len()].copy_from_slice(iv_partial);
+
+    let ciphertext = base64::Engine::decode(
+        &base64::engine::general_purpose::STANDARD,
+        encrypt,
+    )
+    .context("failed to decode encrypt from base64")?;
+
+    let mut buf = ciphertext;
+    let decrypted = Aes256CbcDec::new(aes_key.into(), &iv.into())
+        .decrypt_padded_mut::<Pkcs7>(&mut buf)
+        .map_err(|e| anyhow::anyhow!("AES decryption failed: {:?}", e))?;
+
+    // Parse: [4-byte content length (network byte order)][content][receiveid]
+    if decrypted.len() < 4 {
+        anyhow::bail!("decrypted content too short: {} bytes", decrypted.len());
+    }
+
+    let content_len =
+        u32::from_be_bytes([decrypted[0], decrypted[1], decrypted[2], decrypted[3]])
+            as usize;
+
+    if decrypted.len() < 4 + content_len {
+        anyhow::bail!(
+            "decrypted content length mismatch: header says {} but remaining is {}",
+            content_len,
+            decrypted.len() - 4
+        );
+    }
+
+    let content = &decrypted[4..4 + content_len];
+    let content_str =
+        String::from_utf8(content.to_vec()).context("decrypted content is not valid UTF-8")?;
+
+    Ok(content_str)
+}
+
+/// Get a random nonce string (for generating callback response).
+pub fn generate_nonce() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{nanos}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_signature_verification() {
+        let token = "test_token";
+        let timestamp = "1400000000";
+        let nonce = "123456";
+        let encrypt = "encrypted_content_placeholder";
+        let msg_signature = compute_signature(token, timestamp, nonce, encrypt);
+
+        assert!(verify_signature(
+            token, timestamp, nonce, encrypt, &msg_signature
+        ));
+        assert!(!verify_signature(
+            token, timestamp, nonce, encrypt, "invalid_signature"
+        ));
+    }
+
+    fn compute_signature(token: &str, timestamp: &str, nonce: &str, encrypt: &str) -> String {
+        let mut hasher = Sha1::new();
+        hasher.update(token.as_bytes());
+        hasher.update(timestamp.as_bytes());
+        hasher.update(nonce.as_bytes());
+        hasher.update(encrypt.as_bytes());
+        hex::encode(hasher.finalize())
+    }
+
+    #[test]
+    fn test_signature_different_order_fails() {
+        // Changing the order of arguments should produce different signature
+        let sig1 = compute_signature("token_a", "1000", "nonce1", "encrypt1");
+        let sig2 = compute_signature("token_b", "1000", "nonce1", "encrypt1");
+        assert_ne!(sig1, sig2);
+    }
+
+    #[test]
+    fn test_decrypt_invalid_key() {
+        let result = decrypt_msg("not-base64!!!", "dGVzdA==");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decrypt_short_key() {
+        // Key that decodes to less than 43 bytes
+        let short_key = base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            &[0u8; 20],
+        );
+        let result = decrypt_msg(&short_key, "dGVzdA==");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decrypt_invalid_encrypt() {
+        // Invalid base64 in encrypt field
+        let long_key = base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            &[0u8; 43],
+        );
+        let result = decrypt_msg(&long_key, "not-base64!!!");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_generate_nonce_is_non_empty() {
+        let nonce = generate_nonce();
+        assert!(!nonce.is_empty());
+    }
+
+    #[test]
+    fn test_generate_nonce_unique() {
+        let nonce1 = generate_nonce();
+        let nonce2 = generate_nonce();
+        // Very unlikely to collide
+        assert_ne!(nonce1, nonce2);
+    }
+}

--- a/crates/jyc-channels/src/wecom/crypto.rs
+++ b/crates/jyc-channels/src/wecom/crypto.rs
@@ -6,7 +6,7 @@
 //!
 //! Reference: https://developer.work.weixin.qq.com/document/path/90968
 
-use aes::cipher::{block_padding::Pkcs7, BlockDecryptMut, KeyIvInit};
+use aes::cipher::{BlockDecryptMut, KeyIvInit, block_padding::Pkcs7};
 use anyhow::{Context, Result};
 use sha1::{Digest, Sha1};
 
@@ -46,11 +46,9 @@ pub fn verify_signature(
 ///
 /// Returns the decrypted content string (the inner XML).
 pub fn decrypt_msg(encoding_aes_key: &str, encrypt: &str) -> Result<String> {
-    let raw_key = base64::Engine::decode(
-        &base64::engine::general_purpose::STANDARD,
-        encoding_aes_key,
-    )
-    .context("failed to decode encoding_aes_key from base64")?;
+    let raw_key =
+        base64::Engine::decode(&base64::engine::general_purpose::STANDARD, encoding_aes_key)
+            .context("failed to decode encoding_aes_key from base64")?;
 
     if raw_key.len() != 43 {
         anyhow::bail!(
@@ -69,11 +67,8 @@ pub fn decrypt_msg(encoding_aes_key: &str, encrypt: &str) -> Result<String> {
     let mut iv = [0u8; 16];
     iv[..iv_partial.len()].copy_from_slice(iv_partial);
 
-    let ciphertext = base64::Engine::decode(
-        &base64::engine::general_purpose::STANDARD,
-        encrypt,
-    )
-    .context("failed to decode encrypt from base64")?;
+    let ciphertext = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, encrypt)
+        .context("failed to decode encrypt from base64")?;
 
     let mut buf = ciphertext;
     let decrypted = Aes256CbcDec::new(aes_key.into(), &iv.into())
@@ -86,8 +81,7 @@ pub fn decrypt_msg(encoding_aes_key: &str, encrypt: &str) -> Result<String> {
     }
 
     let content_len =
-        u32::from_be_bytes([decrypted[0], decrypted[1], decrypted[2], decrypted[3]])
-            as usize;
+        u32::from_be_bytes([decrypted[0], decrypted[1], decrypted[2], decrypted[3]]) as usize;
 
     if decrypted.len() < 4 + content_len {
         anyhow::bail!(
@@ -127,10 +121,18 @@ mod tests {
         let msg_signature = compute_signature(token, timestamp, nonce, encrypt);
 
         assert!(verify_signature(
-            token, timestamp, nonce, encrypt, &msg_signature
+            token,
+            timestamp,
+            nonce,
+            encrypt,
+            &msg_signature
         ));
         assert!(!verify_signature(
-            token, timestamp, nonce, encrypt, "invalid_signature"
+            token,
+            timestamp,
+            nonce,
+            encrypt,
+            "invalid_signature"
         ));
     }
 
@@ -160,10 +162,8 @@ mod tests {
     #[test]
     fn test_decrypt_short_key() {
         // Key that decodes to less than 43 bytes
-        let short_key = base64::Engine::encode(
-            &base64::engine::general_purpose::STANDARD,
-            &[0u8; 20],
-        );
+        let short_key =
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &[0u8; 20]);
         let result = decrypt_msg(&short_key, "dGVzdA==");
         assert!(result.is_err());
     }
@@ -171,10 +171,8 @@ mod tests {
     #[test]
     fn test_decrypt_invalid_encrypt() {
         // Invalid base64 in encrypt field
-        let long_key = base64::Engine::encode(
-            &base64::engine::general_purpose::STANDARD,
-            &[0u8; 43],
-        );
+        let long_key =
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &[0u8; 43]);
         let result = decrypt_msg(&long_key, "not-base64!!!");
         assert!(result.is_err());
     }

--- a/crates/jyc-channels/src/wecom/inbound.rs
+++ b/crates/jyc-channels/src/wecom/inbound.rs
@@ -160,7 +160,7 @@ impl WecomInboundAdapter {
     }
 }
 
-fn register_handler(
+async fn register_handler(
     config: &WecomConfig,
     channel_name: &str,
     thread_name: &str,
@@ -169,8 +169,6 @@ fn register_handler(
 ) -> Result<()> {
     let channel_name_clone_1 = channel_name.to_string();
     let channel_name_clone_2 = channel_name_clone_1.clone();
-    let channel_name_clone_3 = channel_name_clone_1.clone();
-    let thread_name_owned = thread_name.to_string();
     let on_message: Arc<dyn Fn(InboundMessage) -> Result<()> + Send + Sync> = Arc::from(on_message);
 
     // Build the per-channel webhook config
@@ -228,17 +226,13 @@ fn register_handler(
         }),
     };
 
-    let server_clone = server.clone();
-    let chan = channel_name_clone_3.clone();
-    let th = thread_name_owned.clone();
-    tokio::spawn(async move {
-        server_clone.register_channel(&chan, webhook_config).await;
-        tracing::info!(
-            channel = %chan,
-            thread = %th,
-            "WeCom inbound adapter registered webhook handler"
-        );
-    });
+    server.register_channel(channel_name, webhook_config).await;
+
+    tracing::info!(
+        channel = %channel_name,
+        thread = %thread_name,
+        "WeCom inbound adapter registered webhook handler"
+    );
 
     Ok(())
 }
@@ -282,7 +276,8 @@ impl InboundAdapter for WecomInboundAdapter {
             &self.thread_name,
             options.on_message,
             self.server.clone(),
-        )?;
+        )
+        .await?;
 
         tracing::info!(
             channel = %channel_name,

--- a/crates/jyc-channels/src/wecom/inbound.rs
+++ b/crates/jyc-channels/src/wecom/inbound.rs
@@ -39,13 +39,18 @@ impl ChannelMatcher for WecomMatcher {
 
     fn derive_thread_name(
         &self,
-        _message: &InboundMessage,
+        message: &InboundMessage,
         _patterns: &[ChannelPattern],
         _pattern_match: Option<&PatternMatch>,
     ) -> String {
-        // WeCom uses one bot = one fixed thread.
-        // The thread name is derived from the channel name by the inbound adapter.
-        "wecom".to_string()
+        // Extract the channel name from sender_address (format: "wecom:{channel_name}").
+        // This is the single source of truth for thread name derivation — the adapter
+        // delegates to this method so the saver and the router agree on the thread name.
+        message
+            .sender_address
+            .strip_prefix("wecom:")
+            .map(|s| jyc_utils::helpers::sanitize_for_filesystem(s))
+            .unwrap_or_else(|| "wecom".to_string())
     }
 
     fn match_message(
@@ -246,11 +251,15 @@ impl ChannelMatcher for WecomInboundAdapter {
 
     fn derive_thread_name(
         &self,
-        _message: &InboundMessage,
-        _patterns: &[ChannelPattern],
-        _pattern_match: Option<&PatternMatch>,
+        message: &InboundMessage,
+        patterns: &[ChannelPattern],
+        pattern_match: Option<&PatternMatch>,
     ) -> String {
-        self.thread_name.clone()
+        // Delegate to `WecomMatcher` so the saver and the router agree
+        // on the thread name. They MUST agree — when they don't, the
+        // attachment saver writes to a different directory than where
+        // the agent thread actually runs.
+        WecomMatcher.derive_thread_name(message, patterns, pattern_match)
     }
 
     fn match_message(
@@ -465,8 +474,42 @@ mod tests {
     #[test]
     fn test_derive_thread_name() {
         let matcher = WecomMatcher;
+        let mut msg = make_wecom_message("user1", "Hello");
+        msg.sender_address = "wecom:my_bot".to_string();
+        let name = matcher.derive_thread_name(&msg, &[], None);
+        assert_eq!(name, "my_bot");
+    }
+
+    #[test]
+    fn test_derive_thread_name_fallback() {
+        let matcher = WecomMatcher;
         let msg = make_wecom_message("user1", "Hello");
+        // sender_address without "wecom:" prefix should fall back to "wecom"
         let name = matcher.derive_thread_name(&msg, &[], None);
         assert_eq!(name, "wecom");
+    }
+
+    #[test]
+    fn test_adapter_derive_thread_name_matches_matcher() {
+        use std::sync::Arc;
+        use crate::wecom::server::WecomWebhookServer;
+
+        let config = WecomConfig {
+            token: "test".to_string(),
+            encoding_aes_key: "abc123abc123abc123abc123abc123abc123abc123abc123abc12".to_string(),
+            corp_id: "test_corp".to_string(),
+            webhook_url: "https://example.com/webhook".to_string(),
+            metadata: std::collections::HashMap::new(),
+        };
+        let server = Arc::new(WecomWebhookServer::new("127.0.0.1:1"));
+        let adapter = WecomInboundAdapter::new(&config, "my_bot", server);
+
+        let mut msg = make_wecom_message("user1", "Hello");
+        msg.sender_address = "wecom:my_bot".to_string();
+
+        let adapter_name = adapter.derive_thread_name(&msg, &[], None);
+        let matcher_name = WecomMatcher.derive_thread_name(&msg, &[], None);
+        assert_eq!(adapter_name, matcher_name);
+        assert_eq!(adapter_name, "my_bot");
     }
 }

--- a/crates/jyc-channels/src/wecom/inbound.rs
+++ b/crates/jyc-channels/src/wecom/inbound.rs
@@ -49,7 +49,7 @@ impl ChannelMatcher for WecomMatcher {
         message
             .sender_address
             .strip_prefix("wecom:")
-            .map(|s| jyc_utils::helpers::sanitize_for_filesystem(s))
+            .map(jyc_utils::helpers::sanitize_for_filesystem)
             .unwrap_or_else(|| "wecom".to_string())
     }
 
@@ -85,14 +85,11 @@ pub fn wecom_match_message(
                 continue;
             }
 
-            let body_lower = message
-                .content
-                .text
-                .as_deref()
-                .unwrap_or("")
-                .to_lowercase();
+            let body_lower = message.content.text.as_deref().unwrap_or("").to_lowercase();
 
-            let keyword_match = keywords.iter().any(|k| body_lower.contains(&k.to_lowercase()));
+            let keyword_match = keywords
+                .iter()
+                .any(|k| body_lower.contains(&k.to_lowercase()));
             if !keyword_match {
                 matches = false;
             } else {
@@ -115,13 +112,13 @@ pub fn wecom_match_message(
             }
 
             // Check regex match
-            if let Some(ref regex_str) = sender.regex {
-                if let Ok(re) = regex::Regex::new(regex_str) {
-                    if !re.is_match(sender_addr) {
-                        matches = false;
-                    } else {
-                        match_details.insert("sender_regex".to_string(), regex_str.clone());
-                    }
+            if let Some(ref regex_str) = sender.regex
+                && let Ok(re) = regex::Regex::new(regex_str)
+            {
+                if !re.is_match(sender_addr) {
+                    matches = false;
+                } else {
+                    match_details.insert("sender_regex".to_string(), regex_str.clone());
                 }
             }
         }
@@ -153,11 +150,7 @@ pub struct WecomInboundAdapter {
 
 impl WecomInboundAdapter {
     /// Create a new WeCom inbound adapter.
-    pub fn new(
-        config: &WecomConfig,
-        channel_name: &str,
-        server: Arc<WecomWebhookServer>,
-    ) -> Self {
+    pub fn new(config: &WecomConfig, channel_name: &str, server: Arc<WecomWebhookServer>) -> Self {
         Self {
             channel_name: channel_name.to_string(),
             thread_name: sanitize_for_filesystem(channel_name),
@@ -189,7 +182,10 @@ fn register_handler(
             let message = InboundMessage {
                 id: uuid::Uuid::new_v4().to_string(),
                 channel: "wecom".to_string(),
-                channel_uid: format!("wecom_{}", chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)),
+                channel_uid: format!(
+                    "wecom_{}",
+                    chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+                ),
                 sender: "wecom_bot".to_string(),
                 sender_address: format!("wecom:{}", channel_name_clone_1),
                 recipients: vec![],
@@ -207,7 +203,10 @@ fn register_handler(
                 metadata: {
                     let mut m = HashMap::new();
                     let meta_channel = channel_name_clone_2.clone();
-                    m.insert("channel_name".to_string(), serde_json::Value::String(meta_channel));
+                    m.insert(
+                        "channel_name".to_string(),
+                        serde_json::Value::String(meta_channel),
+                    );
                     m
                 },
                 matched_pattern: None,
@@ -491,8 +490,8 @@ mod tests {
 
     #[test]
     fn test_adapter_derive_thread_name_matches_matcher() {
-        use std::sync::Arc;
         use crate::wecom::server::WecomWebhookServer;
+        use std::sync::Arc;
 
         let config = WecomConfig {
             token: "test".to_string(),

--- a/crates/jyc-channels/src/wecom/inbound.rs
+++ b/crates/jyc-channels/src/wecom/inbound.rs
@@ -1,0 +1,472 @@
+//! WeCom (企业微信) inbound adapter and matcher implementation.
+//!
+//! This module handles receiving messages from WeCom via the shared webhook server.
+//! Unlike WeChat's WebSocket or Feishu's WebSocket, WeCom uses HTTP callbacks:
+//! WeCom sends POST requests to the shared axum HTTP server at `/webhook/{channel_name}`.
+//!
+//! One channel = one Bot = one fixed thread.
+//! Thread name is derived from the channel configuration name.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+use jyc_types::{
+    ChannelMatcher, ChannelPattern, InboundAdapter, InboundAdapterOptions, InboundMessage,
+    PatternMatch,
+};
+use jyc_utils::helpers::sanitize_for_filesystem;
+
+use crate::wecom::server::{ChannelWebhookConfig, WecomWebhookServer};
+use jyc_types::WecomConfig;
+
+/// WeCom channel matcher — stateless pattern matching.
+///
+/// Supports:
+/// - `keywords`: match messages containing specific words (case-insensitive)
+/// - `sender`: match sender by exact address (shared with email/feishu/wechat)
+///
+/// All present rules use AND logic. Empty rules match all messages.
+/// One bot = one fixed thread: thread name is the channel name.
+pub struct WecomMatcher;
+
+impl ChannelMatcher for WecomMatcher {
+    fn channel_type(&self) -> &str {
+        "wecom"
+    }
+
+    fn derive_thread_name(
+        &self,
+        _message: &InboundMessage,
+        _patterns: &[ChannelPattern],
+        _pattern_match: Option<&PatternMatch>,
+    ) -> String {
+        // WeCom uses one bot = one fixed thread.
+        // The thread name is derived from the channel name by the inbound adapter.
+        "wecom".to_string()
+    }
+
+    fn match_message(
+        &self,
+        message: &InboundMessage,
+        patterns: &[ChannelPattern],
+    ) -> Option<PatternMatch> {
+        wecom_match_message(message, patterns)
+    }
+}
+
+/// Match a message against WeCom-specific patterns.
+///
+/// Rules within a pattern use AND logic — all present rules must match.
+/// Within each rule, sub-values use OR logic.
+/// Returns the first matching pattern.
+pub fn wecom_match_message(
+    message: &InboundMessage,
+    patterns: &[ChannelPattern],
+) -> Option<PatternMatch> {
+    for pattern in patterns {
+        if !pattern.enabled {
+            continue;
+        }
+
+        let mut matches = true;
+        let mut match_details = HashMap::new();
+
+        // --- Keywords rule ---
+        if let Some(ref keywords) = pattern.rules.keywords {
+            if keywords.is_empty() {
+                continue;
+            }
+
+            let body_lower = message
+                .content
+                .text
+                .as_deref()
+                .unwrap_or("")
+                .to_lowercase();
+
+            let keyword_match = keywords.iter().any(|k| body_lower.contains(&k.to_lowercase()));
+            if !keyword_match {
+                matches = false;
+            } else {
+                match_details.insert("keywords".to_string(), keywords.join(","));
+            }
+        }
+
+        // --- Sender rule ---
+        if let Some(ref sender) = pattern.rules.sender {
+            let sender_addr = &message.sender_address;
+
+            // Check exact matches
+            if let Some(ref exact) = sender.exact {
+                let exact_match = exact.iter().any(|e| e.eq_ignore_ascii_case(sender_addr));
+                if !exact_match {
+                    matches = false;
+                } else {
+                    match_details.insert("sender_exact".to_string(), sender_addr.clone());
+                }
+            }
+
+            // Check regex match
+            if let Some(ref regex_str) = sender.regex {
+                if let Ok(re) = regex::Regex::new(regex_str) {
+                    if !re.is_match(sender_addr) {
+                        matches = false;
+                    } else {
+                        match_details.insert("sender_regex".to_string(), regex_str.clone());
+                    }
+                }
+            }
+        }
+
+        if matches {
+            return Some(PatternMatch {
+                pattern_name: pattern.name.clone(),
+                channel: "wecom".to_string(),
+                matches: match_details,
+            });
+        }
+    }
+
+    None
+}
+
+/// WeCom inbound adapter.
+///
+/// Unlike Feishu/WeChat which maintain persistent connections (WebSocket),
+/// WeCom uses HTTP callbacks. The inbound adapter:
+/// 1. Registers a callback handler with the shared WecomWebhookServer
+/// 2. Runs until cancellation (the actual work is done by the server)
+pub struct WecomInboundAdapter {
+    channel_name: String,
+    thread_name: String,
+    config: WecomConfig,
+    server: Arc<WecomWebhookServer>,
+}
+
+impl WecomInboundAdapter {
+    /// Create a new WeCom inbound adapter.
+    pub fn new(
+        config: &WecomConfig,
+        channel_name: &str,
+        server: Arc<WecomWebhookServer>,
+    ) -> Self {
+        Self {
+            channel_name: channel_name.to_string(),
+            thread_name: sanitize_for_filesystem(channel_name),
+            config: config.clone(),
+            server,
+        }
+    }
+}
+
+fn register_handler(
+    config: &WecomConfig,
+    channel_name: &str,
+    thread_name: &str,
+    on_message: Box<dyn Fn(InboundMessage) -> Result<()> + Send + Sync>,
+    server: Arc<WecomWebhookServer>,
+) -> Result<()> {
+    let channel_name_clone_1 = channel_name.to_string();
+    let channel_name_clone_2 = channel_name_clone_1.clone();
+    let channel_name_clone_3 = channel_name_clone_1.clone();
+    let thread_name_owned = thread_name.to_string();
+    let on_message: Arc<dyn Fn(InboundMessage) -> Result<()> + Send + Sync> = Arc::from(on_message);
+
+    // Build the per-channel webhook config
+    let webhook_config = ChannelWebhookConfig {
+        token: config.token.clone(),
+        encoding_aes_key: config.encoding_aes_key.clone(),
+        corp_id: config.corp_id.clone(),
+        on_message: Arc::new(move |decrypted_xml: String| {
+            let message = InboundMessage {
+                id: uuid::Uuid::new_v4().to_string(),
+                channel: "wecom".to_string(),
+                channel_uid: format!("wecom_{}", chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)),
+                sender: "wecom_bot".to_string(),
+                sender_address: format!("wecom:{}", channel_name_clone_1),
+                recipients: vec![],
+                topic: "WeCom Message".to_string(),
+                content: jyc_types::MessageContent {
+                    text: Some(decrypted_xml),
+                    html: None,
+                    markdown: None,
+                },
+                timestamp: chrono::Utc::now(),
+                thread_refs: None,
+                reply_to_id: None,
+                external_id: None,
+                attachments: vec![],
+                metadata: {
+                    let mut m = HashMap::new();
+                    let meta_channel = channel_name_clone_2.clone();
+                    m.insert("channel_name".to_string(), serde_json::Value::String(meta_channel));
+                    m
+                },
+                matched_pattern: None,
+            };
+
+            let cb = on_message.clone();
+            let err_channel = channel_name_clone_2.clone();
+            tokio::spawn(async move {
+                if let Err(e) = cb(message) {
+                    tracing::error!(
+                        error = %e,
+                        channel = %err_channel,
+                        "WeCom inbound: on_message callback error"
+                    );
+                }
+            });
+
+            Ok(())
+        }),
+    };
+
+    let server_clone = server.clone();
+    let chan = channel_name_clone_3.clone();
+    let th = thread_name_owned.clone();
+    tokio::spawn(async move {
+        server_clone.register_channel(&chan, webhook_config).await;
+        tracing::info!(
+            channel = %chan,
+            thread = %th,
+            "WeCom inbound adapter registered webhook handler"
+        );
+    });
+
+    Ok(())
+}
+
+impl ChannelMatcher for WecomInboundAdapter {
+    fn channel_type(&self) -> &str {
+        "wecom"
+    }
+
+    fn derive_thread_name(
+        &self,
+        _message: &InboundMessage,
+        _patterns: &[ChannelPattern],
+        _pattern_match: Option<&PatternMatch>,
+    ) -> String {
+        self.thread_name.clone()
+    }
+
+    fn match_message(
+        &self,
+        message: &InboundMessage,
+        patterns: &[ChannelPattern],
+    ) -> Option<PatternMatch> {
+        wecom_match_message(message, patterns)
+    }
+}
+
+#[async_trait]
+impl InboundAdapter for WecomInboundAdapter {
+    async fn start(&self, options: InboundAdapterOptions, cancel: CancellationToken) -> Result<()> {
+        let channel_name = self.channel_name.clone();
+
+        // Register the webhook callback handler with the on_message callback
+        register_handler(
+            &self.config,
+            &channel_name,
+            &self.thread_name,
+            options.on_message,
+            self.server.clone(),
+        )?;
+
+        tracing::info!(
+            channel = %channel_name,
+            "WeCom inbound adapter started (waiting for webhook callbacks)"
+        );
+
+        // Wait until cancellation
+        cancel.cancelled().await;
+
+        tracing::info!(
+            channel = %channel_name,
+            "WeCom inbound adapter stopped"
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jyc_types::{MessageContent, PatternRules, SenderRule};
+
+    fn make_wecom_message(sender: &str, text: &str) -> InboundMessage {
+        InboundMessage {
+            id: "test-id".to_string(),
+            channel: "wecom".to_string(),
+            channel_uid: "test-uid".to_string(),
+            sender: sender.to_string(),
+            sender_address: sender.to_string(),
+            recipients: vec![],
+            topic: "Test".to_string(),
+            content: MessageContent {
+                text: Some(text.to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata: HashMap::new(),
+            matched_pattern: None,
+        }
+    }
+
+    fn make_wecom_pattern(
+        name: &str,
+        keywords: Option<Vec<String>>,
+        sender: Option<SenderRule>,
+    ) -> ChannelPattern {
+        ChannelPattern {
+            name: name.to_string(),
+            channel: "wecom".to_string(),
+            enabled: true,
+            rules: PatternRules {
+                keywords,
+                sender,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_channel_type() {
+        let matcher = WecomMatcher;
+        assert_eq!(matcher.channel_type(), "wecom");
+    }
+
+    #[test]
+    fn test_match_by_keywords() {
+        let msg = make_wecom_message("user1", "I need 帮助 with this");
+        let patterns = vec![make_wecom_pattern(
+            "help_pattern",
+            Some(vec!["帮助".to_string(), "help".to_string()]),
+            None,
+        )];
+
+        let result = wecom_match_message(&msg, &patterns);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().pattern_name, "help_pattern");
+    }
+
+    #[test]
+    fn test_match_keywords_case_insensitive() {
+        let msg = make_wecom_message("user1", "I need HELP");
+        let patterns = vec![make_wecom_pattern(
+            "help_pattern",
+            Some(vec!["help".to_string()]),
+            None,
+        )];
+
+        assert!(wecom_match_message(&msg, &patterns).is_some());
+    }
+
+    #[test]
+    fn test_no_match_wrong_keywords() {
+        let msg = make_wecom_message("user1", "Just chatting");
+        let patterns = vec![make_wecom_pattern(
+            "help_pattern",
+            Some(vec!["帮助".to_string(), "help".to_string()]),
+            None,
+        )];
+
+        assert!(wecom_match_message(&msg, &patterns).is_none());
+    }
+
+    #[test]
+    fn test_empty_rules_matches_all() {
+        let msg = make_wecom_message("user1", "Hello");
+        let patterns = vec![make_wecom_pattern("catch_all", None, None)];
+
+        assert!(wecom_match_message(&msg, &patterns).is_some());
+    }
+
+    #[test]
+    fn test_match_by_sender() {
+        let msg = make_wecom_message("wx_abc123", "Hello");
+        let patterns = vec![make_wecom_pattern(
+            "vip_user",
+            None,
+            Some(SenderRule {
+                exact: Some(vec!["wx_abc123".to_string()]),
+                ..Default::default()
+            }),
+        )];
+
+        assert!(wecom_match_message(&msg, &patterns).is_some());
+    }
+
+    #[test]
+    fn test_no_match_wrong_sender() {
+        let msg = make_wecom_message("other_user", "Hello");
+        let patterns = vec![make_wecom_pattern(
+            "vip_user",
+            None,
+            Some(SenderRule {
+                exact: Some(vec!["wx_abc123".to_string()]),
+                ..Default::default()
+            }),
+        )];
+
+        assert!(wecom_match_message(&msg, &patterns).is_none());
+    }
+
+    #[test]
+    fn test_disabled_pattern_ignored() {
+        let msg = make_wecom_message("user1", "帮助 please");
+        let mut pattern = make_wecom_pattern("help_pattern", Some(vec!["帮助".to_string()]), None);
+        pattern.enabled = false;
+
+        let result = wecom_match_message(&msg, &[pattern]);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_keywords_and_sender_and() {
+        let msg = make_wecom_message("vip_user", "需要帮助");
+        let patterns = vec![make_wecom_pattern(
+            "vip_help",
+            Some(vec!["帮助".to_string()]),
+            Some(SenderRule {
+                exact: Some(vec!["vip_user".to_string()]),
+                ..Default::default()
+            }),
+        )];
+
+        assert!(wecom_match_message(&msg, &patterns).is_some());
+    }
+
+    #[test]
+    fn test_keywords_and_sender_no_match() {
+        let msg = make_wecom_message("other_user", "需要帮助");
+        let patterns = vec![make_wecom_pattern(
+            "vip_help",
+            Some(vec!["帮助".to_string()]),
+            Some(SenderRule {
+                exact: Some(vec!["vip_user".to_string()]),
+                ..Default::default()
+            }),
+        )];
+
+        assert!(wecom_match_message(&msg, &patterns).is_none());
+    }
+
+    #[test]
+    fn test_derive_thread_name() {
+        let matcher = WecomMatcher;
+        let msg = make_wecom_message("user1", "Hello");
+        let name = matcher.derive_thread_name(&msg, &[], None);
+        assert_eq!(name, "wecom");
+    }
+}

--- a/crates/jyc-channels/src/wecom/mod.rs
+++ b/crates/jyc-channels/src/wecom/mod.rs
@@ -11,4 +11,5 @@
 //! - One channel = one Bot = one fixed thread (similar to WeChat).
 
 pub mod crypto;
+pub mod inbound;
 pub mod server;

--- a/crates/jyc-channels/src/wecom/mod.rs
+++ b/crates/jyc-channels/src/wecom/mod.rs
@@ -1,0 +1,13 @@
+//! WeCom (企业微信) channel implementation for JYC.
+//!
+//! This module provides inbound and outbound adapters for the WeCom messaging platform.
+//! WeCom uses a shared HTTP server (axum) for receiving callback messages and
+//! Bot webhook URLs for sending messages.
+//!
+//! Architecture:
+//! - Inbound: Shared axum HTTP server at `/webhook/{channel_name}`, all channels
+//!   share one server instance (global `wecom.bind_addr`).
+//! - Outbound: POST to Bot webhook URL for each channel.
+//! - One channel = one Bot = one fixed thread (similar to WeChat).
+
+pub mod crypto;

--- a/crates/jyc-channels/src/wecom/mod.rs
+++ b/crates/jyc-channels/src/wecom/mod.rs
@@ -12,4 +12,5 @@
 
 pub mod crypto;
 pub mod inbound;
+pub mod outbound;
 pub mod server;

--- a/crates/jyc-channels/src/wecom/mod.rs
+++ b/crates/jyc-channels/src/wecom/mod.rs
@@ -11,3 +11,4 @@
 //! - One channel = one Bot = one fixed thread (similar to WeChat).
 
 pub mod crypto;
+pub mod server;

--- a/crates/jyc-channels/src/wecom/outbound.rs
+++ b/crates/jyc-channels/src/wecom/outbound.rs
@@ -1,0 +1,262 @@
+//! WeCom (企业微信) outbound adapter implementation.
+//!
+//! This module handles sending messages via WeCom Bot webhook URLs.
+//! WeCom Bot supports text and markdown message types.
+//!
+//! Reference: https://developer.work.weixin.qq.com/document/path/91770
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use std::path::Path;
+use std::sync::Arc;
+
+use jyc_core::message_storage::MessageStorage;
+use jyc_types::{
+    config::OutboundAttachmentConfig, InboundMessage, OutboundAdapter, OutboundAttachment,
+    SendResult,
+};
+
+use crate::wecom::crypto::generate_nonce;
+
+/// WeCom outbound adapter — sends messages via Bot webhook URL.
+///
+/// WeCom Bot supports two message types:
+/// - `text`: plain text messages (default)
+/// - `markdown`: markdown formatted messages
+///
+/// Unlike WeChat, WeCom does not share a connection between inbound and outbound.
+/// Each outbound request is a standalone HTTP POST to the Bot webhook URL.
+pub struct WecomOutboundAdapter {
+    webhook_url: String,
+    storage: Arc<MessageStorage>,
+    #[allow(dead_code)]
+    attachment_config: Option<OutboundAttachmentConfig>,
+    #[allow(dead_code)]
+    footer_enabled: bool,
+}
+
+impl WecomOutboundAdapter {
+    /// Create a new WeCom outbound adapter with attachments and footer support.
+    pub fn new_with_attachments(
+        webhook_url: String,
+        storage: Arc<MessageStorage>,
+        attachment_config: Option<OutboundAttachmentConfig>,
+        footer_enabled: bool,
+    ) -> Self {
+        Self {
+            webhook_url,
+            storage,
+            attachment_config,
+            footer_enabled,
+        }
+    }
+
+    /// Build the JSON payload for a WeCom Bot message.
+    fn build_payload(reply_text: &str, _original: &InboundMessage) -> serde_json::Value {
+        // Detect if the content looks like markdown
+        let is_markdown = reply_text.contains("```")
+            || reply_text.contains("**")
+            || reply_text.contains("##")
+            || reply_text.contains("|")
+            || reply_text.contains("- [")
+            || reply_text.contains("![");
+
+        if is_markdown {
+            serde_json::json!({
+                "msgtype": "markdown",
+                "markdown": {
+                    "content": reply_text
+                }
+            })
+        } else {
+            serde_json::json!({
+                "msgtype": "text",
+                "text": {
+                    "content": reply_text
+                }
+            })
+        }
+    }
+}
+
+#[async_trait]
+impl OutboundAdapter for WecomOutboundAdapter {
+    fn channel_type(&self) -> &str {
+        "wecom"
+    }
+
+    async fn connect(&self) -> Result<()> {
+        // WeCom uses stateless HTTP requests, no persistent connection needed
+        tracing::debug!("WeCom outbound: no connection needed (stateless HTTP)");
+        Ok(())
+    }
+
+    async fn disconnect(&self) -> Result<()> {
+        // No-op for stateless HTTP
+        Ok(())
+    }
+
+    fn clean_body(&self, raw_body: &str) -> String {
+        // WeCom is a simple channel with no quoting conventions to strip
+        raw_body.to_string()
+    }
+
+    async fn send_reply(
+        &self,
+        original: &InboundMessage,
+        reply_text: &str,
+        thread_path: &Path,
+        message_dir: &str,
+        _attachments: Option<&[OutboundAttachment]>,
+    ) -> Result<SendResult> {
+        // Build the message payload
+        let payload = Self::build_payload(reply_text, original);
+
+        // Send via HTTP POST to the Bot webhook URL
+        let client = reqwest::Client::new();
+        let response = client
+            .post(&self.webhook_url)
+            .json(&payload)
+            .send()
+            .await
+            .with_context(|| format!("failed to send WeCom message to webhook URL"))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "WeCom webhook returned error {}: {}",
+                status,
+                body
+            );
+        }
+
+        let message_id = format!("wecom_{}", generate_nonce());
+        let result = SendResult {
+            message_id: message_id.clone(),
+        };
+
+        // Store the reply
+        self.storage
+            .store_reply(thread_path, message_dir, reply_text)
+            .await
+            .context("failed to store WeCom reply")?;
+
+        Ok(result)
+    }
+
+    async fn send_alert(&self, _recipient: &str, subject: &str, body: &str) -> Result<SendResult> {
+        let payload = serde_json::json!({
+            "msgtype": "markdown",
+            "markdown": {
+                "content": format!("## {}\n\n{}", subject, body)
+            }
+        });
+
+        let client = reqwest::Client::new();
+        let response = client
+            .post(&self.webhook_url)
+            .json(&payload)
+            .send()
+            .await
+            .with_context(|| "failed to send WeCom alert")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("WeCom alert webhook returned error {}: {}", status, body);
+        }
+
+        let message_id = format!("wecom_{}", generate_nonce());
+        Ok(SendResult { message_id })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jyc_types::MessageContent;
+
+    fn make_test_message(text: &str) -> InboundMessage {
+        InboundMessage {
+            id: "test-id".to_string(),
+            channel: "wecom".to_string(),
+            channel_uid: "test-uid".to_string(),
+            sender: "test_user".to_string(),
+            sender_address: "wecom:test".to_string(),
+            recipients: vec![],
+            topic: "Test".to_string(),
+            content: MessageContent {
+                text: Some(text.to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata: std::collections::HashMap::new(),
+            matched_pattern: None,
+        }
+    }
+
+    #[test]
+    fn test_build_payload_text() {
+        let msg = make_test_message("Hello");
+        let payload = WecomOutboundAdapter::build_payload("Hello World", &msg);
+        assert_eq!(payload["msgtype"], "text");
+        assert_eq!(payload["text"]["content"], "Hello World");
+    }
+
+    #[test]
+    fn test_build_payload_markdown() {
+        let msg = make_test_message("Hello");
+        let payload = WecomOutboundAdapter::build_payload("## Title\n\n**bold** text", &msg);
+        assert_eq!(payload["msgtype"], "markdown");
+        assert_eq!(payload["markdown"]["content"], "## Title\n\n**bold** text");
+    }
+
+    #[test]
+    fn test_build_payload_markdown_with_code_block() {
+        let msg = make_test_message("Hello");
+        let payload = WecomOutboundAdapter::build_payload("```rust\nfn main() {}\n```", &msg);
+        assert_eq!(payload["msgtype"], "markdown");
+    }
+
+    #[test]
+    fn test_build_payload_markdown_with_table() {
+        let msg = make_test_message("Hello");
+        let payload = WecomOutboundAdapter::build_payload("| A | B |\n|---|---|", &msg);
+        assert_eq!(payload["msgtype"], "markdown");
+    }
+
+    #[test]
+    fn test_clean_body() {
+        let storage = Arc::new(MessageStorage::new(&std::path::PathBuf::from(
+            std::env::temp_dir(),
+        )));
+        let adapter = WecomOutboundAdapter::new_with_attachments(
+            "https://example.com/webhook".to_string(),
+            storage,
+            None,
+            true,
+        );
+        let cleaned = adapter.clean_body("Hello **world**");
+        assert_eq!(cleaned, "Hello **world**");
+    }
+
+    #[test]
+    fn test_channel_type() {
+        let storage = Arc::new(MessageStorage::new(&std::path::PathBuf::from(
+            std::env::temp_dir(),
+        )));
+        let adapter = WecomOutboundAdapter::new_with_attachments(
+            "https://example.com/webhook".to_string(),
+            storage,
+            None,
+            true,
+        );
+        assert_eq!(adapter.channel_type(), "wecom");
+    }
+}

--- a/crates/jyc-channels/src/wecom/outbound.rs
+++ b/crates/jyc-channels/src/wecom/outbound.rs
@@ -33,6 +33,8 @@ pub struct WecomOutboundAdapter {
     attachment_config: Option<OutboundAttachmentConfig>,
     #[allow(dead_code)]
     footer_enabled: bool,
+    /// Shared HTTP client with connection pool.
+    client: reqwest::Client,
 }
 
 impl WecomOutboundAdapter {
@@ -48,6 +50,7 @@ impl WecomOutboundAdapter {
             storage,
             attachment_config,
             footer_enabled,
+            client: reqwest::Client::new(),
         }
     }
 
@@ -113,8 +116,8 @@ impl OutboundAdapter for WecomOutboundAdapter {
         let payload = Self::build_payload(reply_text, original);
 
         // Send via HTTP POST to the Bot webhook URL
-        let client = reqwest::Client::new();
-        let response = client
+        let response = self
+            .client
             .post(&self.webhook_url)
             .json(&payload)
             .send()
@@ -149,8 +152,8 @@ impl OutboundAdapter for WecomOutboundAdapter {
             }
         });
 
-        let client = reqwest::Client::new();
-        let response = client
+        let response = self
+            .client
             .post(&self.webhook_url)
             .json(&payload)
             .send()

--- a/crates/jyc-channels/src/wecom/outbound.rs
+++ b/crates/jyc-channels/src/wecom/outbound.rs
@@ -12,8 +12,8 @@ use std::sync::Arc;
 
 use jyc_core::message_storage::MessageStorage;
 use jyc_types::{
-    config::OutboundAttachmentConfig, InboundMessage, OutboundAdapter, OutboundAttachment,
-    SendResult,
+    InboundMessage, OutboundAdapter, OutboundAttachment, SendResult,
+    config::OutboundAttachmentConfig,
 };
 
 use crate::wecom::crypto::generate_nonce;
@@ -119,16 +119,12 @@ impl OutboundAdapter for WecomOutboundAdapter {
             .json(&payload)
             .send()
             .await
-            .with_context(|| format!("failed to send WeCom message to webhook URL"))?;
+            .with_context(|| "failed to send WeCom message to webhook URL".to_string())?;
 
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            anyhow::bail!(
-                "WeCom webhook returned error {}: {}",
-                status,
-                body
-            );
+            anyhow::bail!("WeCom webhook returned error {}: {}", status, body);
         }
 
         let message_id = format!("wecom_{}", generate_nonce());

--- a/crates/jyc-channels/src/wecom/outbound.rs
+++ b/crates/jyc-channels/src/wecom/outbound.rs
@@ -232,9 +232,7 @@ mod tests {
 
     #[test]
     fn test_clean_body() {
-        let storage = Arc::new(MessageStorage::new(&std::path::PathBuf::from(
-            std::env::temp_dir(),
-        )));
+        let storage = Arc::new(MessageStorage::new(&std::env::temp_dir()));
         let adapter = WecomOutboundAdapter::new_with_attachments(
             "https://example.com/webhook".to_string(),
             storage,
@@ -247,9 +245,7 @@ mod tests {
 
     #[test]
     fn test_channel_type() {
-        let storage = Arc::new(MessageStorage::new(&std::path::PathBuf::from(
-            std::env::temp_dir(),
-        )));
+        let storage = Arc::new(MessageStorage::new(&std::env::temp_dir()));
         let adapter = WecomOutboundAdapter::new_with_attachments(
             "https://example.com/webhook".to_string(),
             storage,

--- a/crates/jyc-channels/src/wecom/server.rs
+++ b/crates/jyc-channels/src/wecom/server.rs
@@ -1,0 +1,356 @@
+//! Shared HTTP server for WeCom (企业微信) webhook callbacks.
+//!
+//! All WeCom channels share a single axum HTTP server that listens on
+//! the global `[wecom].bind_addr`. Each channel registers a handler for
+//! `/webhook/{channel_name}`.
+//!
+//! ## WeCom Callback Protocol
+//!
+//! ### URL Verification (GET)
+//! WeCom sends a GET request with query parameters:
+//! - `msg_signature` — SHA1 signature
+//! - `timestamp` — current timestamp
+//! - `nonce` — random nonce
+//! - `echostr` — encrypted string to echo back
+//!
+//! Response: the decrypted `echostr` as plain text (status 200).
+//!
+//! ### Message Callback (POST)
+//! WeCom sends a POST request with XML body containing `Encrypt`.
+//! Query parameters: `msg_signature`, `timestamp`, `nonce`.
+//! Response: empty body with status 200.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+use axum::extract::{Path, Query};
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::Router;
+use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
+
+use crate::wecom::crypto;
+
+/// Per-channel configuration stored in the webhook server.
+#[derive(Clone)]
+pub struct ChannelWebhookConfig {
+    /// Token for signature verification.
+    pub token: String,
+    /// Encoding AES key for message decryption.
+    pub encoding_aes_key: String,
+    /// Corporiation ID.
+    pub corp_id: String,
+    /// Handler for incoming decrypted messages.
+    pub on_message: Arc<dyn Fn(String) -> Result<()> + Send + Sync>,
+}
+
+/// The shared WeCom webhook server state.
+pub struct WecomWebhookServer {
+    bind_addr: String,
+    channels: Arc<RwLock<HashMap<String, ChannelWebhookConfig>>>,
+}
+
+impl WecomWebhookServer {
+    /// Create a new shared webhook server with the given bind address.
+    pub fn new(bind_addr: &str) -> Self {
+        Self {
+            bind_addr: bind_addr.to_string(),
+            channels: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Register a channel's webhook handler.
+    pub async fn register_channel(&self, channel_name: &str, config: ChannelWebhookConfig) {
+        self.channels
+            .write()
+            .await
+            .insert(channel_name.to_string(), config);
+    }
+
+    /// Start the HTTP server.
+    ///
+    /// Runs until the cancellation token is triggered.
+    pub async fn start(&self, cancel: CancellationToken) -> Result<()> {
+        let channels = self.channels.clone();
+
+        let app = Router::new()
+            .route(
+                "/webhook/{channel_name}",
+                get(handle_get).post(handle_post),
+            )
+            .with_state(channels);
+
+        let bind_addr: std::net::SocketAddr = self
+            .bind_addr
+            .parse()
+            .map_err(|e| anyhow::anyhow!("invalid bind_addr '{}': {}", self.bind_addr, e))?;
+
+        let listener = tokio::net::TcpListener::bind(bind_addr)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to bind to {}: {}", bind_addr, e))?;
+
+        tracing::info!(
+            bind_addr = %bind_addr,
+            "WeCom webhook server started"
+        );
+
+        axum::serve(listener, app)
+            .with_graceful_shutdown(async move { cancel.cancelled().await; })
+            .await
+            .map_err(|e| anyhow::anyhow!("wecom webhook server error: {}", e))?;
+
+        Ok(())
+    }
+}
+
+/// Query parameters for WeCom callback.
+#[derive(Debug, serde::Deserialize)]
+pub struct CallbackQuery {
+    pub msg_signature: String,
+    pub timestamp: String,
+    pub nonce: String,
+    pub echostr: Option<String>,
+}
+
+/// Handle GET request — URL verification.
+///
+/// WeCom sends this to verify the callback URL. We must:
+/// 1. Verify the signature using token + timestamp + nonce + echostr
+/// 2. Decrypt the echostr using encoding_aes_key
+/// 3. Return the decrypted echostr as plain text
+async fn handle_get(
+    Path(channel_name): Path<String>,
+    Query(query): Query<CallbackQuery>,
+    channels: axum::extract::State<Arc<RwLock<HashMap<String, ChannelWebhookConfig>>>>,
+) -> impl IntoResponse {
+    let config = match channels.read().await.get(&channel_name) {
+        Some(c) => c.clone(),
+        None => {
+            return (
+                axum::http::StatusCode::NOT_FOUND,
+                format!("channel '{channel_name}' not found"),
+            );
+        }
+    };
+
+    let echostr = match &query.echostr {
+        Some(s) => s,
+        None => {
+            return (
+                axum::http::StatusCode::BAD_REQUEST,
+                "missing echostr parameter".to_string(),
+            );
+        }
+    };
+
+    // Verify signature
+    if !crypto::verify_signature(
+        &config.token,
+        &query.timestamp,
+        &query.nonce,
+        echostr,
+        &query.msg_signature,
+    ) {
+        tracing::warn!(
+            channel = %channel_name,
+            "WeCom URL verification: signature mismatch"
+        );
+        return (
+            axum::http::StatusCode::FORBIDDEN,
+            "signature verification failed".to_string(),
+        );
+    }
+
+    // Decrypt echostr
+    match crypto::decrypt_msg(&config.encoding_aes_key, echostr) {
+        Ok(plaintext) => {
+            tracing::info!(
+                channel = %channel_name,
+                "WeCom URL verification successful"
+            );
+            (axum::http::StatusCode::OK, plaintext)
+        }
+        Err(e) => {
+            tracing::error!(
+                channel = %channel_name,
+                error = %e,
+                "WeCom URL verification: decryption failed"
+            );
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("decryption failed: {}", e),
+            )
+        }
+    }
+}
+
+/// Handle POST request — message callback.
+///
+/// WeCom sends a POST with XML body containing `<xml><Encrypt>...</Encrypt></xml>`.
+/// We must:
+/// 1. Verify the signature using token + timestamp + nonce + encrypted content
+/// 2. Decrypt the message
+/// 3. Call the channel's on_message handler
+/// 4. Return 200 OK
+async fn handle_post(
+    Path(channel_name): Path<String>,
+    Query(query): Query<CallbackQuery>,
+    channels: axum::extract::State<Arc<RwLock<HashMap<String, ChannelWebhookConfig>>>>,
+    body: String,
+) -> impl IntoResponse {
+    let config = match channels.read().await.get(&channel_name) {
+        Some(c) => c.clone(),
+        None => {
+            return (
+                axum::http::StatusCode::NOT_FOUND,
+                format!("channel '{channel_name}' not found"),
+            );
+        }
+    };
+
+    // Parse the XML body to extract <Encrypt>
+    let encrypt = match extract_encrypt_from_xml(&body) {
+        Some(e) => e,
+        None => {
+            tracing::warn!(
+                channel = %channel_name,
+                "WeCom callback: no Encrypt element in XML body"
+            );
+            return (
+                axum::http::StatusCode::BAD_REQUEST,
+                "missing Encrypt element".to_string(),
+            );
+        }
+    };
+
+    // Verify signature
+    if !crypto::verify_signature(
+        &config.token,
+        &query.timestamp,
+        &query.nonce,
+        &encrypt,
+        &query.msg_signature,
+    ) {
+        tracing::warn!(
+            channel = %channel_name,
+            "WeCom callback: signature mismatch"
+        );
+        return (
+            axum::http::StatusCode::FORBIDDEN,
+            "signature verification failed".to_string(),
+        );
+    }
+
+    // Decrypt the message
+    match crypto::decrypt_msg(&config.encoding_aes_key, &encrypt) {
+        Ok(decrypted) => {
+            tracing::debug!(
+                channel = %channel_name,
+                "WeCom callback: message decrypted successfully"
+            );
+
+            // Call the channel's message handler
+            if let Err(e) = (config.on_message)(decrypted) {
+                tracing::error!(
+                    channel = %channel_name,
+                    error = %e,
+                    "WeCom callback: message handler error"
+                );
+            }
+
+            (axum::http::StatusCode::OK, String::new())
+        }
+        Err(e) => {
+            tracing::error!(
+                channel = %channel_name,
+                error = %e,
+                "WeCom callback: decryption failed"
+            );
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("decryption failed: {}", e),
+            )
+        }
+    }
+}
+
+/// Extract the `<Encrypt>` content from a WeCom XML message body.
+///
+/// The XML format is:
+/// ```xml
+/// <xml>
+///   <ToUserName><![CDATA[wx1234567890]]></ToUserName>
+///   <Encrypt><![CDATA[base64_encrypted_content]]></Encrypt>
+///   <AgentID><![CDATA[1000002]]></AgentID>
+/// </xml>
+/// ```
+fn extract_encrypt_from_xml(xml: &str) -> Option<String> {
+    // Simple extraction using string search
+    // Look for <Encrypt><![CDATA[...]]></Encrypt>
+    let start_marker = "<Encrypt><![CDATA[";
+    let end_marker = "]]></Encrypt>";
+
+    let start = xml.find(start_marker)?;
+    let content_start = start + start_marker.len();
+    let end = xml[content_start..].find(end_marker)?;
+
+    Some(xml[content_start..content_start + end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_callback_query_deserialize() {
+        let query = CallbackQuery {
+            msg_signature: "abc123".to_string(),
+            timestamp: "1700000000".to_string(),
+            nonce: "123456".to_string(),
+            echostr: Some("encrypted_echo".to_string()),
+        };
+        assert_eq!(query.msg_signature, "abc123");
+        assert_eq!(query.timestamp, "1700000000");
+        assert_eq!(query.nonce, "123456");
+        assert_eq!(query.echostr, Some("encrypted_echo".to_string()));
+    }
+
+    #[test]
+    fn test_callback_query_no_echostr() {
+        let query = CallbackQuery {
+            msg_signature: "abc".to_string(),
+            timestamp: "100".to_string(),
+            nonce: "xyz".to_string(),
+            echostr: None,
+        };
+        assert_eq!(query.msg_signature, "abc");
+        assert!(query.echostr.is_none());
+    }
+
+    #[test]
+    fn test_extract_encrypt_from_xml() {
+        let xml = r#"<xml>
+            <ToUserName><![CDATA[ww123456]]></ToUserName>
+            <Encrypt><![CDATA[base64encryptedcontent]]></Encrypt>
+            <AgentID><![CDATA[1000002]]></AgentID>
+        </xml>"#;
+
+        let encrypt = extract_encrypt_from_xml(xml);
+        assert_eq!(encrypt, Some("base64encryptedcontent".to_string()));
+    }
+
+    #[test]
+    fn test_extract_encrypt_from_xml_missing() {
+        let xml = r#"<xml><ToUserName>test</ToUserName></xml>"#;
+        assert!(extract_encrypt_from_xml(xml).is_none());
+    }
+
+    #[test]
+    fn test_extract_encrypt_from_xml_empty() {
+        let xml = r#"<xml><Encrypt><![CDATA[]]></Encrypt></xml>"#;
+        let encrypt = extract_encrypt_from_xml(xml);
+        assert_eq!(encrypt, Some("".to_string()));
+    }
+}

--- a/crates/jyc-channels/src/wecom/server.rs
+++ b/crates/jyc-channels/src/wecom/server.rs
@@ -40,7 +40,7 @@ pub struct ChannelWebhookConfig {
     pub token: String,
     /// Encoding AES key for message decryption.
     pub encoding_aes_key: String,
-    /// Corporiation ID.
+    /// Corp ID.
     pub corp_id: String,
     /// Handler for incoming decrypted messages.
     pub on_message: Arc<dyn Fn(String) -> Result<()> + Send + Sync>,

--- a/crates/jyc-channels/src/wecom/server.rs
+++ b/crates/jyc-channels/src/wecom/server.rs
@@ -24,10 +24,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Result;
+use axum::Router;
 use axum::extract::{Path, Query};
 use axum::response::IntoResponse;
 use axum::routing::get;
-use axum::Router;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
@@ -76,10 +76,7 @@ impl WecomWebhookServer {
         let channels = self.channels.clone();
 
         let app = Router::new()
-            .route(
-                "/webhook/{channel_name}",
-                get(handle_get).post(handle_post),
-            )
+            .route("/webhook/{channel_name}", get(handle_get).post(handle_post))
             .with_state(channels);
 
         let bind_addr: std::net::SocketAddr = self
@@ -97,7 +94,9 @@ impl WecomWebhookServer {
         );
 
         axum::serve(listener, app)
-            .with_graceful_shutdown(async move { cancel.cancelled().await; })
+            .with_graceful_shutdown(async move {
+                cancel.cancelled().await;
+            })
             .await
             .map_err(|e| anyhow::anyhow!("wecom webhook server error: {}", e))?;
 

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -18,6 +18,9 @@ use jyc_channels::github::inbound::GithubMatcher;
 use jyc_channels::github::outbound::GithubOutboundAdapter;
 use jyc_channels::wechat::inbound::WechatInboundAdapter;
 use jyc_channels::wechat::outbound::WechatOutboundAdapter;
+use jyc_channels::wecom::inbound::WecomInboundAdapter;
+use jyc_channels::wecom::outbound::WecomOutboundAdapter;
+use jyc_channels::wecom::server::WecomWebhookServer;
 use jyc_core::message_router::MessageRouter;
 use jyc_core::message_storage::MessageStorage;
 use jyc_core::metrics::MetricsCollector;
@@ -81,6 +84,31 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
     let mut all_workspace_dirs: Vec<std::path::PathBuf> = Vec::new();
     let config_snapshot = config.load();
     let agent_config = Arc::new(config_snapshot.agent.clone());
+
+    // Initialize shared WeCom webhook server (if any wecom channel is configured)
+    let has_wecom = config_snapshot
+        .channels
+        .values()
+        .any(|c| c.channel_type == "wecom");
+    let wecom_server: Option<Arc<WecomWebhookServer>> = if has_wecom {
+        let bind_addr = config_snapshot
+            .wecom
+            .as_ref()
+            .map(|w| w.bind_addr.clone())
+            .unwrap_or_else(|| "127.0.0.1:10001".to_string());
+        let server = Arc::new(WecomWebhookServer::new(&bind_addr));
+        // Start the server in background
+        let server_for_task = server.clone();
+        let cancel_wecom = cancel.clone();
+        tokio::spawn(async move {
+            if let Err(e) = server_for_task.start(cancel_wecom).await {
+                tracing::error!(error = %e, "WeCom webhook server error");
+            }
+        });
+        Some(server)
+    } else {
+        None
+    };
 
     for (channel_name, channel_config) in &config_snapshot.channels {
         let channel_type = channel_config.channel_type.as_str();
@@ -160,6 +188,21 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                 // Store the sender_arc for later use in the inbound section
                 wechat_sender_arc = Some(adapter.sender_arc());
                 Arc::new(adapter)
+            }
+            "wecom" => {
+                let wecom_config = channel_config
+                    .wecom
+                    .as_ref()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("channel '{channel_name}': missing wecom config")
+                    })?
+                    .clone();
+                Arc::new(WecomOutboundAdapter::new_with_attachments(
+                    wecom_config.webhook_url,
+                    storage.clone(),
+                    outbound_attachment_config,
+                    footer_enabled,
+                ))
             }
             other => {
                 tracing::warn!(
@@ -620,6 +663,72 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                         tracing::error!(
                             error = %e,
                             "WeChat inbound adapter error"
+                        );
+                    }
+
+                    // Shutdown thread manager for this channel
+                    tm.shutdown().await;
+                }.instrument(channel_span));
+
+                tasks.push(task);
+            }
+            "wecom" => {
+                let wecom_config = channel_config
+                    .wecom
+                    .as_ref()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("channel '{channel_name}': missing wecom config")
+                    })?
+                    .clone();
+
+                let wecom_server = wecom_server
+                    .clone()
+                    .ok_or_else(|| anyhow::anyhow!("WeCom webhook server not initialized"))?;
+                let patterns_for_callback = patterns.clone();
+                let router_for_callback = router.clone();
+                let channel_name_owned = channel_name.clone();
+
+                let task = tokio::spawn(async move {
+                    use jyc_types::InboundAdapter;
+                    use jyc_channels::wecom::inbound::WecomMatcher;
+
+                    let adapter = WecomInboundAdapter::new(
+                        &wecom_config,
+                        &channel_name_owned,
+                        wecom_server,
+                    );
+
+                    let thread_manager_clone = thread_manager.clone();
+                    let options = jyc_types::InboundAdapterOptions {
+                        on_message: Box::new(move |message| {
+                            let router = router_for_callback.clone();
+                            let patterns = patterns_for_callback.clone();
+
+                            tokio::spawn(async move {
+                                router.route(&WecomMatcher, message, &patterns).await;
+                            });
+
+                            Ok(())
+                        }),
+                        on_thread_close: Some(Box::new(move |thread_name: String| {
+                            let tm = thread_manager_clone.clone();
+                            tokio::spawn(async move {
+                                if let Err(e) = tm.close_thread(&thread_name).await {
+                                    tracing::error!(error = %e, thread = %thread_name, "Failed to close thread");
+                                }
+                            });
+                            Ok(())
+                        })),
+                        on_error: Box::new(|error| {
+                            tracing::error!(error = %error, "WeCom inbound error");
+                        }),
+                        attachment_config: inbound_attachment_config.clone(),
+                    };
+
+                    if let Err(e) = adapter.start(options, cancel_child).await {
+                        tracing::error!(
+                            error = %e,
+                            "WeCom inbound adapter error"
                         );
                     }
 

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -97,14 +97,37 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
             .map(|w| w.bind_addr.clone())
             .unwrap_or_else(|| "127.0.0.1:10001".to_string());
         let server = Arc::new(WecomWebhookServer::new(&bind_addr));
-        // Start the server in background
+        // Use a oneshot channel to detect server startup success/failure
+        let (startup_tx, startup_rx) = tokio::sync::oneshot::channel::<Result<()>>();
         let server_for_task = server.clone();
         let cancel_wecom = cancel.clone();
         tokio::spawn(async move {
-            if let Err(e) = server_for_task.start(cancel_wecom).await {
-                tracing::error!(error = %e, "WeCom webhook server error");
+            let result = server_for_task.start(cancel_wecom).await;
+            if let Err(ref e) = result {
+                tracing::error!(error = %e, "WeCom webhook server failed to start");
             }
+            let _ = startup_tx.send(result);
         });
+        // Wait briefly to detect binding failures (port in use, etc.)
+        match tokio::time::timeout(std::time::Duration::from_secs(5), startup_rx).await {
+            Ok(Ok(Ok(()))) => {
+                tracing::info!(bind_addr = %bind_addr, "WeCom webhook server started");
+            }
+            Ok(Ok(Err(e))) => {
+                anyhow::bail!("WeCom webhook server failed to start: {}", e);
+            }
+            Ok(Err(_)) => {
+                // Channel closed without sending — server task panicked
+                anyhow::bail!("WeCom webhook server task panicked during startup");
+            }
+            Err(_) => {
+                // Timeout — server is still binding or serving, assume success
+                tracing::info!(
+                    bind_addr = %bind_addr,
+                    "WeCom webhook server startup pending (may be slow to bind)"
+                );
+            }
+        }
         Some(server)
     } else {
         None

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -662,7 +662,8 @@ impl ThreadManager {
             // 2. Pattern-level model from config
             // 3. Channel-level model from config
             // 4. Global agent model from config
-            let model = read_model_override(&thread_path).await
+            let model = read_model_override(&thread_path)
+                .await
                 .or_else(|| {
                     let pattern_name = pattern.as_ref()?;
                     let cfg = self.config.load();
@@ -676,9 +677,7 @@ impl ThreadManager {
                     let channel_cfg = cfg.channels.get(&self.channel_name)?;
                     channel_cfg.model.clone()
                 })
-                .or_else(|| {
-                    self.config.load().agent.model.clone()
-                });
+                .or_else(|| self.config.load().agent.model.clone());
 
             let mode = read_mode_override(&thread_path).await;
 

--- a/crates/jyc-types/src/config.rs
+++ b/crates/jyc-types/src/config.rs
@@ -1,10 +1,13 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::WecomGlobalConfig;
+
 use crate::channel::ChannelPattern;
 use crate::feishu_config::FeishuConfig;
 use crate::github_config::GithubConfig;
 use crate::wechat_config::WechatConfig;
+use crate::wecom_config::WecomConfig;
 
 /// MCP server configuration for agent dynamic tool loading.
 ///
@@ -65,6 +68,10 @@ pub struct AppConfig {
     #[serde(default)]
     pub attachments: Option<UnifiedAttachmentConfig>,
 
+    /// WeCom global configuration (shared HTTP server settings)
+    #[serde(default)]
+    pub wecom: Option<WecomGlobalConfig>,
+
     /// Named MCP server configurations, referenced by templates.
     /// Each template in `templates.toml` can specify which MCPs it needs.
     #[serde(default)]
@@ -124,6 +131,9 @@ pub struct ChannelConfig {
 
     /// WeChat configuration (for wechat channels)
     pub wechat: Option<WechatConfig>,
+
+    /// WeCom configuration (for wecom channels)
+    pub wecom: Option<WecomConfig>,
 
     /// Monitoring settings (IDLE vs poll, interval, etc.)
     pub monitor: Option<MonitorConfig>,

--- a/crates/jyc-types/src/lib.rs
+++ b/crates/jyc-types/src/lib.rs
@@ -6,6 +6,7 @@ pub mod github_config;
 pub mod inspect;
 pub mod validation;
 pub mod wechat_config;
+pub mod wecom_config;
 
 pub use agent::*;
 pub use channel::*;
@@ -14,3 +15,4 @@ pub use feishu_config::*;
 pub use github_config::*;
 pub use inspect::*;
 pub use wechat_config::*;
+pub use wecom_config::*;

--- a/crates/jyc-types/src/validation.rs
+++ b/crates/jyc-types/src/validation.rs
@@ -186,6 +186,45 @@ pub fn validate_config(config: &AppConfig) -> Vec<ValidationError> {
                     message: "Feishu configuration is required for feishu channel type".into(),
                 });
             }
+        } else if channel.channel_type == "wecom" {
+            // Validate WeCom channel specifics
+            if let Some(ref wecom_config) = channel.wecom {
+                if wecom_config.token.is_empty() {
+                    errors.push(ValidationError {
+                        path: format!("{prefix}.wecom.token"),
+                        message: "WeCom token is required".into(),
+                    });
+                }
+                if wecom_config.encoding_aes_key.is_empty() {
+                    errors.push(ValidationError {
+                        path: format!("{prefix}.wecom.encoding_aes_key"),
+                        message: "WeCom encoding_aes_key is required (use ${ENV_VAR} syntax)".into(),
+                    });
+                }
+                if wecom_config.corp_id.is_empty() {
+                    errors.push(ValidationError {
+                        path: format!("{prefix}.wecom.corp_id"),
+                        message: "WeCom corp_id is required".into(),
+                    });
+                }
+                if wecom_config.webhook_url.is_empty() {
+                    errors.push(ValidationError {
+                        path: format!("{prefix}.wecom.webhook_url"),
+                        message: "WeCom webhook_url is required (use ${ENV_VAR} syntax)".into(),
+                    });
+                }
+                if !wecom_config.webhook_url.starts_with("https://") {
+                    errors.push(ValidationError {
+                        path: format!("{prefix}.wecom.webhook_url"),
+                        message: "WeCom webhook_url must start with https://".into(),
+                    });
+                }
+            } else {
+                errors.push(ValidationError {
+                    path: format!("{prefix}.wecom"),
+                    message: "WeCom configuration is required for wecom channel type".into(),
+                });
+            }
         }
 
         // Validate patterns
@@ -822,5 +861,89 @@ max_per_message = 5
         assert!(errors.iter().any(|e| e.path.contains("allowed_extensions")));
         assert!(errors.iter().any(|e| e.path.contains("max_file_size")));
         assert!(errors.iter().any(|e| e.path.contains("max_per_message")));
+    }
+
+    #[test]
+    fn test_wecom_valid_config_passes() {
+        let toml = r#"
+[general]
+max_concurrent_threads = 3
+
+[channels.wecom_bot]
+type = "wecom"
+
+[channels.wecom_bot.wecom]
+token = "wecom_token_xxx"
+encoding_aes_key = "abc123abc123abc123abc123abc123abc123abc123abc123abc12"
+corp_id = "ww1234567890abcdef"
+webhook_url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx"
+
+[agent]
+enabled = true
+mode = "agent"
+"#;
+        let config = load_config_from_str(toml).unwrap();
+        let errors = validate_config(&config);
+        assert!(errors.is_empty(), "expected no errors, got: {:?}", errors);
+    }
+
+    #[test]
+    fn test_wecom_missing_config_fails() {
+        let toml = r#"
+[general]
+[channels.wecom_bot]
+type = "wecom"
+
+[agent]
+enabled = true
+mode = "agent"
+"#;
+        let config = load_config_from_str(toml).unwrap();
+        let errors = validate_config(&config);
+        assert!(errors.iter().any(|e| e.path.contains("wecom")));
+    }
+
+    #[test]
+    fn test_wecom_missing_token_fails() {
+        let toml = r#"
+[general]
+[channels.wecom_bot]
+type = "wecom"
+
+[channels.wecom_bot.wecom]
+token = ""
+encoding_aes_key = "abc123abc123abc123abc123abc123abc123abc123abc123abc12"
+corp_id = "ww1234567890abcdef"
+webhook_url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx"
+
+[agent]
+enabled = true
+mode = "agent"
+"#;
+        let config = load_config_from_str(toml).unwrap();
+        let errors = validate_config(&config);
+        assert!(errors.iter().any(|e| e.path.contains("wecom.token")));
+    }
+
+    #[test]
+    fn test_wecom_invalid_webhook_url_fails() {
+        let toml = r#"
+[general]
+[channels.wecom_bot]
+type = "wecom"
+
+[channels.wecom_bot.wecom]
+token = "valid_token"
+encoding_aes_key = "abc123abc123abc123abc123abc123abc123abc123abc123abc12"
+corp_id = "ww1234567890abcdef"
+webhook_url = "http://insecure-url.com"
+
+[agent]
+enabled = true
+mode = "agent"
+"#;
+        let config = load_config_from_str(toml).unwrap();
+        let errors = validate_config(&config);
+        assert!(errors.iter().any(|e| e.path.contains("wecom.webhook_url")));
     }
 }

--- a/crates/jyc-types/src/validation.rs
+++ b/crates/jyc-types/src/validation.rs
@@ -198,7 +198,8 @@ pub fn validate_config(config: &AppConfig) -> Vec<ValidationError> {
                 if wecom_config.encoding_aes_key.is_empty() {
                     errors.push(ValidationError {
                         path: format!("{prefix}.wecom.encoding_aes_key"),
-                        message: "WeCom encoding_aes_key is required (use ${ENV_VAR} syntax)".into(),
+                        message: "WeCom encoding_aes_key is required (use ${ENV_VAR} syntax)"
+                            .into(),
                     });
                 }
                 if wecom_config.corp_id.is_empty() {

--- a/crates/jyc-types/src/wecom_config.rs
+++ b/crates/jyc-types/src/wecom_config.rs
@@ -1,0 +1,86 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// WeCom (企业微信) global configuration — shared HTTP server settings.
+///
+/// All WeCom channels share a single HTTP server for receiving callback messages.
+/// The server listens on `bind_addr` and routes requests by path `/webhook/{channel_name}`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct WecomGlobalConfig {
+    /// TCP bind address for the shared HTTP server (default: "127.0.0.1:10001")
+    #[serde(default = "default_bind_addr")]
+    pub bind_addr: String,
+}
+
+impl Default for WecomGlobalConfig {
+    fn default() -> Self {
+        Self {
+            bind_addr: default_bind_addr(),
+        }
+    }
+}
+
+fn default_bind_addr() -> String {
+    "127.0.0.1:10001".to_string()
+}
+
+/// WeCom (企业微信) channel-specific configuration.
+///
+/// Contains credentials for receiving callback messages (token, encoding_aes_key, corp_id)
+/// and the Bot webhook URL for sending messages.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct WecomConfig {
+    /// Token for callback message verification (from WeCom Bot callback settings)
+    pub token: String,
+
+    /// Encoding AES Key (with "=" padding) for message decryption
+    pub encoding_aes_key: String,
+
+    /// Corp ID / Enterprise ID for message decryption
+    pub corp_id: String,
+
+    /// Bot webhook URL for sending outgoing messages
+    /// (e.g., "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx")
+    pub webhook_url: String,
+
+    /// Additional metadata
+    #[serde(default)]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_global_config() {
+        let config = WecomGlobalConfig::default();
+        assert_eq!(config.bind_addr, "127.0.0.1:10001");
+    }
+
+    #[test]
+    fn test_config_deserialize() {
+        let toml_str = r#"
+            token = "wecom_token_xxx"
+            encoding_aes_key = "abc123abc123abc123abc123abc123abc123abc123abc123abc12"
+            corp_id = "ww1234567890abcdef"
+            webhook_url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx-xxx-xxx"
+        "#;
+
+        let config: WecomConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.token, "wecom_token_xxx");
+        assert_eq!(config.encoding_aes_key, "abc123abc123abc123abc123abc123abc123abc123abc123abc12");
+        assert_eq!(config.corp_id, "ww1234567890abcdef");
+        assert_eq!(config.webhook_url, "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx-xxx-xxx");
+    }
+
+    #[test]
+    fn test_global_config_deserialize() {
+        let toml_str = r#"
+            bind_addr = "0.0.0.0:20001"
+        "#;
+
+        let config: WecomGlobalConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.bind_addr, "0.0.0.0:20001");
+    }
+}

--- a/crates/jyc-types/src/wecom_config.rs
+++ b/crates/jyc-types/src/wecom_config.rs
@@ -69,9 +69,15 @@ mod tests {
 
         let config: WecomConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.token, "wecom_token_xxx");
-        assert_eq!(config.encoding_aes_key, "abc123abc123abc123abc123abc123abc123abc123abc123abc12");
+        assert_eq!(
+            config.encoding_aes_key,
+            "abc123abc123abc123abc123abc123abc123abc123abc123abc12"
+        );
         assert_eq!(config.corp_id, "ww1234567890abcdef");
-        assert_eq!(config.webhook_url, "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx-xxx-xxx");
+        assert_eq!(
+            config.webhook_url,
+            "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx-xxx-xxx"
+        );
     }
 
     #[test]

--- a/docs/channels/wecom.md
+++ b/docs/channels/wecom.md
@@ -1,0 +1,156 @@
+# WeCom (企业微信) Channel
+
+WeCom (WeChat Work / 企业微信) Bot channel implementation for JYC.
+
+## Architecture
+
+```
+┌─────────────────┐     POST /webhook/{name}      ┌──────────────────┐
+│   WeCom Server  │ ──────────────────────────▶   │  Shared HTTP     │
+│  (第三方平台)    │                               │  Server (axum)   │
+│                 │ ◀──────────────────────────   │  127.0.0.1:10001 │
+│                 │    200 OK (decrypted echo)    └────────┬─────────┘
+└─────────────────┘                                       │
+                                                    ┌──────┴──────┐
+                                                    │  Inbound    │
+                                                    │  Adapter    │
+                                                    └──────┬──────┘
+                                                           │
+                                                    ┌──────┴──────┐
+                                                    │  Message    │
+                                                    │  Router     │
+                                                    └─────────────┘
+
+┌─────────────────┐     POST webhook URL           ┌──────────────────┐
+│  WeCom Bot API  │ ◀──────────────────────────   │  Outbound        │
+│  (qyapi.weixin) │     {"msgtype":"text",...}    │  Adapter         │
+└─────────────────┘                                └──────────────────┘
+```
+
+### Key Design Decisions
+
+- **Shared HTTP Server**: All WeCom channels share a single axum HTTP server (方案B).
+  Configured via `[wecom].bind_addr` (default: `127.0.0.1:10001`).
+- **Path-based Routing**: Each channel registers at `/webhook/{channel_name}`.
+- **One Bot = One Thread**: Similar to WeChat, each WeCom Bot maps to a single thread.
+- **Stateless Outbound**: Outbound messages are standalone HTTP POST requests to the Bot webhook URL.
+
+## Configuration
+
+### Global Server Config
+
+```toml
+[wecom]
+bind_addr = "127.0.0.1:10001"
+```
+
+### Channel Config
+
+```toml
+[channels.my_bot]
+type = "wecom"
+
+[channels.my_bot.wecom]
+token = "your_token_from_wecom"
+encoding_aes_key = "your_aes_key_43_chars"
+corp_id = "ww1234567890abcdef"
+webhook_url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx-xxx"
+
+[[channels.my_bot.patterns]]
+name = "catch_all"
+
+[channels.my_bot.patterns.rules]
+keywords = ["help", "问题"]
+```
+
+### Configuration Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `token` | Yes | Token from WeCom callback settings |
+| `encoding_aes_key` | Yes | Base64-encoded AES key (43 chars with `=`) |
+| `corp_id` | Yes | Enterprise ID / Corp ID |
+| `webhook_url` | Yes | Bot webhook URL for sending messages |
+| `bind_addr` | No | Global server bind address (default: `127.0.0.1:10001`) |
+
+## Webhook Protocol
+
+### URL Verification (GET)
+
+WeCom sends a GET request with:
+- `msg_signature` — SHA1(token + timestamp + nonce + echostr)
+- `timestamp` — current timestamp
+- `nonce` — random nonce
+- `echostr` — encrypted echo string
+
+Response: decrypted `echostr` as plain text (status 200).
+
+### Message Callback (POST)
+
+WeCom sends a POST request with XML body:
+```xml
+<xml>
+  <ToUserName><![CDATA[ww123456]]></ToUserName>
+  <Encrypt><![CDATA[base64_encrypted_content]]></Encrypt>
+  <AgentID><![CDATA[1000002]]></AgentID>
+</xml>
+```
+
+The server:
+1. Verifies SHA1 signature
+2. Decrypts the AES-256-CBC encrypted content
+3. Routes to the channel's message handler
+4. Returns 200 OK
+
+## Message Types
+
+### Outbound: Text
+
+```json
+{
+  "msgtype": "text",
+  "text": {
+    "content": "Hello World"
+  }
+}
+```
+
+### Outbound: Markdown
+
+```json
+{
+  "msgtype": "markdown",
+  "markdown": {
+    "content": "# Title\n\n**bold** text"
+  }
+}
+```
+
+The adapter auto-detects markdown content by checking for code blocks (` ``` `), bold (`**`), headings (`##`), tables (`|`), task lists (`- [`), and images (`![`).
+
+## Testing
+
+```bash
+# Test WeCom crypto module
+cargo test -p jyc-channels wecom::crypto
+
+# Test WeCom server module
+cargo test -p jyc-channels wecom::server
+
+# Test WeCom inbound adapter
+cargo test -p jyc-channels wecom::inbound
+
+# Test WeCom outbound adapter
+cargo test -p jyc-channels wecom::outbound
+
+# Test configuration validation
+cargo test -p jyc-types wecom
+
+# Run all wecom tests
+cargo test -p jyc-channels wecom
+```
+
+## References
+
+- [WeCom Bot Message Types](https://developer.work.weixin.qq.com/document/path/91770)
+- [WeCom Callback Protocol](https://developer.work.weixin.qq.com/document/path/90968)


### PR DESCRIPTION
## Spec

新增 wecom 渠道类型，支持企业微信 Bot 回调（webhook）。启动一个共享 HTTP 服务器（axum），所有 wecom channel 注册在 /webhook/{channel_name} 路径下。支持消息接收（加解密验证）和发送（Bot webhook URL）。

Fixes #225

## Implementation Plan

### Step 1: 新增 WecomConfig 配置类型
**What:** 在 crates/jyc-types/src/wecom_config.rs 创建 WecomConfig 结构体，包含 token、encoding_aes_key、corp_id、webhook_url 等字段，并添加 serde Deserialize/Serialize derive。同时新增 WecomGlobalConfig（bind_addr 字段）用于全局 HTTP 服务器配置。
**Why:** 企业微信 Bot 需要 token + AES key 做消息加解密，需要 webhook_url 做发送，需要全局 bind_addr 启动共享 HTTP 服务器。
**Verify:** cargo build -p jyc-types 编译通过。

### Step 2: 在 ChannelConfig 和 AppConfig 中注册 wecom 配置
**What:** 修改 crates/jyc-types/src/config.rs：在 ChannelConfig 添加 wecom 字段和 AppConfig 添加顶层 wecom 字段。
**Why:** 让 wecom 配置可被 deserialize。
**Verify:** cargo build -p jyc-types 编译通过。

### Step 3: 新增企业微信消息加解密模块
**What:** 创建 crates/jyc-channels/src/wecom/crypto.rs，实现 verify_signature 和 decrypt_msg（AES-256-CBC + PKCS7）。
**Why:** 企业微信回调消息是加密的 XML，必须先解密才能解析。
**Verify:** cargo test -p jyc-channels wecom::crypto

### Step 4: 新增 WecomWebhookServer 共享 HTTP 服务器
**What:** 创建 crates/jyc-channels/src/wecom/server.rs，实现全局单例服务器，/webhook/{channel_name} 路由分发。
**Why:** 方案B：所有 wecom channel 共享一个 HTTP 服务器。
**Verify:** cargo test -p jyc-channels wecom::server

### Step 5: 新增 WecomInboundAdapter 和 WecomMatcher
**What:** 创建 inbound.rs，支持 sender/keywords 匹配，线程命名参考飞书。
**Why:** 收消息的核心逻辑。
**Verify:** cargo test -p jyc-channels wecom::inbound

### Step 6: 新增 WecomOutboundAdapter
**What:** 创建 outbound.rs，POST webhook_url 发送 text/markdown 消息。
**Why:** 发送消息的核心逻辑。
**Verify:** cargo test -p jyc-channels wecom::outbound

### Step 7: 注册 wecom 子模块和依赖
**What:** 创建 mod.rs，更新 lib.rs 和 Cargo.toml 添加 axum/xml 依赖。
**Why:** 集成到 channel crate。
**Verify:** cargo build -p jyc-channels

### Step 8: 在 monitor.rs 中集成 wecom channel
**What:** 添加 wecom 匹配分支，初始化共享服务器并创建 adapter。
**Why:** 集成到 monitor 生命周期。
**Verify:** cargo build 全项目编译通过。

### Step 9: 添加配置验证
**What:** validation.rs 添加 wecom 配置校验。
**Verify:** cargo test -p jyc-types validation

### Step 10: 更新 config.example.toml 和文档
**What:** 添加 wecom 配置示例和 docs/channels/wecom.md。
**Verify:** 手动检查文档完整性。

## Design Decisions
- axum: HTTP 框架，tokio 原生
- 方案B（统一端口+路径路由）: 所有 channel 共享 /webhook/{channel_name}
- 全局 [wecom].bind_addr: 不在每个 channel 重复
- 线程命名参考 Feishu: 群聊用 chat_name，私聊用 sender_name
- 消息加解密: 遵循企业微信官方算法（AES-256-CBC + PKCS7 + Base64）