### PR TITLE
feat: wecom external contact mode — token-based outbound with chat_id routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to JYC will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **WeCom channel: migrated from Bot webhook to external contact API.** The
+  outbound adapter now uses `corp_id` + `corp_secret` for access_token-based
+  authentication via `GET /cgi-bin/gettoken`, then sends messages via
+  `POST /cgi-bin/externalcontact/message/send` with `chat_id` routing.
+  The `webhook_url` configuration field is replaced by `corp_secret`. (#228)
+
 ### Added
 
 - **WeCom (企业微信) Bot channel.** New channel type `wecom` supporting inbound

--- a/config.example.toml
+++ b/config.example.toml
@@ -529,15 +529,15 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # # keywords = ["help", "support", "问题"]
 
 # # --- Channel: my_wecom_bot ---
-# # WeCom (企业微信) Bot channel.
+# # WeCom (企业微信) channel using the external contact API for outbound messaging.
 # # Receives messages via webhook callback (/webhook/{channel_name}) and
-# # sends replies via Bot webhook URL.
+# # sends replies via the WeCom External Contact API with access_token auth.
 # #
 # # Prerequisites:
-# # 1. Create a Bot in WeCom and configure the callback URL
+# # 1. Create an app in WeCom and configure the callback URL
 # #    (e.g., https://your-domain.com/webhook/my_wecom_bot)
 # # 2. Get the token, encoding_aes_key, and corp_id from WeCom callback settings
-# # 3. Get the Bot webhook URL from WeCom Bot settings
+# # 3. Get the corp_secret from WeCom app management
 # #
 # # Global HTTP server config (shared by all wecom channels):
 # [wecom]
@@ -550,7 +550,7 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # token = "your_wecom_token"
 # encoding_aes_key = "your_encoding_aes_key_43bytes"
 # corp_id = "ww1234567890abcdef"
-# webhook_url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx-xxx"
+# corp_secret = "${WECOM_CORP_SECRET}"
 #
 # # Define a catch-all pattern
 # [[channels.my_wecom_bot.patterns]]

--- a/crates/jyc-channels/src/wecom/inbound.rs
+++ b/crates/jyc-channels/src/wecom/inbound.rs
@@ -43,15 +43,26 @@ impl ChannelMatcher for WecomMatcher {
         _patterns: &[ChannelPattern],
         _pattern_match: Option<&PatternMatch>,
     ) -> String {
-        // Thread name is derived from chat_id in metadata: wecom_{sanitized_chat_id}
-        // This ensures one thread per WeCom chat group.
+        // Thread name is derived from chat_id + channel_name in metadata:
+        // {channel_name}_{sanitized_chat_id} (e.g. "my_bot_wrOgQhDgA...")
+        // This ensures one thread per channel+group pair.
         if let Some(chat_id) = message
             .metadata
             .get("chat_id")
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
         {
-            format!("wecom_{}", sanitize_for_filesystem(chat_id))
+            let channel_name = message
+                .metadata
+                .get("channel_name")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .unwrap_or("wecom");
+            format!(
+                "{}_{}",
+                sanitize_for_filesystem(channel_name),
+                sanitize_for_filesystem(chat_id)
+            )
         } else {
             // Fallback: use the channel name from sender_address
             message
@@ -501,6 +512,24 @@ mod tests {
             "chat_id".to_string(),
             serde_json::Value::String("wr9876543210".to_string()),
         );
+        metadata.insert(
+            "channel_name".to_string(),
+            serde_json::Value::String("my_bot".to_string()),
+        );
+        let msg = make_wecom_message("user1", "Hello", metadata);
+        let name = matcher.derive_thread_name(&msg, &[], None);
+        assert_eq!(name, "my_bot_wr9876543210");
+    }
+
+    #[test]
+    fn test_derive_thread_name_from_chat_id_without_channel_name() {
+        // If channel_name is missing from metadata, falls back to "wecom" prefix
+        let matcher = WecomMatcher;
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "chat_id".to_string(),
+            serde_json::Value::String("wr9876543210".to_string()),
+        );
         let msg = make_wecom_message("user1", "Hello", metadata);
         let name = matcher.derive_thread_name(&msg, &[], None);
         assert_eq!(name, "wecom_wr9876543210");
@@ -522,6 +551,10 @@ mod tests {
         metadata.insert(
             "chat_id".to_string(),
             serde_json::Value::String("".to_string()),
+        );
+        metadata.insert(
+            "channel_name".to_string(),
+            serde_json::Value::String("my_bot".to_string()),
         );
         let msg = make_wecom_message("wecom:fallback_bot", "Hello", metadata);
         let name = matcher.derive_thread_name(&msg, &[], None);
@@ -548,12 +581,16 @@ mod tests {
             "chat_id".to_string(),
             serde_json::Value::String("wr12345".to_string()),
         );
+        metadata.insert(
+            "channel_name".to_string(),
+            serde_json::Value::String("my_bot".to_string()),
+        );
         let mut msg = make_wecom_message("wecom:user1", "Hello", metadata);
         msg.sender_address = "wecom:user1".to_string();
 
         let adapter_name = adapter.derive_thread_name(&msg, &[], None);
         let matcher_name = WecomMatcher.derive_thread_name(&msg, &[], None);
         assert_eq!(adapter_name, matcher_name);
-        assert_eq!(adapter_name, "wecom_wr12345");
+        assert_eq!(adapter_name, "my_bot_wr12345");
     }
 }

--- a/crates/jyc-channels/src/wecom/inbound.rs
+++ b/crates/jyc-channels/src/wecom/inbound.rs
@@ -325,7 +325,11 @@ mod tests {
     use super::*;
     use jyc_types::{MessageContent, PatternRules, SenderRule};
 
-    fn make_wecom_message(sender: &str, text: &str, metadata: HashMap<String, serde_json::Value>) -> InboundMessage {
+    fn make_wecom_message(
+        sender: &str,
+        text: &str,
+        metadata: HashMap<String, serde_json::Value>,
+    ) -> InboundMessage {
         InboundMessage {
             id: "test-id".to_string(),
             channel: "wecom".to_string(),
@@ -493,7 +497,10 @@ mod tests {
     fn test_derive_thread_name_from_chat_id() {
         let matcher = WecomMatcher;
         let mut metadata = HashMap::new();
-        metadata.insert("chat_id".to_string(), serde_json::Value::String("wr9876543210".to_string()));
+        metadata.insert(
+            "chat_id".to_string(),
+            serde_json::Value::String("wr9876543210".to_string()),
+        );
         let msg = make_wecom_message("user1", "Hello", metadata);
         let name = matcher.derive_thread_name(&msg, &[], None);
         assert_eq!(name, "wecom_wr9876543210");
@@ -512,7 +519,10 @@ mod tests {
     fn test_derive_thread_name_empty_chat_id_fallback() {
         let matcher = WecomMatcher;
         let mut metadata = HashMap::new();
-        metadata.insert("chat_id".to_string(), serde_json::Value::String("".to_string()));
+        metadata.insert(
+            "chat_id".to_string(),
+            serde_json::Value::String("".to_string()),
+        );
         let msg = make_wecom_message("wecom:fallback_bot", "Hello", metadata);
         let name = matcher.derive_thread_name(&msg, &[], None);
         assert_eq!(name, "fallback_bot");
@@ -534,7 +544,10 @@ mod tests {
         let adapter = WecomInboundAdapter::new(&config, "my_bot", server);
 
         let mut metadata = HashMap::new();
-        metadata.insert("chat_id".to_string(), serde_json::Value::String("wr12345".to_string()));
+        metadata.insert(
+            "chat_id".to_string(),
+            serde_json::Value::String("wr12345".to_string()),
+        );
         let mut msg = make_wecom_message("wecom:user1", "Hello", metadata);
         msg.sender_address = "wecom:user1".to_string();
 

--- a/crates/jyc-channels/src/wecom/inbound.rs
+++ b/crates/jyc-channels/src/wecom/inbound.rs
@@ -4,8 +4,8 @@
 //! Unlike WeChat's WebSocket or Feishu's WebSocket, WeCom uses HTTP callbacks:
 //! WeCom sends POST requests to the shared axum HTTP server at `/webhook/{channel_name}`.
 //!
-//! One channel = one Bot = one fixed thread.
-//! Thread name is derived from the channel configuration name.
+//! Thread name is derived from the `chat_id` field in the WeCom message metadata,
+//! following the pattern `wecom_{sanitized_chat_id}` — one thread per chat group.
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -19,7 +19,7 @@ use jyc_types::{
 };
 use jyc_utils::helpers::sanitize_for_filesystem;
 
-use crate::wecom::server::{ChannelWebhookConfig, WecomWebhookServer};
+use crate::wecom::server::{ChannelWebhookConfig, ParsedWecomMessage, WecomWebhookServer};
 use jyc_types::WecomConfig;
 
 /// WeCom channel matcher — stateless pattern matching.
@@ -29,7 +29,7 @@ use jyc_types::WecomConfig;
 /// - `sender`: match sender by exact address (shared with email/feishu/wechat)
 ///
 /// All present rules use AND logic. Empty rules match all messages.
-/// One bot = one fixed thread: thread name is the channel name.
+/// Thread name is derived from `metadata["chat_id"]`: `wecom_{sanitized_chat_id}`.
 pub struct WecomMatcher;
 
 impl ChannelMatcher for WecomMatcher {
@@ -43,14 +43,23 @@ impl ChannelMatcher for WecomMatcher {
         _patterns: &[ChannelPattern],
         _pattern_match: Option<&PatternMatch>,
     ) -> String {
-        // Extract the channel name from sender_address (format: "wecom:{channel_name}").
-        // This is the single source of truth for thread name derivation — the adapter
-        // delegates to this method so the saver and the router agree on the thread name.
-        message
-            .sender_address
-            .strip_prefix("wecom:")
-            .map(jyc_utils::helpers::sanitize_for_filesystem)
-            .unwrap_or_else(|| "wecom".to_string())
+        // Thread name is derived from chat_id in metadata: wecom_{sanitized_chat_id}
+        // This ensures one thread per WeCom chat group.
+        if let Some(chat_id) = message
+            .metadata
+            .get("chat_id")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        {
+            format!("wecom_{}", sanitize_for_filesystem(chat_id))
+        } else {
+            // Fallback: use the channel name from sender_address
+            message
+                .sender_address
+                .strip_prefix("wecom:")
+                .map(sanitize_for_filesystem)
+                .unwrap_or_else(|| "wecom".to_string())
+        }
     }
 
     fn match_message(
@@ -176,7 +185,7 @@ async fn register_handler(
         token: config.token.clone(),
         encoding_aes_key: config.encoding_aes_key.clone(),
         corp_id: config.corp_id.clone(),
-        on_message: Arc::new(move |decrypted_xml: String| {
+        on_message: Arc::new(move |parsed: ParsedWecomMessage| {
             let message = InboundMessage {
                 id: uuid::Uuid::new_v4().to_string(),
                 channel: "wecom".to_string(),
@@ -184,26 +193,41 @@ async fn register_handler(
                     "wecom_{}",
                     chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
                 ),
-                sender: "wecom_bot".to_string(),
-                sender_address: format!("wecom:{}", channel_name_clone_1),
+                sender: parsed.from_user.clone(),
+                sender_address: format!("wecom:{}", parsed.from_user),
                 recipients: vec![],
                 topic: "WeCom Message".to_string(),
                 content: jyc_types::MessageContent {
-                    text: Some(decrypted_xml),
+                    text: Some(parsed.content.clone()),
                     html: None,
                     markdown: None,
                 },
                 timestamp: chrono::Utc::now(),
                 thread_refs: None,
                 reply_to_id: None,
-                external_id: None,
+                external_id: Some(parsed.msg_id.clone()),
                 attachments: vec![],
                 metadata: {
                     let mut m = HashMap::new();
-                    let meta_channel = channel_name_clone_2.clone();
+                    m.insert(
+                        "chat_id".to_string(),
+                        serde_json::Value::String(parsed.chat_id.clone()),
+                    );
+                    m.insert(
+                        "msg_type".to_string(),
+                        serde_json::Value::String(parsed.msg_type.clone()),
+                    );
+                    m.insert(
+                        "from_user".to_string(),
+                        serde_json::Value::String(parsed.from_user.clone()),
+                    );
+                    m.insert(
+                        "msg_id".to_string(),
+                        serde_json::Value::String(parsed.msg_id.clone()),
+                    );
                     m.insert(
                         "channel_name".to_string(),
-                        serde_json::Value::String(meta_channel),
+                        serde_json::Value::String(channel_name_clone_1.clone()),
                     );
                     m
                 },
@@ -301,7 +325,7 @@ mod tests {
     use super::*;
     use jyc_types::{MessageContent, PatternRules, SenderRule};
 
-    fn make_wecom_message(sender: &str, text: &str) -> InboundMessage {
+    fn make_wecom_message(sender: &str, text: &str, metadata: HashMap<String, serde_json::Value>) -> InboundMessage {
         InboundMessage {
             id: "test-id".to_string(),
             channel: "wecom".to_string(),
@@ -320,7 +344,7 @@ mod tests {
             reply_to_id: None,
             external_id: None,
             attachments: vec![],
-            metadata: HashMap::new(),
+            metadata,
             matched_pattern: None,
         }
     }
@@ -351,7 +375,7 @@ mod tests {
 
     #[test]
     fn test_match_by_keywords() {
-        let msg = make_wecom_message("user1", "I need 帮助 with this");
+        let msg = make_wecom_message("user1", "I need 帮助 with this", HashMap::new());
         let patterns = vec![make_wecom_pattern(
             "help_pattern",
             Some(vec!["帮助".to_string(), "help".to_string()]),
@@ -365,7 +389,7 @@ mod tests {
 
     #[test]
     fn test_match_keywords_case_insensitive() {
-        let msg = make_wecom_message("user1", "I need HELP");
+        let msg = make_wecom_message("user1", "I need HELP", HashMap::new());
         let patterns = vec![make_wecom_pattern(
             "help_pattern",
             Some(vec!["help".to_string()]),
@@ -377,7 +401,7 @@ mod tests {
 
     #[test]
     fn test_no_match_wrong_keywords() {
-        let msg = make_wecom_message("user1", "Just chatting");
+        let msg = make_wecom_message("user1", "Just chatting", HashMap::new());
         let patterns = vec![make_wecom_pattern(
             "help_pattern",
             Some(vec!["帮助".to_string(), "help".to_string()]),
@@ -389,7 +413,7 @@ mod tests {
 
     #[test]
     fn test_empty_rules_matches_all() {
-        let msg = make_wecom_message("user1", "Hello");
+        let msg = make_wecom_message("user1", "Hello", HashMap::new());
         let patterns = vec![make_wecom_pattern("catch_all", None, None)];
 
         assert!(wecom_match_message(&msg, &patterns).is_some());
@@ -397,12 +421,12 @@ mod tests {
 
     #[test]
     fn test_match_by_sender() {
-        let msg = make_wecom_message("wx_abc123", "Hello");
+        let msg = make_wecom_message("wecom:wx_abc123", "Hello", HashMap::new());
         let patterns = vec![make_wecom_pattern(
             "vip_user",
             None,
             Some(SenderRule {
-                exact: Some(vec!["wx_abc123".to_string()]),
+                exact: Some(vec!["wecom:wx_abc123".to_string()]),
                 ..Default::default()
             }),
         )];
@@ -412,12 +436,12 @@ mod tests {
 
     #[test]
     fn test_no_match_wrong_sender() {
-        let msg = make_wecom_message("other_user", "Hello");
+        let msg = make_wecom_message("wecom:other_user", "Hello", HashMap::new());
         let patterns = vec![make_wecom_pattern(
             "vip_user",
             None,
             Some(SenderRule {
-                exact: Some(vec!["wx_abc123".to_string()]),
+                exact: Some(vec!["wecom:wx_abc123".to_string()]),
                 ..Default::default()
             }),
         )];
@@ -427,7 +451,7 @@ mod tests {
 
     #[test]
     fn test_disabled_pattern_ignored() {
-        let msg = make_wecom_message("user1", "帮助 please");
+        let msg = make_wecom_message("user1", "帮助 please", HashMap::new());
         let mut pattern = make_wecom_pattern("help_pattern", Some(vec!["帮助".to_string()]), None);
         pattern.enabled = false;
 
@@ -437,12 +461,12 @@ mod tests {
 
     #[test]
     fn test_keywords_and_sender_and() {
-        let msg = make_wecom_message("vip_user", "需要帮助");
+        let msg = make_wecom_message("wecom:vip_user", "需要帮助", HashMap::new());
         let patterns = vec![make_wecom_pattern(
             "vip_help",
             Some(vec!["帮助".to_string()]),
             Some(SenderRule {
-                exact: Some(vec!["vip_user".to_string()]),
+                exact: Some(vec!["wecom:vip_user".to_string()]),
                 ..Default::default()
             }),
         )];
@@ -452,12 +476,12 @@ mod tests {
 
     #[test]
     fn test_keywords_and_sender_no_match() {
-        let msg = make_wecom_message("other_user", "需要帮助");
+        let msg = make_wecom_message("wecom:other_user", "需要帮助", HashMap::new());
         let patterns = vec![make_wecom_pattern(
             "vip_help",
             Some(vec!["帮助".to_string()]),
             Some(SenderRule {
-                exact: Some(vec!["vip_user".to_string()]),
+                exact: Some(vec!["wecom:vip_user".to_string()]),
                 ..Default::default()
             }),
         )];
@@ -466,21 +490,32 @@ mod tests {
     }
 
     #[test]
-    fn test_derive_thread_name() {
+    fn test_derive_thread_name_from_chat_id() {
         let matcher = WecomMatcher;
-        let mut msg = make_wecom_message("user1", "Hello");
-        msg.sender_address = "wecom:my_bot".to_string();
+        let mut metadata = HashMap::new();
+        metadata.insert("chat_id".to_string(), serde_json::Value::String("wr9876543210".to_string()));
+        let msg = make_wecom_message("user1", "Hello", metadata);
         let name = matcher.derive_thread_name(&msg, &[], None);
-        assert_eq!(name, "my_bot");
+        assert_eq!(name, "wecom_wr9876543210");
     }
 
     #[test]
     fn test_derive_thread_name_fallback() {
         let matcher = WecomMatcher;
-        let msg = make_wecom_message("user1", "Hello");
-        // sender_address without "wecom:" prefix should fall back to "wecom"
+        // No chat_id in metadata — falls back to sender_address
+        let msg = make_wecom_message("wecom:my_bot", "Hello", HashMap::new());
         let name = matcher.derive_thread_name(&msg, &[], None);
-        assert_eq!(name, "wecom");
+        assert_eq!(name, "my_bot");
+    }
+
+    #[test]
+    fn test_derive_thread_name_empty_chat_id_fallback() {
+        let matcher = WecomMatcher;
+        let mut metadata = HashMap::new();
+        metadata.insert("chat_id".to_string(), serde_json::Value::String("".to_string()));
+        let msg = make_wecom_message("wecom:fallback_bot", "Hello", metadata);
+        let name = matcher.derive_thread_name(&msg, &[], None);
+        assert_eq!(name, "fallback_bot");
     }
 
     #[test]
@@ -492,18 +527,20 @@ mod tests {
             token: "test".to_string(),
             encoding_aes_key: "abc123abc123abc123abc123abc123abc123abc123abc123abc12".to_string(),
             corp_id: "test_corp".to_string(),
-            webhook_url: "https://example.com/webhook".to_string(),
+            corp_secret: "test_secret".to_string(),
             metadata: std::collections::HashMap::new(),
         };
         let server = Arc::new(WecomWebhookServer::new("127.0.0.1:1"));
         let adapter = WecomInboundAdapter::new(&config, "my_bot", server);
 
-        let mut msg = make_wecom_message("user1", "Hello");
-        msg.sender_address = "wecom:my_bot".to_string();
+        let mut metadata = HashMap::new();
+        metadata.insert("chat_id".to_string(), serde_json::Value::String("wr12345".to_string()));
+        let mut msg = make_wecom_message("wecom:user1", "Hello", metadata);
+        msg.sender_address = "wecom:user1".to_string();
 
         let adapter_name = adapter.derive_thread_name(&msg, &[], None);
         let matcher_name = WecomMatcher.derive_thread_name(&msg, &[], None);
         assert_eq!(adapter_name, matcher_name);
-        assert_eq!(adapter_name, "my_bot");
+        assert_eq!(adapter_name, "wecom_wr12345");
     }
 }

--- a/crates/jyc-channels/src/wecom/inbound.rs
+++ b/crates/jyc-channels/src/wecom/inbound.rs
@@ -5,7 +5,7 @@
 //! WeCom sends POST requests to the shared axum HTTP server at `/webhook/{channel_name}`.
 //!
 //! Thread name is derived from the `chat_id` field in the WeCom message metadata,
-//! following the pattern `wecom_{sanitized_chat_id}` — one thread per chat group.
+//! following the pattern `{channel_name}_{sanitized_chat_id}` — one thread per chat group.
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -29,7 +29,7 @@ use jyc_types::WecomConfig;
 /// - `sender`: match sender by exact address (shared with email/feishu/wechat)
 ///
 /// All present rules use AND logic. Empty rules match all messages.
-/// Thread name is derived from `metadata["chat_id"]`: `wecom_{sanitized_chat_id}`.
+/// Thread name is derived from `metadata["chat_id"]`: `{channel_name}_{sanitized_chat_id}`.
 pub struct WecomMatcher;
 
 impl ChannelMatcher for WecomMatcher {

--- a/crates/jyc-channels/src/wecom/outbound.rs
+++ b/crates/jyc-channels/src/wecom/outbound.rs
@@ -21,7 +21,8 @@ use jyc_types::{
 use crate::wecom::crypto::generate_nonce;
 
 /// The external contact message send API base URL.
-const EXTERNAL_CONTACT_API: &str = "https://qyapi.weixin.qq.com/cgi-bin/externalcontact/message/send";
+const EXTERNAL_CONTACT_API: &str =
+    "https://qyapi.weixin.qq.com/cgi-bin/externalcontact/message/send";
 
 /// The token refresh API base URL.
 const TOKEN_API: &str = "https://qyapi.weixin.qq.com/cgi-bin/gettoken";
@@ -94,11 +95,7 @@ impl AccessTokenCache {
         let errcode = body["errcode"].as_i64().unwrap_or(-1);
         if errcode != 0 {
             let errmsg = body["errmsg"].as_str().unwrap_or("unknown error");
-            anyhow::bail!(
-                "WeCom gettoken API returned error {}: {}",
-                errcode,
-                errmsg
-            );
+            anyhow::bail!("WeCom gettoken API returned error {}: {}", errcode, errmsg);
         }
 
         let token = body["access_token"]
@@ -273,10 +270,7 @@ impl OutboundAdapter for WecomOutboundAdapter {
             .with_context(|| "failed to send WeCom external contact message".to_string())?;
 
         let status = response.status();
-        let body: serde_json::Value = response
-            .json()
-            .await
-            .unwrap_or(serde_json::Value::Null);
+        let body: serde_json::Value = response.json().await.unwrap_or(serde_json::Value::Null);
 
         if !status.is_success() {
             let errmsg = body["errmsg"].as_str().unwrap_or("unknown error");
@@ -312,18 +306,15 @@ impl OutboundAdapter for WecomOutboundAdapter {
         Ok(result)
     }
 
-    async fn send_alert(&self, _recipient: &str, subject: &str, body: &str) -> Result<SendResult> {
+    async fn send_alert(&self, recipient: &str, subject: &str, body: &str) -> Result<SendResult> {
         // Get the access token
         let token = self.get_token().await?;
 
-        // For alerts, we still need a chat_id — use the _recipient as chat_id
+        // For alerts, we still need a chat_id — use the recipient as chat_id
         // recipient format: "wecom:{chat_id}"
-        let chat_id = _recipient
+        let chat_id = recipient
             .strip_prefix("wecom:")
-            .or_else(|| {
-                // Also try direct chat_id
-                Some(_recipient)
-            })
+            .or(Some(recipient))
             .unwrap_or_default();
 
         let payload = Self::build_alert_payload(chat_id, subject, body);
@@ -340,7 +331,11 @@ impl OutboundAdapter for WecomOutboundAdapter {
         if !response.status().is_success() {
             let status = response.status();
             let response_body = response.text().await.unwrap_or_default();
-            anyhow::bail!("WeCom alert API returned error {}: {}", status, response_body);
+            anyhow::bail!(
+                "WeCom alert API returned error {}: {}",
+                status,
+                response_body
+            );
         }
 
         let message_id = format!("wecom_{}", generate_nonce());
@@ -355,7 +350,10 @@ mod tests {
 
     fn make_test_message(text: &str, chat_id: &str) -> InboundMessage {
         let mut metadata = std::collections::HashMap::new();
-        metadata.insert("chat_id".to_string(), serde_json::Value::String(chat_id.to_string()));
+        metadata.insert(
+            "chat_id".to_string(),
+            serde_json::Value::String(chat_id.to_string()),
+        );
         InboundMessage {
             id: "test-id".to_string(),
             channel: "wecom".to_string(),
@@ -458,7 +456,11 @@ mod tests {
 
     #[test]
     fn test_build_alert_payload() {
-        let payload = WecomOutboundAdapter::build_alert_payload("wr12345", "Alert Title", "Alert body content");
+        let payload = WecomOutboundAdapter::build_alert_payload(
+            "wr12345",
+            "Alert Title",
+            "Alert body content",
+        );
         assert_eq!(payload["chat_id"], "wr12345");
         assert_eq!(payload["msgtype"], "markdown");
         let content = payload["markdown"]["content"].as_str().unwrap();

--- a/crates/jyc-channels/src/wecom/outbound.rs
+++ b/crates/jyc-channels/src/wecom/outbound.rs
@@ -1,14 +1,16 @@
 //! WeCom (企业微信) outbound adapter implementation.
 //!
-//! This module handles sending messages via WeCom Bot webhook URLs.
-//! WeCom Bot supports text and markdown message types.
+//! This module handles sending messages via the WeCom External Contact API
+//! (`/cgi-bin/externalcontact/message/send`). Authentication uses
+//! `corpid` + `corpsecret` to obtain an access_token.
 //!
-//! Reference: https://developer.work.weixin.qq.com/document/path/91770
+//! Reference: https://developer.work.weixin.qq.com/document/path/92135
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Instant;
 
 use jyc_core::message_storage::MessageStorage;
 use jyc_types::{
@@ -18,16 +20,128 @@ use jyc_types::{
 
 use crate::wecom::crypto::generate_nonce;
 
-/// WeCom outbound adapter — sends messages via Bot webhook URL.
+/// The external contact message send API base URL.
+const EXTERNAL_CONTACT_API: &str = "https://qyapi.weixin.qq.com/cgi-bin/externalcontact/message/send";
+
+/// The token refresh API base URL.
+const TOKEN_API: &str = "https://qyapi.weixin.qq.com/cgi-bin/gettoken";
+
+/// The number of seconds before token expiry to proactively refresh.
+const TOKEN_REFRESH_MARGIN_SECS: u64 = 300;
+
+/// Thread-safe access token cache.
 ///
-/// WeCom Bot supports two message types:
+/// Stores the token and its expiry Instant. Refreshes automatically
+/// when the token is missing or will expire within 5 minutes.
+pub struct AccessTokenCache {
+    inner: Arc<std::sync::Mutex<Option<(String, Instant)>>>,
+    corp_id: String,
+    corp_secret: String,
+    client: reqwest::Client,
+}
+
+impl AccessTokenCache {
+    /// Create a new access token cache.
+    pub fn new(corp_id: String, corp_secret: String) -> Self {
+        Self {
+            inner: Arc::new(std::sync::Mutex::new(None)),
+            corp_id,
+            corp_secret,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Get a valid access token, refreshing if necessary.
+    ///
+    /// If the cached token exists and will not expire within
+    /// `TOKEN_REFRESH_MARGIN_SECS` seconds, returns it directly.
+    /// Otherwise calls the WeCom gettoken API to obtain a new one.
+    pub async fn get_token(&self) -> Result<String> {
+        // Check if cached token is still valid
+        {
+            let cache = self.inner.lock().unwrap();
+            if let Some((token, expiry)) = cache.as_ref() {
+                let now = Instant::now();
+                let remaining = if *expiry > now {
+                    *expiry - now
+                } else {
+                    std::time::Duration::from_secs(0)
+                };
+                if remaining.as_secs() > TOKEN_REFRESH_MARGIN_SECS {
+                    return Ok(token.clone());
+                }
+            }
+        }
+
+        // Need to refresh: fetch new token from API
+        let url = format!(
+            "{}?corpid={}&corpsecret={}",
+            TOKEN_API, self.corp_id, self.corp_secret
+        );
+
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context("failed to request WeCom access_token")?;
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .context("failed to parse WeCom access_token response")?;
+
+        let errcode = body["errcode"].as_i64().unwrap_or(-1);
+        if errcode != 0 {
+            let errmsg = body["errmsg"].as_str().unwrap_or("unknown error");
+            anyhow::bail!(
+                "WeCom gettoken API returned error {}: {}",
+                errcode,
+                errmsg
+            );
+        }
+
+        let token = body["access_token"]
+            .as_str()
+            .context("missing access_token in gettoken response")?
+            .to_string();
+        let expires_in = body["expires_in"].as_i64().unwrap_or(7200) as u64;
+
+        let expiry = Instant::now()
+            .checked_add(std::time::Duration::from_secs(expires_in))
+            .context("token expiry overflow")?;
+
+        // Update cache
+        {
+            let mut cache = self.inner.lock().unwrap();
+            *cache = Some((token.clone(), expiry));
+        }
+
+        tracing::debug!(
+            expires_in_secs = expires_in,
+            "WeCom access_token obtained and cached"
+        );
+
+        Ok(token)
+    }
+
+    /// Get a clone of the inner mutex for testing/sharing.
+    #[cfg(test)]
+    fn inner_clone(&self) -> Arc<std::sync::Mutex<Option<(String, Instant)>>> {
+        self.inner.clone()
+    }
+}
+
+/// WeCom outbound adapter — sends messages via external contact API.
+///
+/// Uses `corp_id` + `corp_secret` to obtain an access_token for authentication,
+/// then sends messages to the WeCom External Contact message API.
+///
+/// Supports two message types:
 /// - `text`: plain text messages (default)
 /// - `markdown`: markdown formatted messages
-///
-/// Unlike WeChat, WeCom does not share a connection between inbound and outbound.
-/// Each outbound request is a standalone HTTP POST to the Bot webhook URL.
 pub struct WecomOutboundAdapter {
-    webhook_url: String,
+    access_token_cache: AccessTokenCache,
     storage: Arc<MessageStorage>,
     #[allow(dead_code)]
     attachment_config: Option<OutboundAttachmentConfig>,
@@ -40,13 +154,14 @@ pub struct WecomOutboundAdapter {
 impl WecomOutboundAdapter {
     /// Create a new WeCom outbound adapter with attachments and footer support.
     pub fn new_with_attachments(
-        webhook_url: String,
+        corp_id: String,
+        corp_secret: String,
         storage: Arc<MessageStorage>,
         attachment_config: Option<OutboundAttachmentConfig>,
         footer_enabled: bool,
     ) -> Self {
         Self {
-            webhook_url,
+            access_token_cache: AccessTokenCache::new(corp_id, corp_secret),
             storage,
             attachment_config,
             footer_enabled,
@@ -54,8 +169,22 @@ impl WecomOutboundAdapter {
         }
     }
 
-    /// Build the JSON payload for a WeCom Bot message.
-    fn build_payload(reply_text: &str, _original: &InboundMessage) -> serde_json::Value {
+    /// Get a valid access token from the cache.
+    async fn get_token(&self) -> Result<String> {
+        self.access_token_cache.get_token().await
+    }
+
+    /// Build the JSON payload for a WeCom external contact message.
+    ///
+    /// The payload includes `chat_id` and the message content (text or markdown).
+    fn build_payload(reply_text: &str, original: &InboundMessage) -> serde_json::Value {
+        // Get the chat_id from the original message metadata
+        let chat_id = original
+            .metadata
+            .get("chat_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+
         // Detect if the content looks like markdown
         let is_markdown = reply_text.contains("```")
             || reply_text.contains("**")
@@ -66,6 +195,7 @@ impl WecomOutboundAdapter {
 
         if is_markdown {
             serde_json::json!({
+                "chat_id": chat_id,
                 "msgtype": "markdown",
                 "markdown": {
                     "content": reply_text
@@ -73,12 +203,24 @@ impl WecomOutboundAdapter {
             })
         } else {
             serde_json::json!({
+                "chat_id": chat_id,
                 "msgtype": "text",
                 "text": {
                     "content": reply_text
                 }
             })
         }
+    }
+
+    /// Build the JSON payload for an alert message (always markdown).
+    fn build_alert_payload(chat_id: &str, subject: &str, body: &str) -> serde_json::Value {
+        serde_json::json!({
+            "chat_id": chat_id,
+            "msgtype": "markdown",
+            "markdown": {
+                "content": format!("## {}\n\n{}", subject, body)
+            }
+        })
     }
 }
 
@@ -89,8 +231,10 @@ impl OutboundAdapter for WecomOutboundAdapter {
     }
 
     async fn connect(&self) -> Result<()> {
-        // WeCom uses stateless HTTP requests, no persistent connection needed
-        tracing::debug!("WeCom outbound: no connection needed (stateless HTTP)");
+        // WeCom uses stateless HTTP requests, no persistent connection needed.
+        // We verify connectivity by fetching an access token.
+        self.get_token().await?;
+        tracing::debug!("WeCom outbound: connected (access_token obtained)");
         Ok(())
     }
 
@@ -112,22 +256,46 @@ impl OutboundAdapter for WecomOutboundAdapter {
         message_dir: &str,
         _attachments: Option<&[OutboundAttachment]>,
     ) -> Result<SendResult> {
-        // Build the message payload
+        // Get the access token
+        let token = self.get_token().await?;
+
+        // Build the message payload with chat_id from the original message
         let payload = Self::build_payload(reply_text, original);
 
-        // Send via HTTP POST to the Bot webhook URL
+        // Send via HTTP POST to the external contact API
+        let url = format!("{}?access_token={}", EXTERNAL_CONTACT_API, token);
         let response = self
             .client
-            .post(&self.webhook_url)
+            .post(&url)
             .json(&payload)
             .send()
             .await
-            .with_context(|| "failed to send WeCom message to webhook URL".to_string())?;
+            .with_context(|| "failed to send WeCom external contact message".to_string())?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("WeCom webhook returned error {}: {}", status, body);
+        let status = response.status();
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .unwrap_or(serde_json::Value::Null);
+
+        if !status.is_success() {
+            let errmsg = body["errmsg"].as_str().unwrap_or("unknown error");
+            anyhow::bail!(
+                "WeCom external contact API returned error {}: {} (status: {})",
+                body["errcode"],
+                errmsg,
+                status
+            );
+        }
+
+        let errcode = body["errcode"].as_i64().unwrap_or(-1);
+        if errcode != 0 {
+            let errmsg = body["errmsg"].as_str().unwrap_or("unknown error");
+            anyhow::bail!(
+                "WeCom external contact API returned error {}: {}",
+                errcode,
+                errmsg
+            );
         }
 
         let message_id = format!("wecom_{}", generate_nonce());
@@ -145,16 +313,25 @@ impl OutboundAdapter for WecomOutboundAdapter {
     }
 
     async fn send_alert(&self, _recipient: &str, subject: &str, body: &str) -> Result<SendResult> {
-        let payload = serde_json::json!({
-            "msgtype": "markdown",
-            "markdown": {
-                "content": format!("## {}\n\n{}", subject, body)
-            }
-        });
+        // Get the access token
+        let token = self.get_token().await?;
 
+        // For alerts, we still need a chat_id — use the _recipient as chat_id
+        // recipient format: "wecom:{chat_id}"
+        let chat_id = _recipient
+            .strip_prefix("wecom:")
+            .or_else(|| {
+                // Also try direct chat_id
+                Some(_recipient)
+            })
+            .unwrap_or_default();
+
+        let payload = Self::build_alert_payload(chat_id, subject, body);
+
+        let url = format!("{}?access_token={}", EXTERNAL_CONTACT_API, token);
         let response = self
             .client
-            .post(&self.webhook_url)
+            .post(&url)
             .json(&payload)
             .send()
             .await
@@ -162,8 +339,8 @@ impl OutboundAdapter for WecomOutboundAdapter {
 
         if !response.status().is_success() {
             let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            anyhow::bail!("WeCom alert webhook returned error {}: {}", status, body);
+            let response_body = response.text().await.unwrap_or_default();
+            anyhow::bail!("WeCom alert API returned error {}: {}", status, response_body);
         }
 
         let message_id = format!("wecom_{}", generate_nonce());
@@ -176,7 +353,9 @@ mod tests {
     use super::*;
     use jyc_types::MessageContent;
 
-    fn make_test_message(text: &str) -> InboundMessage {
+    fn make_test_message(text: &str, chat_id: &str) -> InboundMessage {
+        let mut metadata = std::collections::HashMap::new();
+        metadata.insert("chat_id".to_string(), serde_json::Value::String(chat_id.to_string()));
         InboundMessage {
             id: "test-id".to_string(),
             channel: "wecom".to_string(),
@@ -195,46 +374,59 @@ mod tests {
             reply_to_id: None,
             external_id: None,
             attachments: vec![],
-            metadata: std::collections::HashMap::new(),
+            metadata,
             matched_pattern: None,
         }
     }
 
     #[test]
     fn test_build_payload_text() {
-        let msg = make_test_message("Hello");
+        let msg = make_test_message("Hello", "wr12345");
         let payload = WecomOutboundAdapter::build_payload("Hello World", &msg);
+        assert_eq!(payload["chat_id"], "wr12345");
         assert_eq!(payload["msgtype"], "text");
         assert_eq!(payload["text"]["content"], "Hello World");
     }
 
     #[test]
     fn test_build_payload_markdown() {
-        let msg = make_test_message("Hello");
+        let msg = make_test_message("Hello", "wr12345");
         let payload = WecomOutboundAdapter::build_payload("## Title\n\n**bold** text", &msg);
+        assert_eq!(payload["chat_id"], "wr12345");
         assert_eq!(payload["msgtype"], "markdown");
         assert_eq!(payload["markdown"]["content"], "## Title\n\n**bold** text");
     }
 
     #[test]
     fn test_build_payload_markdown_with_code_block() {
-        let msg = make_test_message("Hello");
+        let msg = make_test_message("Hello", "wr12345");
         let payload = WecomOutboundAdapter::build_payload("```rust\nfn main() {}\n```", &msg);
+        assert_eq!(payload["chat_id"], "wr12345");
         assert_eq!(payload["msgtype"], "markdown");
     }
 
     #[test]
     fn test_build_payload_markdown_with_table() {
-        let msg = make_test_message("Hello");
+        let msg = make_test_message("Hello", "wr12345");
         let payload = WecomOutboundAdapter::build_payload("| A | B |\n|---|---|", &msg);
+        assert_eq!(payload["chat_id"], "wr12345");
         assert_eq!(payload["msgtype"], "markdown");
+    }
+
+    #[test]
+    fn test_build_payload_empty_chat_id() {
+        let msg = make_test_message("Hello", "");
+        let payload = WecomOutboundAdapter::build_payload("Hello World", &msg);
+        assert_eq!(payload["chat_id"], "");
+        assert_eq!(payload["msgtype"], "text");
     }
 
     #[test]
     fn test_clean_body() {
         let storage = Arc::new(MessageStorage::new(&std::env::temp_dir()));
         let adapter = WecomOutboundAdapter::new_with_attachments(
-            "https://example.com/webhook".to_string(),
+            "corp_id".to_string(),
+            "corp_secret".to_string(),
             storage,
             None,
             true,
@@ -247,11 +439,36 @@ mod tests {
     fn test_channel_type() {
         let storage = Arc::new(MessageStorage::new(&std::env::temp_dir()));
         let adapter = WecomOutboundAdapter::new_with_attachments(
-            "https://example.com/webhook".to_string(),
+            "corp_id".to_string(),
+            "corp_secret".to_string(),
             storage,
             None,
             true,
         );
         assert_eq!(adapter.channel_type(), "wecom");
+    }
+
+    #[test]
+    fn test_access_token_cache_creation() {
+        let cache = AccessTokenCache::new("corp_id".to_string(), "corp_secret".to_string());
+        let inner = cache.inner_clone();
+        let guard = inner.lock().unwrap();
+        assert!(guard.is_none());
+    }
+
+    #[test]
+    fn test_build_alert_payload() {
+        let payload = WecomOutboundAdapter::build_alert_payload("wr12345", "Alert Title", "Alert body content");
+        assert_eq!(payload["chat_id"], "wr12345");
+        assert_eq!(payload["msgtype"], "markdown");
+        let content = payload["markdown"]["content"].as_str().unwrap();
+        assert!(content.contains("Alert Title"));
+        assert!(content.contains("Alert body content"));
+    }
+
+    #[test]
+    fn test_build_alert_payload_empty_chat_id() {
+        let payload = WecomOutboundAdapter::build_alert_payload("", "Subject", "Body");
+        assert_eq!(payload["chat_id"], "");
     }
 }

--- a/crates/jyc-channels/src/wecom/outbound.rs
+++ b/crates/jyc-channels/src/wecom/outbound.rs
@@ -325,10 +325,7 @@ impl OutboundAdapter for WecomOutboundAdapter {
             .with_context(|| "failed to send WeCom alert")?;
 
         let status = response.status();
-        let body: serde_json::Value = response
-            .json()
-            .await
-            .unwrap_or(serde_json::Value::Null);
+        let body: serde_json::Value = response.json().await.unwrap_or(serde_json::Value::Null);
 
         if !status.is_success() {
             let errmsg = body["errmsg"].as_str().unwrap_or("unknown error");

--- a/crates/jyc-channels/src/wecom/outbound.rs
+++ b/crates/jyc-channels/src/wecom/outbound.rs
@@ -310,12 +310,8 @@ impl OutboundAdapter for WecomOutboundAdapter {
         // Get the access token
         let token = self.get_token().await?;
 
-        // For alerts, we still need a chat_id — use the recipient as chat_id
-        // recipient format: "wecom:{chat_id}"
-        let chat_id = recipient
-            .strip_prefix("wecom:")
-            .or(Some(recipient))
-            .unwrap_or_default();
+        // The recipient is in format "wecom:{chat_id}" — extract the chat_id
+        let chat_id = recipient.strip_prefix("wecom:").unwrap_or(recipient);
 
         let payload = Self::build_alert_payload(chat_id, subject, body);
 
@@ -328,14 +324,26 @@ impl OutboundAdapter for WecomOutboundAdapter {
             .await
             .with_context(|| "failed to send WeCom alert")?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let response_body = response.text().await.unwrap_or_default();
+        let status = response.status();
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .unwrap_or(serde_json::Value::Null);
+
+        if !status.is_success() {
+            let errmsg = body["errmsg"].as_str().unwrap_or("unknown error");
             anyhow::bail!(
-                "WeCom alert API returned error {}: {}",
+                "WeCom alert API returned error {}: {} (status: {})",
+                body["errcode"],
+                errmsg,
                 status,
-                response_body
             );
+        }
+
+        let errcode = body["errcode"].as_i64().unwrap_or(-1);
+        if errcode != 0 {
+            let errmsg = body["errmsg"].as_str().unwrap_or("unknown error");
+            anyhow::bail!("WeCom alert API returned error {}: {}", errcode, errmsg);
         }
 
         let message_id = format!("wecom_{}", generate_nonce());

--- a/crates/jyc-channels/src/wecom/server.rs
+++ b/crates/jyc-channels/src/wecom/server.rs
@@ -33,6 +33,27 @@ use tokio_util::sync::CancellationToken;
 
 use crate::wecom::crypto;
 
+/// A parsed WeCom callback message from the decrypted XML.
+///
+/// Fields correspond to the inner XML body after AES decryption.
+/// Reference: https://developer.work.weixin.qq.com/document/path/90255
+#[derive(Debug, Clone)]
+pub struct ParsedWecomMessage {
+    /// Message content (text from `<Content>`).
+    pub content: String,
+    /// Sender's UserName (from `<FromUserName>`).
+    pub from_user: String,
+    /// Chat ID — the group chat room ID (from `<ChatId>`).
+    /// This is used for routing outbound messages to the correct group.
+    pub chat_id: String,
+    /// Message type (from `<MsgType>`, e.g. "text", "image").
+    pub msg_type: String,
+    /// Message ID (from `<MsgId>`).
+    pub msg_id: String,
+    /// Create time (from `<CreateTime>`).
+    pub create_time: String,
+}
+
 /// Per-channel configuration stored in the webhook server.
 #[derive(Clone)]
 pub struct ChannelWebhookConfig {
@@ -42,8 +63,8 @@ pub struct ChannelWebhookConfig {
     pub encoding_aes_key: String,
     /// Corp ID.
     pub corp_id: String,
-    /// Handler for incoming decrypted messages.
-    pub on_message: Arc<dyn Fn(String) -> Result<()> + Send + Sync>,
+    /// Handler for incoming decrypted parsed messages.
+    pub on_message: Arc<dyn Fn(ParsedWecomMessage) -> Result<()> + Send + Sync>,
 }
 
 /// The shared WeCom webhook server state.
@@ -250,8 +271,23 @@ async fn handle_post(
                 "WeCom callback: message decrypted successfully"
             );
 
-            // Call the channel's message handler
-            if let Err(e) = (config.on_message)(decrypted) {
+            // Parse the decrypted XML into structured fields
+            let parsed = match parse_decrypted_xml(&decrypted) {
+                Some(p) => p,
+                None => {
+                    tracing::warn!(
+                        channel = %channel_name,
+                        "WeCom callback: failed to parse decrypted XML"
+                    );
+                    return (
+                        axum::http::StatusCode::BAD_REQUEST,
+                        "failed to parse decrypted XML".to_string(),
+                    );
+                }
+            };
+
+            // Call the channel's message handler with the parsed message
+            if let Err(e) = (config.on_message)(parsed) {
                 tracing::error!(
                     channel = %channel_name,
                     error = %e,
@@ -296,6 +332,67 @@ fn extract_encrypt_from_xml(xml: &str) -> Option<String> {
     let end = xml[content_start..].find(end_marker)?;
 
     Some(xml[content_start..content_start + end].to_string())
+}
+
+/// Parse the decrypted XML message body into a `ParsedWecomMessage`.
+///
+/// The XML format (after AES decryption) is:
+/// ```xml
+/// <xml>
+///   <ToUserName><![CDATA[ww1234567890]]></ToUserName>
+///   <FromUserName><![CDATA[UserID]]></FromUserName>
+///   <CreateTime>1700000000</CreateTime>
+///   <MsgType><![CDATA[text]]></MsgType>
+///   <Content><![CDATA[Hello]]></Content>
+///   <MsgId>1234567890</MsgId>
+///   <ChatId><![CDATA[wr1234567890]]></ChatId>
+/// </xml>
+/// ```
+///
+/// Uses simple string extraction (same style as `extract_encrypt_from_xml`).
+pub fn parse_decrypted_xml(xml: &str) -> Option<ParsedWecomMessage> {
+    let content = extract_xml_field(xml, "Content").unwrap_or_default();
+    let from_user = extract_xml_field(xml, "FromUserName")?;
+    let chat_id = extract_xml_field(xml, "ChatId")?;
+    let msg_type = extract_xml_field(xml, "MsgType")?;
+    let msg_id = extract_xml_field(xml, "MsgId").unwrap_or_default();
+    let create_time = extract_xml_field(xml, "CreateTime").unwrap_or_default();
+
+    Some(ParsedWecomMessage {
+        content,
+        from_user,
+        chat_id,
+        msg_type,
+        msg_id,
+        create_time,
+    })
+}
+
+/// Extract the CDATA content of an XML field (e.g. `<FieldName><![CDATA[value]]></FieldName>`).
+///
+/// Also supports non-CDATA fields like `<CreateTime>1700000000</CreateTime>`.
+fn extract_xml_field(xml: &str, field: &str) -> Option<String> {
+    // Try CDATA format first: <Field><![CDATA[value]]></Field>
+    let cdata_start = format!("<{}><![CDATA[", field);
+    let cdata_end = format!("]]></{}>", field);
+    if let Some(start) = xml.find(&cdata_start) {
+        let value_start = start + cdata_start.len();
+        if let Some(end) = xml[value_start..].find(&cdata_end) {
+            return Some(xml[value_start..value_start + end].to_string());
+        }
+    }
+
+    // Try plain format: <Field>value</Field>
+    let plain_start = format!("<{}>", field);
+    let plain_end = format!("</{}>", field);
+    if let Some(start) = xml.find(&plain_start) {
+        let value_start = start + plain_start.len();
+        if let Some(end) = xml[value_start..].find(&plain_end) {
+            return Some(xml[value_start..value_start + end].to_string());
+        }
+    }
+
+    None
 }
 
 #[cfg(test)]
@@ -351,5 +448,99 @@ mod tests {
         let xml = r#"<xml><Encrypt><![CDATA[]]></Encrypt></xml>"#;
         let encrypt = extract_encrypt_from_xml(xml);
         assert_eq!(encrypt, Some("".to_string()));
+    }
+
+    #[test]
+    fn test_parse_decrypted_xml_full() {
+        let xml = r#"<xml>
+            <ToUserName><![CDATA[ww123456]]></ToUserName>
+            <FromUserName><![CDATA[user001]]></FromUserName>
+            <CreateTime>1700000000</CreateTime>
+            <MsgType><![CDATA[text]]></MsgType>
+            <Content><![CDATA[Hello World]]></Content>
+            <MsgId>1234567890</MsgId>
+            <ChatId><![CDATA[wr9876543210]]></ChatId>
+        </xml>"#;
+
+        let parsed = parse_decrypted_xml(xml).expect("should parse");
+        assert_eq!(parsed.content, "Hello World");
+        assert_eq!(parsed.from_user, "user001");
+        assert_eq!(parsed.chat_id, "wr9876543210");
+        assert_eq!(parsed.msg_type, "text");
+        assert_eq!(parsed.msg_id, "1234567890");
+        assert_eq!(parsed.create_time, "1700000000");
+    }
+
+    #[test]
+    fn test_parse_decrypted_xml_missing_chat_id() {
+        let xml = r#"<xml>
+            <FromUserName><![CDATA[user001]]></FromUserName>
+            <MsgType><![CDATA[text]]></MsgType>
+            <Content><![CDATA[Hello]]></Content>
+        </xml>"#;
+        assert!(parse_decrypted_xml(xml).is_none());
+    }
+
+    #[test]
+    fn test_parse_decrypted_xml_missing_from_user() {
+        let xml = r#"<xml>
+            <ChatId><![CDATA[wr123]]></ChatId>
+            <MsgType><![CDATA[text]]></MsgType>
+            <Content><![CDATA[Hello]]></Content>
+        </xml>"#;
+        assert!(parse_decrypted_xml(xml).is_none());
+    }
+
+    #[test]
+    fn test_extract_xml_field_cdata() {
+        let xml = r#"<xml><Content><![CDATA[hello]]></Content></xml>"#;
+        assert_eq!(extract_xml_field(xml, "Content"), Some("hello".to_string()));
+    }
+
+    #[test]
+    fn test_extract_xml_field_plain() {
+        let xml = r#"<xml><CreateTime>1700000000</CreateTime></xml>"#;
+        assert_eq!(
+            extract_xml_field(xml, "CreateTime"),
+            Some("1700000000".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_xml_field_not_found() {
+        let xml = r#"<xml><Other>value</Other></xml>"#;
+        assert_eq!(extract_xml_field(xml, "Missing"), None);
+    }
+
+    #[test]
+    fn test_parse_decrypted_xml_empty_content() {
+        let xml = r#"<xml>
+            <FromUserName><![CDATA[user001]]></FromUserName>
+            <CreateTime>1700000000</CreateTime>
+            <MsgType><![CDATA[text]]></MsgType>
+            <Content><![CDATA[]]></Content>
+            <MsgId>1234567890</MsgId>
+            <ChatId><![CDATA[wr9876543210]]></ChatId>
+        </xml>"#;
+
+        let parsed = parse_decrypted_xml(xml).expect("should parse with empty content");
+        assert_eq!(parsed.content, "");
+        assert_eq!(parsed.from_user, "user001");
+        assert_eq!(parsed.chat_id, "wr9876543210");
+    }
+
+    #[test]
+    fn test_parse_decrypted_xml_missing_content_optional() {
+        let xml = r#"<xml>
+            <FromUserName><![CDATA[user001]]></FromUserName>
+            <CreateTime>1700000000</CreateTime>
+            <MsgType><![CDATA[image]]></MsgType>
+            <MsgId>1234567890</MsgId>
+            <ChatId><![CDATA[wr9876543210]]></ChatId>
+        </xml>"#;
+
+        let parsed = parse_decrypted_xml(xml).expect("should parse without Content");
+        assert_eq!(parsed.content, "");
+        assert_eq!(parsed.msg_type, "image");
     }
 }

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -221,7 +221,8 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     })?
                     .clone();
                 Arc::new(WecomOutboundAdapter::new_with_attachments(
-                    wecom_config.webhook_url,
+                    wecom_config.corp_id,
+                    wecom_config.corp_secret,
                     storage.clone(),
                     outbound_attachment_config,
                     footer_enabled,

--- a/crates/jyc-types/src/validation.rs
+++ b/crates/jyc-types/src/validation.rs
@@ -208,16 +208,10 @@ pub fn validate_config(config: &AppConfig) -> Vec<ValidationError> {
                         message: "WeCom corp_id is required".into(),
                     });
                 }
-                if wecom_config.webhook_url.is_empty() {
+                if wecom_config.corp_secret.is_empty() {
                     errors.push(ValidationError {
-                        path: format!("{prefix}.wecom.webhook_url"),
-                        message: "WeCom webhook_url is required (use ${ENV_VAR} syntax)".into(),
-                    });
-                }
-                if !wecom_config.webhook_url.starts_with("https://") {
-                    errors.push(ValidationError {
-                        path: format!("{prefix}.wecom.webhook_url"),
-                        message: "WeCom webhook_url must start with https://".into(),
+                        path: format!("{prefix}.wecom.corp_secret"),
+                        message: "WeCom corp_secret is required (use ${ENV_VAR} syntax)".into(),
                     });
                 }
             } else {
@@ -877,7 +871,7 @@ type = "wecom"
 token = "wecom_token_xxx"
 encoding_aes_key = "abc123abc123abc123abc123abc123abc123abc123abc123abc12"
 corp_id = "ww1234567890abcdef"
-webhook_url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx"
+corp_secret = "my_corp_secret_value"
 
 [agent]
 enabled = true
@@ -915,7 +909,7 @@ type = "wecom"
 token = ""
 encoding_aes_key = "abc123abc123abc123abc123abc123abc123abc123abc123abc12"
 corp_id = "ww1234567890abcdef"
-webhook_url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx"
+corp_secret = "my_corp_secret_value"
 
 [agent]
 enabled = true
@@ -927,7 +921,7 @@ mode = "agent"
     }
 
     #[test]
-    fn test_wecom_invalid_webhook_url_fails() {
+    fn test_wecom_missing_corp_secret_fails() {
         let toml = r#"
 [general]
 [channels.wecom_bot]
@@ -937,7 +931,7 @@ type = "wecom"
 token = "valid_token"
 encoding_aes_key = "abc123abc123abc123abc123abc123abc123abc123abc123abc12"
 corp_id = "ww1234567890abcdef"
-webhook_url = "http://insecure-url.com"
+corp_secret = ""
 
 [agent]
 enabled = true
@@ -945,6 +939,6 @@ mode = "agent"
 "#;
         let config = load_config_from_str(toml).unwrap();
         let errors = validate_config(&config);
-        assert!(errors.iter().any(|e| e.path.contains("wecom.webhook_url")));
+        assert!(errors.iter().any(|e| e.path.contains("wecom.corp_secret")));
     }
 }

--- a/crates/jyc-types/src/wecom_config.rs
+++ b/crates/jyc-types/src/wecom_config.rs
@@ -27,7 +27,7 @@ fn default_bind_addr() -> String {
 /// WeCom (企业微信) channel-specific configuration.
 ///
 /// Contains credentials for receiving callback messages (token, encoding_aes_key, corp_id)
-/// and the Bot webhook URL for sending messages.
+/// and the corp_secret for access_token-based outbound messaging via the external contact API.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct WecomConfig {
     /// Token for callback message verification (from WeCom Bot callback settings)
@@ -36,12 +36,11 @@ pub struct WecomConfig {
     /// Encoding AES Key (with "=" padding) for message decryption
     pub encoding_aes_key: String,
 
-    /// Corp ID / Enterprise ID for message decryption
+    /// Corp ID / Enterprise ID for message decryption and access_token acquisition
     pub corp_id: String,
 
-    /// Bot webhook URL for sending outgoing messages
-    /// (e.g., "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx")
-    pub webhook_url: String,
+    /// Corp secret for access_token acquisition (used for external contact message API)
+    pub corp_secret: String,
 
     /// Additional metadata
     #[serde(default)]
@@ -64,7 +63,7 @@ mod tests {
             token = "wecom_token_xxx"
             encoding_aes_key = "abc123abc123abc123abc123abc123abc123abc123abc123abc12"
             corp_id = "ww1234567890abcdef"
-            webhook_url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx-xxx-xxx"
+            corp_secret = "my_corp_secret_value"
         "#;
 
         let config: WecomConfig = toml::from_str(toml_str).unwrap();
@@ -74,10 +73,7 @@ mod tests {
             "abc123abc123abc123abc123abc123abc123abc123abc123abc12"
         );
         assert_eq!(config.corp_id, "ww1234567890abcdef");
-        assert_eq!(
-            config.webhook_url,
-            "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx-xxx-xxx"
-        );
+        assert_eq!(config.corp_secret, "my_corp_secret_value");
     }
 
     #[test]

--- a/docs/channels/wecom.md
+++ b/docs/channels/wecom.md
@@ -168,16 +168,18 @@ bold (`**`), headings (`##`), tables (`|`), task lists (`- [`), and images (`![`
 
 ## Thread Naming
 
-Threads are named using the `chat_id` field from the inbound message metadata:
+Threads are named using the `chat_id` field combined with the `channel_name` from the inbound message metadata:
 
 ```
-wecom_{sanitized_chat_id}
+{channel_name}_{sanitized_chat_id}
 ```
+
+For example, a channel named `my_bot` receiving a message from chat group `wrOgQhDgA...` will produce thread name `my_bot_wrOgQhDgA...`.
 
 This ensures:
-- One thread per WeCom chat group (consistent with the "一群一线程" design)
-- Consistency with Feishu's `feishu_{chat_id}` naming pattern
-- Proper isolation between different group conversations
+- One thread per channel+group pair (consistent with the "通道 + 群" design)
+- Consistency with Feishu's `{channel_name}_{chat_id}` naming pattern
+- Proper isolation between different channels and group conversations
 
 ## Testing
 

--- a/docs/channels/wecom.md
+++ b/docs/channels/wecom.md
@@ -1,6 +1,7 @@
 # WeCom (企业微信) Channel
 
-WeCom (WeChat Work / 企业微信) Bot channel implementation for JYC.
+WeCom (WeChat Work / 企业微信) channel implementation for JYC, using the
+**external contact (客户群) API** for outbound messaging.
 
 ## Architecture
 
@@ -21,10 +22,14 @@ WeCom (WeChat Work / 企业微信) Bot channel implementation for JYC.
                                                     │  Router     │
                                                     └─────────────┘
 
-┌─────────────────┐     POST webhook URL           ┌──────────────────┐
-│  WeCom Bot API  │ ◀──────────────────────────   │  Outbound        │
-│  (qyapi.weixin) │     {"msgtype":"text",...}    │  Adapter         │
-└─────────────────┘                                └──────────────────┘
+┌──────────────────────┐   POST /cgi-bin/externalcontact/ ┌──────────────────┐
+│  WeCom External API  │ ◀─── /message/send?access_token= │  Outbound        │
+│  (qyapi.weixin.cn)   │     {"chat_id":"...",...}       │  Adapter         │
+└──────────────────────┘                                  └──────────────────┘
+
+┌──────────────────────┐   GET /cgi-bin/gettoken          ┌──────────────────┐
+│  WeCom Token API     │ ◀─── ?corpid=...&corpsecret=...  │  Token Cache     │
+└──────────────────────┘   (refreshes before expiry)      └──────────────────┘
 ```
 
 ### Key Design Decisions
@@ -32,8 +37,15 @@ WeCom (WeChat Work / 企业微信) Bot channel implementation for JYC.
 - **Shared HTTP Server**: All WeCom channels share a single axum HTTP server (方案B).
   Configured via `[wecom].bind_addr` (default: `127.0.0.1:10001`).
 - **Path-based Routing**: Each channel registers at `/webhook/{channel_name}`.
-- **One Bot = One Thread**: Similar to WeChat, each WeCom Bot maps to a single thread.
-- **Stateless Outbound**: Outbound messages are standalone HTTP POST requests to the Bot webhook URL.
+- **One Group = One Thread**: Thread name is derived from `chat_id`
+  (`wecom_{sanitized_chat_id}`), ensuring each WeCom chat group maps to a dedicated
+  agent thread.
+- **Token-based Outbound**: Uses `corp_id` + `corp_secret` to obtain an access_token
+  from the WeCom API, then sends messages via the external contact API.
+- **Token Caching**: Access tokens are cached in memory with automatic refresh
+  5 minutes before expiry.
+- **XML Parsing**: Uses simple string extraction (matching `extract_encrypt_from_xml`
+  style) — no XML parsing library dependency.
 
 ## Configuration
 
@@ -54,7 +66,7 @@ type = "wecom"
 token = "your_token_from_wecom"
 encoding_aes_key = "your_aes_key_43_chars"
 corp_id = "ww1234567890abcdef"
-webhook_url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxx-xxx"
+corp_secret = "your_corp_secret_value"
 
 [[channels.my_bot.patterns]]
 name = "catch_all"
@@ -70,7 +82,7 @@ keywords = ["help", "问题"]
 | `token` | Yes | Token from WeCom callback settings |
 | `encoding_aes_key` | Yes | Base64-encoded AES key (43 chars with `=`) |
 | `corp_id` | Yes | Enterprise ID / Corp ID |
-| `webhook_url` | Yes | Bot webhook URL for sending messages |
+| `corp_secret` | Yes | Corp secret for access_token acquisition (use `${ENV_VAR}` syntax) |
 | `bind_addr` | No | Global server bind address (default: `127.0.0.1:10001`) |
 
 ## Webhook Protocol
@@ -99,15 +111,39 @@ WeCom sends a POST request with XML body:
 The server:
 1. Verifies SHA1 signature
 2. Decrypts the AES-256-CBC encrypted content
-3. Routes to the channel's message handler
-4. Returns 200 OK
+3. Parses the decrypted XML into structured fields (Content, FromUserName, ChatId, MsgType, etc.)
+4. Routes to the channel's message handler
+5. Returns 200 OK
 
-## Message Types
+### Parsed Message Fields
+
+After decryption, the inner XML is parsed into the following fields:
+
+| Field | Source | Description |
+|-------|--------|-------------|
+| `content` | `<Content>` | Message text content |
+| `from_user` | `<FromUserName>` | Sender's UserName |
+| `chat_id` | `<ChatId>` | Group chat room ID (used for outbound routing) |
+| `msg_type` | `<MsgType>` | Message type (e.g., "text", "image") |
+| `msg_id` | `<MsgId>` | Unique message ID |
+| `create_time` | `<CreateTime>` | Message creation timestamp |
+
+## Outbound: External Contact API
+
+Outbound messages are sent via the WeCom External Contact API:
+`POST /cgi-bin/externalcontact/message/send?access_token={token}`
+
+### Authentication
+
+1. On startup, the adapter calls `GET /cgi-bin/gettoken?corpid={corp_id}&corpsecret={corp_secret}`
+2. The access_token is cached in memory
+3. Tokens are automatically refreshed 5 minutes before expiry (default: 7200 seconds)
 
 ### Outbound: Text
 
 ```json
 {
+  "chat_id": "wr9876543210",
   "msgtype": "text",
   "text": {
     "content": "Hello World"
@@ -119,6 +155,7 @@ The server:
 
 ```json
 {
+  "chat_id": "wr9876543210",
   "msgtype": "markdown",
   "markdown": {
     "content": "# Title\n\n**bold** text"
@@ -126,7 +163,21 @@ The server:
 }
 ```
 
-The adapter auto-detects markdown content by checking for code blocks (` ``` `), bold (`**`), headings (`##`), tables (`|`), task lists (`- [`), and images (`![`).
+The adapter auto-detects markdown content by checking for code blocks (` ``` `),
+bold (`**`), headings (`##`), tables (`|`), task lists (`- [`), and images (`![`).
+
+## Thread Naming
+
+Threads are named using the `chat_id` field from the inbound message metadata:
+
+```
+wecom_{sanitized_chat_id}
+```
+
+This ensures:
+- One thread per WeCom chat group (consistent with the "一群一线程" design)
+- Consistency with Feishu's `feishu_{chat_id}` naming pattern
+- Proper isolation between different group conversations
 
 ## Testing
 
@@ -134,13 +185,13 @@ The adapter auto-detects markdown content by checking for code blocks (` ``` `),
 # Test WeCom crypto module
 cargo test -p jyc-channels wecom::crypto
 
-# Test WeCom server module
+# Test WeCom server module (including XML parsing)
 cargo test -p jyc-channels wecom::server
 
 # Test WeCom inbound adapter
 cargo test -p jyc-channels wecom::inbound
 
-# Test WeCom outbound adapter
+# Test WeCom outbound adapter (including token cache)
 cargo test -p jyc-channels wecom::outbound
 
 # Test configuration validation
@@ -152,5 +203,6 @@ cargo test -p jyc-channels wecom
 
 ## References
 
-- [WeCom Bot Message Types](https://developer.work.weixin.qq.com/document/path/91770)
+- [WeCom External Contact Message API](https://developer.work.weixin.qq.com/document/path/92135)
 - [WeCom Callback Protocol](https://developer.work.weixin.qq.com/document/path/90968)
+- [WeCom gettoken API](https://developer.work.weixin.qq.com/document/path/91039)

--- a/docs/channels/wecom.md
+++ b/docs/channels/wecom.md
@@ -38,7 +38,7 @@ WeCom (WeChat Work / 企业微信) channel implementation for JYC, using the
   Configured via `[wecom].bind_addr` (default: `127.0.0.1:10001`).
 - **Path-based Routing**: Each channel registers at `/webhook/{channel_name}`.
 - **One Group = One Thread**: Thread name is derived from `chat_id`
-  (`wecom_{sanitized_chat_id}`), ensuring each WeCom chat group maps to a dedicated
+  (`{channel_name}_{sanitized_chat_id}`), ensuring each WeCom chat group maps to a dedicated
   agent thread.
 - **Token-based Outbound**: Uses `corp_id` + `corp_secret` to obtain an access_token
   from the WeCom API, then sends messages via the external contact API.


### PR DESCRIPTION
## Spec

将 WeCom（企业微信）出站方式从「群机器人 Webhook」（`/cgi-bin/webhook/send?key=xxx`）改为「客户群」模式（`/cgi-bin/externalcontact/message/send`），使用 `corpid` + `corpsecret` 获取 access_token 进行认证。同时完善入站 XML 解析（Content / FromUserName / ChatId / MsgType），并将线程命名从「一通道一线程」改为「通道 + 群」（基于 `chat_id` 派生：`{channel_name}_{sanitized_chat_id}`）。

Fixes #227

## Implementation Plan

### Step 1: 配置变更 — `webhook_url` → `corp_secret`
**文件：** `crates/jyc-types/src/wecom_config.rs`
**What:** `WecomConfig` 结构体：删除 `webhook_url: String` 字段，新增 `corp_secret: String` 字段。保留已有的 `corp_id`, `token`, `encoding_aes_key`。
**Why:** 客户群模式使用 `corpid + corpsecret` 获取 access_token，不再使用 webhook URL 中的 key。
**Verify:** `cargo check -p jyc-types`，`cargo test -p jyc-types wecom`

### Step 2: 配置校验更新
**文件：** `crates/jyc-types/src/validation.rs`
**What:** 删除 `webhook_url` 的校验逻辑（空值检查 + `https://` 前缀检查），新增 `corp_secret` 非空校验。更新测试用例。
**Why:** 字段变更后校验逻辑必须同步。
**Verify:** `cargo test -p jyc-types validation::tests::test_wecom`

### Step 3: 入站 — XML 解析 + ChatId 提取
**文件：** `crates/jyc-channels/src/wecom/server.rs`
**What:** 新增 `parse_decrypted_xml(xml: &str) -> Option<ParsedWecomMessage>` 函数，解析解密后的 XML，提取 `<Content>`, `<FromUserName>`, `<ChatId>`, `<MsgType>`, `<MsgId>`, `<CreateTime>`。`handle_post` 中改用 `parse_decrypted_xml` 替代直接传原始 XML。回调签名从 `Fn(String)` 改为 `Fn(ParsedWecomMessage)`。
**Why:** 出站需要 `chat_id` 定位目标群，Agent 需要解析后的 `Content` 文本而非原始 XML。
**Verify:** `cargo test -p jyc-channels wecom::server`

小步拆分：
- **3a.** 定义 `ParsedWecomMessage` 结构体，实现 `parse_decrypted_xml`（含测试）
- **3b.** 修改 `ChannelWebhookConfig::on_message` 签名为 `Arc<dyn Fn(ParsedWecomMessage) ...>`，更新 `handle_post`

### Step 4: 入站适配器 — 构造 InboundMessage + 线程名
**文件：** `crates/jyc-channels/src/wecom/inbound.rs`
**What:** 
- `on_message` 回调中：`sender` 设为 `FromUserName`，`sender_address` 设为 `"wecom:{FromUserName}"`，`content.text` 设为解析后的 `Content`，`metadata` 中存入 `chat_id`, `msg_type`, `from_user`, `msg_id`
- `WecomMatcher::derive_thread_name`：从 `message.metadata["chat_id"]` 取值，格式 `{channel_name}_{sanitized_chat_id}`（channel_name 即配置中的通道名如 `my_bot`），回退到 `"wecom"`
- 更新 `WecomInboundAdapter::derive_thread_name` 委托给 `WecomMatcher`
- `register_handler` 签名适配
**Why:** 出站需要 `chat_id`，线程名需要按「通道 + 群」隔离（如 `my_bot_wrOgQhDgA...`）。
**Verify:** `cargo test -p jyc-channels wecom::inbound`

### Step 5: 出站适配器 — token 认证 + 客户群 API
**文件：** `crates/jyc-channels/src/wecom/outbound.rs`
**What:** 
- 构造函数从 `new_with_attachments(webhook_url, ...)` 改为 `new_with_attachments(corp_id, corp_secret, ...)`
- 新增 `AccessTokenCache` 结构体（`Arc<Mutex<Option<(String, Instant)>>>`）：`get_token()` 方法在 token 不存在或将在 5 分钟内过期时调用 `GET /cgi-bin/gettoken` 刷新
- `send_reply`：从 `original.metadata["chat_id"]` 获取 `chat_id`，POST 到 `https://qyapi.weixin.qq.com/cgi-bin/externalcontact/message/send?access_token={token}`，body 格式 `{"chat_id":"...", "msgtype":"text/markdown", "text/markdown":{"content":"..."}}`
- `send_alert`：使用相同 token，标记 `msgtype: "markdown"`
**Why:** 这是本次变更的核心——切换到客户群 API。
**Verify:** `cargo test -p jyc-channels wecom::outbound`

### Step 6: 入口接线 — monitor.rs
**文件：** `crates/jyc-cli/src/cli/monitor.rs`
**What:** 创建 `WecomOutboundAdapter::new_with_attachments` 时传入 `wecom_config.corp_id` + `wecom_config.corp_secret` 替代原来的 `wecom_config.webhook_url`。
**Why:** 适配器构造函数签名变更后的接线。
**Verify:** `cargo check -p jyc-cli`

### Step 7: 文档和配置示例
**文件：** `docs/channels/wecom.md`, `config.example.toml`, `CHANGELOG.md`
**What:** 
- `wecom.md`：更新架构图（出站改为 token 模式）、配置示例（`webhook_url` → `corp_secret`）、字段表、出站 API 说明
- `config.example.toml`：更新 `[channels.xxx.wecom]` 示例
- `CHANGELOG.md`：在 `[Unreleased]` 的 `Changed` 中添加条目
**Why:** 文档和配置示例必须与代码同步。
**Verify:** 目视检查，`cargo test --workspace` 通过

## Design Decisions
- **Token 缓存策略**：存储在内存中（`Arc<Mutex<...>>`），自动过期前 5 分钟刷新，不需要持久化
- **线程命名**：`{channel_name}_{sanitized_chat_id}`（如 `my_bot_wrOgQhDgA...`），与 Feishu 的 `{channel_name}_{chat_id}` 模式一致
- **向后兼容**：不保持——移除 `webhook_url`（群机器人模式不支持客户群场景）
- **XML 解析**：用简单的字符串查找（与现有 `extract_encrypt_from_xml` 风格一致），不引入 XML 解析库
- **出站消息类型**：保持 text/markdown 自动检测逻辑不变，payload 格式从 `{"msgtype":"text","text":{...}}` 变为 `{"chat_id":"...","msgtype":"text","text":{...}}`
