### PR TITLE
feat: add WeCom KF (Customer Service) channel support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ All notable changes to JYC will be documented in this file.
 
 ### Added
 
+- **WeCom KF (Customer Service) channel.** New channel type `wecomkf` supporting
+  inbound messages via `kf_msg_or_event` event notifications and `kf/sync_msg`
+  API pull, outbound messages via `kf/send_msg` API. Includes cursor-based
+  incremental sync with optional file persistence, in-memory message dedup
+  (10K-entry FIFO cap), and shared token/wehbook infrastructure with the
+  existing wecom channel. One thread per customer per KF account.
+  (#229, #230)
+
 - **WeCom (企业微信) Bot channel.** New channel type `wecom` supporting inbound
   messages via shared axum HTTP server and outbound messages via Bot webhook
   URL. Includes AES-256-CBC message decryption, SHA1 signature verification,

--- a/config.example.toml
+++ b/config.example.toml
@@ -558,3 +558,46 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 #
 # [channels.my_wecom_bot.patterns.rules]
 # # keywords = ["help", "问题"]
+
+# # --- Channel: my_wecomkf_bot ---
+# # WeCom KF (Customer Service) channel.
+# # Uses the WeCom Customer Service API (kf/sync_msg, kf/send_msg)
+# # for inbound message pulling and outbound message sending.
+# #
+# # Unlike the regular wecom channel (external contact API), the KF channel:
+# # - Receives kf_msg_or_event notifications via the shared webhook server
+# # - Pulls messages via kf/sync_msg API (cursor-based incremental sync)
+# # - Sends replies via kf/send_msg API
+# # - One thread per customer per KF account
+# #   ({channel_name}_{open_kfid}_{external_userid})
+# #
+# # Prerequisites:
+# # 1. Enable WeCom KF and configure callback URL
+# # 2. Get the token, encoding_aes_key, and corp_id from KF callback settings
+# # 3. Get the corp_secret from WeCom app management
+# # 4. Note the open_kfid(s) for the KF accounts
+# #
+# # Reuses the shared WeCom webhook server (configured in [wecom] above):
+# # [wecom]
+# # bind_addr = "127.0.0.1:10001"
+# #
+# # [channels.my_wecomkf_bot]
+# # type = "wecomkf"
+# #
+# # [channels.my_wecomkf_bot.wecom_kf]
+# # token = "your_kf_token"
+# # encoding_aes_key = "your_encoding_aes_key_43bytes"
+# # corp_id = "ww1234567890abcdef"
+# # corp_secret = "${WECOM_CORP_SECRET}"
+# # # Optional: filter by KF account IDs (empty = accept all)
+# # open_kf_ids = ["kf1234567890"]
+# # # Optional: cursor persistence file path (JSON)
+# # # If not set, cursors are memory-only (lost on restart)
+# # cursor_store_path = "./data/kf_cursors.json"
+# #
+# # # Define a catch-all pattern
+# # [[channels.my_wecomkf_bot.patterns]]
+# # name = "kf_bot"
+# #
+# # [channels.my_wecomkf_bot.patterns.rules]
+# # # keywords = ["help", "support", "问题"]

--- a/crates/jyc-channels/src/wecom/kf_client.rs
+++ b/crates/jyc-channels/src/wecom/kf_client.rs
@@ -1,0 +1,347 @@
+//! WeCom KF (Customer Service) API client.
+//!
+//! Unlike the regular WeCom external contact API, the KF channel uses
+//! dedicated KF APIs:
+//! - `kf/sync_msg` — pull customer messages incrementally (cursor-based)
+//! - `kf/send_msg` — send reply messages to customers
+//!
+//! Reference: https://developer.work.weixin.qq.com/document/path/94677
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::wecom::token_cache::AccessTokenCache;
+
+/// The KF sync message API base URL.
+const KF_SYNC_API: &str = "https://qyapi.weixin.qq.com/cgi-bin/kf/sync_msg";
+
+/// The KF send message API base URL.
+const KF_SEND_API: &str = "https://qyapi.weixin.qq.com/cgi-bin/kf/send_msg";
+
+/// Response from the WeCom KF `sync_msg` API.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KfSyncResponse {
+    /// Error code (0 = success).
+    pub errcode: i64,
+    /// Error message.
+    pub errmsg: String,
+    /// Next cursor for pagination.
+    #[serde(default)]
+    pub next_cursor: String,
+    /// Whether there are more messages to sync.
+    #[serde(default)]
+    pub has_more: Option<i64>,
+    /// List of synced messages.
+    #[serde(default)]
+    pub msg_list: Vec<KfMessage>,
+}
+
+/// A single KF message from the `sync_msg` API.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KfMessage {
+    /// Message ID.
+    pub msgid: String,
+    /// Open KF ID — the KF account that received this message.
+    #[serde(default)]
+    pub open_kfid: String,
+    /// External user ID — the customer who sent the message.
+    #[serde(default)]
+    pub external_userid: String,
+    /// Send time (unix timestamp).
+    #[serde(default)]
+    pub send_time: i64,
+    /// Message type (e.g. "text", "image", "voice", "video", "file", "location", "event").
+    #[serde(default)]
+    pub msgtype: String,
+    /// Text content (present when msgtype == "text").
+    #[serde(default)]
+    pub text: Option<KfTextContent>,
+}
+
+/// Text content of a KF message.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct KfTextContent {
+    /// The message content.
+    pub content: String,
+}
+
+/// WeCom KF API client.
+///
+/// Provides methods to sync incoming messages and send replies
+/// via the WeCom Customer Service API.
+pub struct KfApiClient {
+    access_token_cache: Arc<AccessTokenCache>,
+    client: reqwest::Client,
+}
+
+impl KfApiClient {
+    /// Create a new KF API client.
+    pub fn new(access_token_cache: Arc<AccessTokenCache>) -> Self {
+        Self {
+            access_token_cache,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Sync messages from a KF account using cursor-based pagination.
+    ///
+    /// - `token`: The token from the KF event notification
+    /// - `cursor`: Pagination cursor (empty string for first request)
+    /// - `open_kfid`: KF account ID to sync messages for
+    /// - `limit`: Maximum number of messages to return (max: 1000)
+    pub async fn sync_messages(
+        &self,
+        token: &str,
+        cursor: &str,
+        open_kfid: &str,
+        limit: u32,
+    ) -> Result<KfSyncResponse> {
+        let access_token = self.access_token_cache.get_token().await?;
+
+        let url = format!("{}?access_token={}", KF_SYNC_API, access_token);
+
+        let payload = serde_json::json!({
+            "token": token,
+            "cursor": cursor,
+            "open_kfid": open_kfid,
+            "limit": limit,
+        });
+
+        let response = self
+            .client
+            .post(&url)
+            .json(&payload)
+            .send()
+            .await
+            .context("failed to send KF sync_msg request")?;
+
+        let status = response.status();
+        let body: KfSyncResponse = response
+            .json()
+            .await
+            .context("failed to parse KF sync_msg response")?;
+
+        if !status.is_success() || body.errcode != 0 {
+            anyhow::bail!(
+                "KF sync_msg API returned error {}: {} (status: {})",
+                body.errcode,
+                body.errmsg,
+                status,
+            );
+        }
+
+        Ok(body)
+    }
+
+    /// Send a reply message to a customer via the KF API.
+    ///
+    /// - `open_kfid`: The KF account ID
+    /// - `touser`: The external user ID (customer)
+    /// - `msgtype`: Message type (e.g. "text", "markdown")
+    /// - `content`: Message content
+    pub async fn send_message(
+        &self,
+        open_kfid: &str,
+        touser: &str,
+        msgtype: &str,
+        content: &str,
+    ) -> Result<()> {
+        let access_token = self.access_token_cache.get_token().await?;
+
+        let url = format!("{}?access_token={}", KF_SEND_API, access_token);
+
+        let payload = serde_json::json!({
+            "touser": touser,
+            "open_kfid": open_kfid,
+            "msgtype": msgtype,
+            "text": {
+                "content": content
+            }
+        });
+
+        #[derive(Deserialize)]
+        struct SendResponse {
+            errcode: i64,
+            errmsg: String,
+        }
+
+        let response = self
+            .client
+            .post(&url)
+            .json(&payload)
+            .send()
+            .await
+            .context("failed to send KF send_msg request")?;
+
+        let status = response.status();
+        let body: SendResponse = response
+            .json()
+            .await
+            .context("failed to parse KF send_msg response")?;
+
+        if !status.is_success() || body.errcode != 0 {
+            anyhow::bail!(
+                "KF send_msg API returned error {}: {} (status: {})",
+                body.errcode,
+                body.errmsg,
+                status,
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Build the sync request payload (for unit testing).
+    #[cfg(test)]
+    pub fn build_sync_request(token: &str, cursor: &str, open_kfid: &str, limit: u32) -> serde_json::Value {
+        serde_json::json!({
+            "token": token,
+            "cursor": cursor,
+            "open_kfid": open_kfid,
+            "limit": limit,
+        })
+    }
+
+    /// Build the send message payload (for unit testing).
+    #[cfg(test)]
+    pub fn build_send_payload(open_kfid: &str, touser: &str, msgtype: &str, content: &str) -> serde_json::Value {
+        serde_json::json!({
+            "touser": touser,
+            "open_kfid": open_kfid,
+            "msgtype": msgtype,
+            "text": {
+                "content": content
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_sync_request() {
+        let payload = KfApiClient::build_sync_request("token123", "cursor_abc", "kf001", 100);
+        assert_eq!(payload["token"], "token123");
+        assert_eq!(payload["cursor"], "cursor_abc");
+        assert_eq!(payload["open_kfid"], "kf001");
+        assert_eq!(payload["limit"], 100);
+    }
+
+    #[test]
+    fn test_build_sync_request_empty_cursor() {
+        let payload = KfApiClient::build_sync_request("token123", "", "kf001", 50);
+        assert_eq!(payload["cursor"], "");
+        assert_eq!(payload["limit"], 50);
+    }
+
+    #[test]
+    fn test_build_send_payload() {
+        let payload =
+            KfApiClient::build_send_payload("kf001", "user123", "text", "Hello, world!");
+        assert_eq!(payload["touser"], "user123");
+        assert_eq!(payload["open_kfid"], "kf001");
+        assert_eq!(payload["msgtype"], "text");
+        assert_eq!(payload["text"]["content"], "Hello, world!");
+    }
+
+    #[test]
+    fn test_build_send_payload_markdown() {
+        let payload =
+            KfApiClient::build_send_payload("kf001", "user123", "markdown", "## Title\n\nbody");
+        assert_eq!(payload["msgtype"], "markdown");
+        assert_eq!(payload["text"]["content"], "## Title\n\nbody");
+    }
+
+    #[test]
+    fn test_kf_sync_response_deserialize() {
+        let json = r#"{
+            "errcode": 0,
+            "errmsg": "ok",
+            "next_cursor": "next_cursor_xyz",
+            "has_more": 1,
+            "msg_list": [
+                {
+                    "msgid": "msg_001",
+                    "open_kfid": "kf001",
+                    "external_userid": "user123",
+                    "send_time": 1700000000,
+                    "msgtype": "text",
+                    "text": {
+                        "content": "Hello"
+                    }
+                },
+                {
+                    "msgid": "msg_002",
+                    "open_kfid": "kf001",
+                    "external_userid": "user456",
+                    "send_time": 1700000001,
+                    "msgtype": "text",
+                    "text": {
+                        "content": "Hi there"
+                    }
+                }
+            ]
+        }"#;
+
+        let resp: KfSyncResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.errcode, 0);
+        assert_eq!(resp.errmsg, "ok");
+        assert_eq!(resp.next_cursor, "next_cursor_xyz");
+        assert_eq!(resp.has_more, Some(1));
+        assert_eq!(resp.msg_list.len(), 2);
+
+        assert_eq!(resp.msg_list[0].msgid, "msg_001");
+        assert_eq!(resp.msg_list[0].open_kfid, "kf001");
+        assert_eq!(resp.msg_list[0].external_userid, "user123");
+        assert_eq!(resp.msg_list[0].text.as_ref().unwrap().content, "Hello");
+
+        assert_eq!(resp.msg_list[1].msgid, "msg_002");
+        assert_eq!(resp.msg_list[1].external_userid, "user456");
+    }
+
+    #[test]
+    fn test_kf_sync_response_empty_msg_list() {
+        let json = r#"{
+            "errcode": 0,
+            "errmsg": "ok",
+            "next_cursor": "",
+            "has_more": 0,
+            "msg_list": []
+        }"#;
+
+        let resp: KfSyncResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.errcode, 0);
+        assert!(resp.msg_list.is_empty());
+        assert_eq!(resp.has_more, Some(0));
+    }
+
+    #[test]
+    fn test_kf_sync_response_error() {
+        let json = r#"{
+            "errcode": 40001,
+            "errmsg": "invalid credential"
+        }"#;
+
+        let resp: KfSyncResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.errcode, 40001);
+        assert_eq!(resp.errmsg, "invalid credential");
+        assert!(resp.msg_list.is_empty());
+    }
+
+    #[test]
+    fn test_kf_sync_response_missing_fields() {
+        let json = r#"{
+            "errcode": 0,
+            "errmsg": "ok"
+        }"#;
+
+        let resp: KfSyncResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.errcode, 0);
+        assert_eq!(resp.next_cursor, "");
+        assert!(resp.msg_list.is_empty());
+    }
+}

--- a/crates/jyc-channels/src/wecom/kf_client.rs
+++ b/crates/jyc-channels/src/wecom/kf_client.rs
@@ -85,6 +85,15 @@ impl KfApiClient {
         }
     }
 
+    /// Verify connectivity by fetching a fresh access token.
+    ///
+    /// Used by the outbound adapter's `connect()` method to validate
+    /// that the corp_id and corp_secret are valid at startup.
+    pub async fn verify_connectivity(&self) -> Result<()> {
+        self.access_token_cache.get_token().await?;
+        Ok(())
+    }
+
     /// Sync messages from a KF account using cursor-based pagination.
     ///
     /// - `token`: The token from the KF event notification
@@ -139,7 +148,7 @@ impl KfApiClient {
     ///
     /// - `open_kfid`: The KF account ID
     /// - `touser`: The external user ID (customer)
-    /// - `msgtype`: Message type (e.g. "text", "markdown")
+    /// - `msgtype`: Message type: "text" (markdown is NOT supported by the KF API)
     /// - `content`: Message content
     pub async fn send_message(
         &self,
@@ -152,14 +161,17 @@ impl KfApiClient {
 
         let url = format!("{}?access_token={}", KF_SEND_API, access_token);
 
-        let payload = serde_json::json!({
+        // Build payload with dynamic content key matching msgtype.
+        // KF API expects the content key to match the msgtype value:
+        //   msgtype="text"  → "text": {"content": "..."}
+        //   msgtype="image" → "image": {"media_id": "..."}
+        let content_obj = serde_json::json!({ "content": content });
+        let mut payload = serde_json::json!({
             "touser": touser,
             "open_kfid": open_kfid,
             "msgtype": msgtype,
-            "text": {
-                "content": content
-            }
         });
+        payload[msgtype] = content_obj;
 
         #[derive(Deserialize)]
         struct SendResponse {
@@ -217,14 +229,14 @@ impl KfApiClient {
         msgtype: &str,
         content: &str,
     ) -> serde_json::Value {
-        serde_json::json!({
+        let content_obj = serde_json::json!({ "content": content });
+        let mut payload = serde_json::json!({
             "touser": touser,
             "open_kfid": open_kfid,
             "msgtype": msgtype,
-            "text": {
-                "content": content
-            }
-        })
+        });
+        payload[msgtype] = content_obj;
+        payload
     }
 }
 
@@ -262,7 +274,7 @@ mod tests {
         let payload =
             KfApiClient::build_send_payload("kf001", "user123", "markdown", "## Title\n\nbody");
         assert_eq!(payload["msgtype"], "markdown");
-        assert_eq!(payload["text"]["content"], "## Title\n\nbody");
+        assert_eq!(payload["markdown"]["content"], "## Title\n\nbody");
     }
 
     #[test]

--- a/crates/jyc-channels/src/wecom/kf_client.rs
+++ b/crates/jyc-channels/src/wecom/kf_client.rs
@@ -195,7 +195,12 @@ impl KfApiClient {
 
     /// Build the sync request payload (for unit testing).
     #[cfg(test)]
-    pub fn build_sync_request(token: &str, cursor: &str, open_kfid: &str, limit: u32) -> serde_json::Value {
+    pub fn build_sync_request(
+        token: &str,
+        cursor: &str,
+        open_kfid: &str,
+        limit: u32,
+    ) -> serde_json::Value {
         serde_json::json!({
             "token": token,
             "cursor": cursor,
@@ -206,7 +211,12 @@ impl KfApiClient {
 
     /// Build the send message payload (for unit testing).
     #[cfg(test)]
-    pub fn build_send_payload(open_kfid: &str, touser: &str, msgtype: &str, content: &str) -> serde_json::Value {
+    pub fn build_send_payload(
+        open_kfid: &str,
+        touser: &str,
+        msgtype: &str,
+        content: &str,
+    ) -> serde_json::Value {
         serde_json::json!({
             "touser": touser,
             "open_kfid": open_kfid,
@@ -240,8 +250,7 @@ mod tests {
 
     #[test]
     fn test_build_send_payload() {
-        let payload =
-            KfApiClient::build_send_payload("kf001", "user123", "text", "Hello, world!");
+        let payload = KfApiClient::build_send_payload("kf001", "user123", "text", "Hello, world!");
         assert_eq!(payload["touser"], "user123");
         assert_eq!(payload["open_kfid"], "kf001");
         assert_eq!(payload["msgtype"], "text");

--- a/crates/jyc-channels/src/wecom/kf_cursor.rs
+++ b/crates/jyc-channels/src/wecom/kf_cursor.rs
@@ -1,0 +1,243 @@
+//! Cursor store for WeCom KF (Customer Service) incremental message sync.
+//!
+//! The KF `sync_msg` API uses cursor-based pagination. Cursors must persist
+//! across restarts to avoid re-syncing all historical messages. This module
+//! provides a thread-safe cursor store with optional file-based persistence.
+//!
+//! If no `persist_path` is configured, cursors are kept in memory only
+//! (lost on restart, but dedup prevents double-processing).
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::RwLock;
+
+use anyhow::Result;
+
+/// Thread-safe cursor store for KF sync cursors.
+///
+/// Maps `open_kfid` → cursor string. Supports optional file persistence
+/// via JSON file for durability across restarts.
+pub struct KfCursorStore {
+    cursors: RwLock<HashMap<String, String>>,
+    persist_path: Option<PathBuf>,
+}
+
+impl KfCursorStore {
+    /// Create a new cursor store.
+    ///
+    /// If `persist_path` is `Some`, the store will load existing cursors
+    /// from the file (if it exists).
+    pub fn new(persist_path: Option<PathBuf>) -> Self {
+        let store = Self {
+            cursors: RwLock::new(HashMap::new()),
+            persist_path,
+        };
+
+        // Load existing cursors from disk (sync, called during construction)
+        if let Err(e) = store.load_from_disk() {
+            tracing::warn!(
+                path = ?store.persist_path,
+                error = %e,
+                "KfCursorStore: failed to load cursors from disk"
+            );
+        }
+
+        store
+    }
+
+    /// Get the cursor for a given `open_kfid`.
+    pub fn get_cursor(&self, open_kfid: &str) -> Option<String> {
+        self.cursors
+            .read()
+            .ok()
+            .and_then(|guard| guard.get(open_kfid).cloned())
+    }
+
+    /// Set the cursor for a given `open_kfid` and optionally persist to disk.
+    pub fn set_cursor(&self, open_kfid: &str, cursor: &str) {
+        if let Ok(mut guard) = self.cursors.write() {
+            guard.insert(open_kfid.to_string(), cursor.to_string());
+        }
+        if let Err(e) = self.save_to_disk() {
+            tracing::warn!(
+                path = ?self.persist_path,
+                error = %e,
+                "KfCursorStore: failed to persist cursors"
+            );
+        }
+    }
+
+    /// Load cursors from the JSON file.
+    fn load_from_disk(&self) -> Result<()> {
+        let path = match &self.persist_path {
+            Some(p) => p,
+            None => return Ok(()),
+        };
+
+        if !path.exists() {
+            return Ok(());
+        }
+
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("failed to read cursor file: {}", e))?;
+
+        let data: HashMap<String, String> = serde_json::from_str(&content)
+            .map_err(|e| anyhow::anyhow!("failed to parse cursor file: {}", e))?;
+
+        if let Ok(mut guard) = self.cursors.write() {
+            guard.extend(data);
+        }
+
+        tracing::debug!(
+            path = %path.display(),
+            "KfCursorStore: loaded cursors from disk"
+        );
+
+        Ok(())
+    }
+
+    /// Save cursors to disk as JSON.
+    fn save_to_disk(&self) -> Result<()> {
+        let path = match &self.persist_path {
+            Some(p) => p.clone(),
+            None => return Ok(()),
+        };
+
+        let data = {
+            let guard = self
+                .cursors
+                .read()
+                .map_err(|e| anyhow::anyhow!("cursor lock poisoned: {}", e))?;
+            serde_json::to_string_pretty(&*guard)
+                .map_err(|e| anyhow::anyhow!("failed to serialize cursors: {}", e))?
+        };
+
+        // Ensure parent directory exists
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| anyhow::anyhow!("failed to create cursor directory: {}", e))?;
+        }
+
+        std::fs::write(&path, &data)
+            .map_err(|e| anyhow::anyhow!("failed to write cursor file: {}", e))?;
+
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn cursors_count(&self) -> usize {
+        self.cursors.read().map(|g| g.len()).unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_cursor_get_set() {
+        let store = KfCursorStore::new(None);
+        assert!(store.get_cursor("kf001").is_none());
+
+        store.set_cursor("kf001", "cursor_abc");
+        assert_eq!(
+            store.get_cursor("kf001"),
+            Some("cursor_abc".to_string())
+        );
+    }
+
+    #[test]
+    fn test_cursor_multiple_kf_accounts() {
+        let store = KfCursorStore::new(None);
+
+        store.set_cursor("kf001", "cursor_001");
+        store.set_cursor("kf002", "cursor_002");
+
+        assert_eq!(
+            store.get_cursor("kf001"),
+            Some("cursor_001".to_string())
+        );
+        assert_eq!(
+            store.get_cursor("kf002"),
+            Some("cursor_002".to_string())
+        );
+    }
+
+    #[test]
+    fn test_cursor_overwrite() {
+        let store = KfCursorStore::new(None);
+
+        store.set_cursor("kf001", "cursor_old");
+        assert_eq!(
+            store.get_cursor("kf001"),
+            Some("cursor_old".to_string())
+        );
+
+        store.set_cursor("kf001", "cursor_new");
+        assert_eq!(
+            store.get_cursor("kf001"),
+            Some("cursor_new".to_string())
+        );
+    }
+
+    #[test]
+    fn test_persist_and_load() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("kf_cursors.json");
+
+        // Create store with persist path and set a cursor
+        {
+            let store = KfCursorStore::new(Some(path.clone()));
+            store.set_cursor("kf001", "cursor_abc");
+            assert_eq!(store.cursors_count(), 1);
+        }
+
+        // Create a new store with the same path — should load from disk
+        {
+            let store = KfCursorStore::new(Some(path.clone()));
+            assert_eq!(store.cursors_count(), 1);
+            assert_eq!(
+                store.get_cursor("kf001"),
+                Some("cursor_abc".to_string())
+            );
+        }
+    }
+
+    #[test]
+    fn test_persist_empty_store() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("kf_cursors.json");
+
+        // Create store with persist path but no cursors set
+        {
+            let store = KfCursorStore::new(Some(path.clone()));
+            assert_eq!(store.cursors_count(), 0);
+        }
+
+        // Create a new store with the same path — should load empty state
+        {
+            let store = KfCursorStore::new(Some(path.clone()));
+            assert_eq!(store.cursors_count(), 0);
+        }
+    }
+
+    #[test]
+    fn test_persist_path_none() {
+        let store = KfCursorStore::new(None);
+        store.set_cursor("kf001", "cursor_abc");
+        assert_eq!(
+            store.get_cursor("kf001"),
+            Some("cursor_abc".to_string())
+        );
+    }
+
+    #[test]
+    fn test_cursor_for_different_open_kfid() {
+        let store = KfCursorStore::new(None);
+        store.set_cursor("kf001", "cursor_001");
+
+        // Non-existent key should return None
+        assert!(store.get_cursor("kf999").is_none());
+    }
+}

--- a/crates/jyc-channels/src/wecom/kf_cursor.rs
+++ b/crates/jyc-channels/src/wecom/kf_cursor.rs
@@ -12,14 +12,20 @@ use std::path::PathBuf;
 use std::sync::RwLock;
 
 use anyhow::Result;
+use tokio::sync::Mutex as TokioMutex;
 
 /// Thread-safe cursor store for KF sync cursors.
 ///
 /// Maps `open_kfid` → cursor string. Supports optional file persistence
-/// via JSON file for durability across restarts.
+/// via JSON file for durability across restarts. File writes use `tokio::fs`
+/// for non-blocking I/O. A dirty flag coalesces multiple writes into a
+/// single disk flush to avoid excessive I/O under rapid sync activity.
 pub struct KfCursorStore {
     cursors: RwLock<HashMap<String, String>>,
     persist_path: Option<PathBuf>,
+    /// Dirty flag and flush lock: only one flush at a time.
+    dirty: std::sync::Mutex<bool>,
+    flush_lock: TokioMutex<()>,
 }
 
 impl KfCursorStore {
@@ -31,6 +37,8 @@ impl KfCursorStore {
         let store = Self {
             cursors: RwLock::new(HashMap::new()),
             persist_path,
+            dirty: std::sync::Mutex::new(false),
+            flush_lock: TokioMutex::new(()),
         };
 
         // Load existing cursors from disk (sync, called during construction)
@@ -53,21 +61,83 @@ impl KfCursorStore {
             .and_then(|guard| guard.get(open_kfid).cloned())
     }
 
-    /// Set the cursor for a given `open_kfid` and optionally persist to disk.
+    /// Set the cursor for a given `open_kfid` and mark the store as dirty.
+    ///
+    /// The actual disk write is deferred to the next `flush_to_disk()` call.
+    /// Multiple `set_cursor` calls between flushes are coalesced into one write.
     pub fn set_cursor(&self, open_kfid: &str, cursor: &str) {
         if let Ok(mut guard) = self.cursors.write() {
             guard.insert(open_kfid.to_string(), cursor.to_string());
         }
-        if let Err(e) = self.save_to_disk() {
-            tracing::warn!(
-                path = ?self.persist_path,
-                error = %e,
-                "KfCursorStore: failed to persist cursors"
-            );
+        // Mark dirty — disk write happens on flush
+        if let Ok(mut d) = self.dirty.lock() {
+            *d = true;
         }
     }
 
-    /// Load cursors from the JSON file.
+    /// Flush cursors to disk if dirty.
+    ///
+    /// Uses `tokio::fs` for non-blocking I/O. Only one flush executes at a
+    /// time (serialized by `flush_lock`). Call this periodically or on shutdown.
+    pub async fn flush_to_disk(&self) -> Result<()> {
+        let path = match &self.persist_path {
+            Some(p) => p.clone(),
+            None => return Ok(()),
+        };
+
+        // Check dirty flag without holding the lock
+        {
+            let d = self.dirty.lock().unwrap();
+            if !*d {
+                return Ok(());
+            }
+        }
+
+        // Serialize flushes — only one write at a time
+        let _guard = self.flush_lock.lock().await;
+
+        // Re-check dirty flag (another thread may have flushed)
+        {
+            let d = self.dirty.lock().unwrap();
+            if !*d {
+                return Ok(());
+            }
+        }
+
+        let data = {
+            let guard = self
+                .cursors
+                .read()
+                .map_err(|e| anyhow::anyhow!("cursor lock poisoned: {}", e))?;
+            serde_json::to_string_pretty(&*guard)
+                .map_err(|e| anyhow::anyhow!("failed to serialize cursors: {}", e))?
+        };
+
+        // Ensure parent directory exists
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to create cursor directory: {}", e))?;
+        }
+
+        // Write atomically: write to temp file then rename
+        let tmp_path = path.with_extension("json.tmp");
+        tokio::fs::write(&tmp_path, &data)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to write cursor temp file: {}", e))?;
+        tokio::fs::rename(&tmp_path, &path)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to rename cursor file: {}", e))?;
+
+        // Clear dirty flag
+        if let Ok(mut d) = self.dirty.lock() {
+            *d = false;
+        }
+
+        Ok(())
+    }
+
+    /// Load cursors from the JSON file (sync, called during construction).
     fn load_from_disk(&self) -> Result<()> {
         let path = match &self.persist_path {
             Some(p) => p,
@@ -87,39 +157,6 @@ impl KfCursorStore {
         if let Ok(mut guard) = self.cursors.write() {
             guard.extend(data);
         }
-
-        tracing::debug!(
-            path = %path.display(),
-            "KfCursorStore: loaded cursors from disk"
-        );
-
-        Ok(())
-    }
-
-    /// Save cursors to disk as JSON.
-    fn save_to_disk(&self) -> Result<()> {
-        let path = match &self.persist_path {
-            Some(p) => p.clone(),
-            None => return Ok(()),
-        };
-
-        let data = {
-            let guard = self
-                .cursors
-                .read()
-                .map_err(|e| anyhow::anyhow!("cursor lock poisoned: {}", e))?;
-            serde_json::to_string_pretty(&*guard)
-                .map_err(|e| anyhow::anyhow!("failed to serialize cursors: {}", e))?
-        };
-
-        // Ensure parent directory exists
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| anyhow::anyhow!("failed to create cursor directory: {}", e))?;
-        }
-
-        std::fs::write(&path, &data)
-            .map_err(|e| anyhow::anyhow!("failed to write cursor file: {}", e))?;
 
         Ok(())
     }
@@ -166,8 +203,8 @@ mod tests {
         assert_eq!(store.get_cursor("kf001"), Some("cursor_new".to_string()));
     }
 
-    #[test]
-    fn test_persist_and_load() {
+    #[tokio::test]
+    async fn test_persist_and_load() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("kf_cursors.json");
 
@@ -176,6 +213,8 @@ mod tests {
             let store = KfCursorStore::new(Some(path.clone()));
             store.set_cursor("kf001", "cursor_abc");
             assert_eq!(store.cursors_count(), 1);
+            // Flush to disk
+            store.flush_to_disk().await.unwrap();
         }
 
         // Create a new store with the same path — should load from disk
@@ -186,8 +225,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_persist_empty_store() {
+    #[tokio::test]
+    async fn test_persist_empty_store() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("kf_cursors.json");
 
@@ -195,6 +234,7 @@ mod tests {
         {
             let store = KfCursorStore::new(Some(path.clone()));
             assert_eq!(store.cursors_count(), 0);
+            store.flush_to_disk().await.unwrap();
         }
 
         // Create a new store with the same path — should load empty state
@@ -215,8 +255,21 @@ mod tests {
     fn test_cursor_for_different_open_kfid() {
         let store = KfCursorStore::new(None);
         store.set_cursor("kf001", "cursor_001");
-
-        // Non-existent key should return None
         assert!(store.get_cursor("kf999").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_flush_to_disk_noop_without_persist_path() {
+        let store = KfCursorStore::new(None);
+        store.set_cursor("kf001", "cursor_abc");
+        assert!(store.flush_to_disk().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_flush_to_disk_not_dirty() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("kf_cursors.json");
+        let store = KfCursorStore::new(Some(path.clone()));
+        assert!(store.flush_to_disk().await.is_ok());
     }
 }

--- a/crates/jyc-channels/src/wecom/kf_cursor.rs
+++ b/crates/jyc-channels/src/wecom/kf_cursor.rs
@@ -141,10 +141,7 @@ mod tests {
         assert!(store.get_cursor("kf001").is_none());
 
         store.set_cursor("kf001", "cursor_abc");
-        assert_eq!(
-            store.get_cursor("kf001"),
-            Some("cursor_abc".to_string())
-        );
+        assert_eq!(store.get_cursor("kf001"), Some("cursor_abc".to_string()));
     }
 
     #[test]
@@ -154,14 +151,8 @@ mod tests {
         store.set_cursor("kf001", "cursor_001");
         store.set_cursor("kf002", "cursor_002");
 
-        assert_eq!(
-            store.get_cursor("kf001"),
-            Some("cursor_001".to_string())
-        );
-        assert_eq!(
-            store.get_cursor("kf002"),
-            Some("cursor_002".to_string())
-        );
+        assert_eq!(store.get_cursor("kf001"), Some("cursor_001".to_string()));
+        assert_eq!(store.get_cursor("kf002"), Some("cursor_002".to_string()));
     }
 
     #[test]
@@ -169,16 +160,10 @@ mod tests {
         let store = KfCursorStore::new(None);
 
         store.set_cursor("kf001", "cursor_old");
-        assert_eq!(
-            store.get_cursor("kf001"),
-            Some("cursor_old".to_string())
-        );
+        assert_eq!(store.get_cursor("kf001"), Some("cursor_old".to_string()));
 
         store.set_cursor("kf001", "cursor_new");
-        assert_eq!(
-            store.get_cursor("kf001"),
-            Some("cursor_new".to_string())
-        );
+        assert_eq!(store.get_cursor("kf001"), Some("cursor_new".to_string()));
     }
 
     #[test]
@@ -197,10 +182,7 @@ mod tests {
         {
             let store = KfCursorStore::new(Some(path.clone()));
             assert_eq!(store.cursors_count(), 1);
-            assert_eq!(
-                store.get_cursor("kf001"),
-                Some("cursor_abc".to_string())
-            );
+            assert_eq!(store.get_cursor("kf001"), Some("cursor_abc".to_string()));
         }
     }
 
@@ -226,10 +208,7 @@ mod tests {
     fn test_persist_path_none() {
         let store = KfCursorStore::new(None);
         store.set_cursor("kf001", "cursor_abc");
-        assert_eq!(
-            store.get_cursor("kf001"),
-            Some("cursor_abc".to_string())
-        );
+        assert_eq!(store.get_cursor("kf001"), Some("cursor_abc".to_string()));
     }
 
     #[test]

--- a/crates/jyc-channels/src/wecom/kf_dedup.rs
+++ b/crates/jyc-channels/src/wecom/kf_dedup.rs
@@ -1,0 +1,170 @@
+//! Deduplication store for WeCom KF (Customer Service) messages.
+//!
+//! The KF `sync_msg` API may return overlapping messages across syncs.
+//! Dedup by `msgid` prevents duplicate processing of the same message.
+//!
+//! Uses an in-memory `HashSet` with a maximum of 10,000 entries.
+//! Older entries are evicted when the limit is exceeded (FIFO).
+
+use std::collections::{HashSet, VecDeque};
+use std::sync::Mutex;
+
+/// Maximum number of seen message IDs to keep in memory.
+const MAX_ENTRIES: usize = 10_000;
+
+/// In-memory deduplication store for KF message IDs.
+///
+/// Tracks seen `msgid` values in a `HashSet` with a FIFO eviction policy
+/// when the number of entries exceeds `MAX_ENTRIES`.
+///
+/// Memory-only: persistent dedup is not needed since the cursor store
+/// prevents most re-syncs. The dedup store catches any overlap within
+/// a single batch or across edge cases.
+pub struct KfDedupStore {
+    seen: Mutex<HashSet<String>>,
+    order: Mutex<VecDeque<String>>,
+}
+
+impl KfDedupStore {
+    /// Create a new empty dedup store.
+    pub fn new() -> Self {
+        Self {
+            seen: Mutex::new(HashSet::new()),
+            order: Mutex::new(VecDeque::new()),
+        }
+    }
+
+    /// Check if a message ID has been seen before.
+    ///
+    /// Returns `true` if the message ID is a duplicate (already seen).
+    pub fn is_duplicate(&self, msgid: &str) -> bool {
+        self.seen
+            .lock()
+            .map(|guard| guard.contains(msgid))
+            .unwrap_or(false)
+    }
+
+    /// Mark a message ID as seen.
+    ///
+    /// If the store has reached `MAX_ENTRIES`, the oldest entry is evicted.
+    pub fn mark_seen(&self, msgid: &str) {
+        if let Ok(mut guard) = self.seen.lock() {
+            if guard.len() >= MAX_ENTRIES {
+                // Evict oldest entry
+                if let Ok(mut order_guard) = self.order.lock() {
+                    if let Some(oldest) = order_guard.pop_front() {
+                        guard.remove(&oldest);
+                    }
+                }
+            }
+
+            if guard.insert(msgid.to_string()) {
+                // Newly inserted — track order for eviction
+                if let Ok(mut order_guard) = self.order.lock() {
+                    order_guard.push_back(msgid.to_string());
+                }
+            }
+        }
+    }
+
+    /// Get the current number of entries (for testing).
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.seen.lock().map(|g| g.len()).unwrap_or(0)
+    }
+}
+
+impl Default for KfDedupStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_store_empty() {
+        let store = KfDedupStore::new();
+        assert!(!store.is_duplicate("msg_001"));
+        assert_eq!(store.len(), 0);
+    }
+
+    #[test]
+    fn test_mark_and_check_duplicate() {
+        let store = KfDedupStore::new();
+        assert!(!store.is_duplicate("msg_001"));
+
+        store.mark_seen("msg_001");
+        assert!(store.is_duplicate("msg_001"));
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn test_multiple_messages() {
+        let store = KfDedupStore::new();
+        store.mark_seen("msg_001");
+        store.mark_seen("msg_002");
+        store.mark_seen("msg_003");
+
+        assert!(store.is_duplicate("msg_001"));
+        assert!(store.is_duplicate("msg_002"));
+        assert!(store.is_duplicate("msg_003"));
+        assert!(!store.is_duplicate("msg_004"));
+        assert!(store.len() == 3);
+    }
+
+    #[test]
+    fn test_duplicate_mark_is_idempotent() {
+        let store = KfDedupStore::new();
+        store.mark_seen("msg_001");
+        store.mark_seen("msg_001"); // mark again
+        assert_eq!(store.len(), 1); // still 1
+    }
+
+    #[test]
+    fn test_eviction_when_max_entries_exceeded() {
+        let store = KfDedupStore::new();
+
+        // Add MAX_ENTRIES + 1 items
+        for i in 0..=MAX_ENTRIES {
+            store.mark_seen(&format!("msg_{:05}", i));
+        }
+
+        // The first item should be evicted
+        assert!(!store.is_duplicate("msg_00000"));
+        // But later items should still be present
+        assert!(store.is_duplicate("msg_00001"));
+        assert!(store.is_duplicate(&format!("msg_{:05}", MAX_ENTRIES)));
+
+        // Size should be capped at MAX_ENTRIES
+        assert_eq!(store.len(), MAX_ENTRIES);
+    }
+
+    #[test]
+    fn test_eviction_keeps_most_recent() {
+        let store = KfDedupStore::new();
+
+        // Fill up to MAX_ENTRIES
+        for i in 0..MAX_ENTRIES {
+            store.mark_seen(&format!("msg_{:05}", i));
+        }
+        assert_eq!(store.len(), MAX_ENTRIES);
+
+        // Add one more — evicts the first one
+        store.mark_seen("msg_final");
+        assert_eq!(store.len(), MAX_ENTRIES);
+        assert!(!store.is_duplicate("msg_00000"));
+        assert!(store.is_duplicate("msg_final"));
+    }
+
+    #[test]
+    fn test_new_instance_does_not_share_state() {
+        let store1 = KfDedupStore::new();
+        store1.mark_seen("msg_001");
+
+        let store2 = KfDedupStore::new();
+        assert!(!store2.is_duplicate("msg_001")); // separate instance
+    }
+}

--- a/crates/jyc-channels/src/wecom/kf_dedup.rs
+++ b/crates/jyc-channels/src/wecom/kf_dedup.rs
@@ -51,10 +51,10 @@ impl KfDedupStore {
         if let Ok(mut guard) = self.seen.lock() {
             if guard.len() >= MAX_ENTRIES {
                 // Evict oldest entry
-                if let Ok(mut order_guard) = self.order.lock() {
-                    if let Some(oldest) = order_guard.pop_front() {
-                        guard.remove(&oldest);
-                    }
+                if let Ok(mut order_guard) = self.order.lock()
+                    && let Some(oldest) = order_guard.pop_front()
+                {
+                    guard.remove(&oldest);
                 }
             }
 

--- a/crates/jyc-channels/src/wecom/kf_dedup.rs
+++ b/crates/jyc-channels/src/wecom/kf_dedup.rs
@@ -12,25 +12,26 @@ use std::sync::Mutex;
 /// Maximum number of seen message IDs to keep in memory.
 const MAX_ENTRIES: usize = 10_000;
 
+type DedupState = (HashSet<String>, VecDeque<String>);
+
 /// In-memory deduplication store for KF message IDs.
 ///
 /// Tracks seen `msgid` values in a `HashSet` with a FIFO eviction policy
-/// when the number of entries exceeds `MAX_ENTRIES`.
+/// when the number of entries exceeds `MAX_ENTRIES`. Both the set and the
+/// insertion-order queue are held under a single `Mutex` for atomicity.
 ///
 /// Memory-only: persistent dedup is not needed since the cursor store
 /// prevents most re-syncs. The dedup store catches any overlap within
 /// a single batch or across edge cases.
 pub struct KfDedupStore {
-    seen: Mutex<HashSet<String>>,
-    order: Mutex<VecDeque<String>>,
+    state: Mutex<DedupState>,
 }
 
 impl KfDedupStore {
     /// Create a new empty dedup store.
     pub fn new() -> Self {
         Self {
-            seen: Mutex::new(HashSet::new()),
-            order: Mutex::new(VecDeque::new()),
+            state: Mutex::new((HashSet::new(), VecDeque::new())),
         }
     }
 
@@ -38,9 +39,9 @@ impl KfDedupStore {
     ///
     /// Returns `true` if the message ID is a duplicate (already seen).
     pub fn is_duplicate(&self, msgid: &str) -> bool {
-        self.seen
+        self.state
             .lock()
-            .map(|guard| guard.contains(msgid))
+            .map(|guard| guard.0.contains(msgid))
             .unwrap_or(false)
     }
 
@@ -48,21 +49,17 @@ impl KfDedupStore {
     ///
     /// If the store has reached `MAX_ENTRIES`, the oldest entry is evicted.
     pub fn mark_seen(&self, msgid: &str) {
-        if let Ok(mut guard) = self.seen.lock() {
-            if guard.len() >= MAX_ENTRIES {
-                // Evict oldest entry
-                if let Ok(mut order_guard) = self.order.lock()
-                    && let Some(oldest) = order_guard.pop_front()
-                {
-                    guard.remove(&oldest);
-                }
+        if let Ok(mut guard) = self.state.lock() {
+            let (ref mut seen, ref mut order) = *guard;
+
+            if seen.len() >= MAX_ENTRIES
+                && let Some(oldest) = order.pop_front()
+            {
+                seen.remove(&oldest);
             }
 
-            if guard.insert(msgid.to_string()) {
-                // Newly inserted — track order for eviction
-                if let Ok(mut order_guard) = self.order.lock() {
-                    order_guard.push_back(msgid.to_string());
-                }
+            if seen.insert(msgid.to_string()) {
+                order.push_back(msgid.to_string());
             }
         }
     }
@@ -70,7 +67,7 @@ impl KfDedupStore {
     /// Get the current number of entries (for testing).
     #[cfg(test)]
     fn len(&self) -> usize {
-        self.seen.lock().map(|g| g.len()).unwrap_or(0)
+        self.state.lock().map(|g| g.0.len()).unwrap_or(0)
     }
 }
 

--- a/crates/jyc-channels/src/wecom/kf_inbound.rs
+++ b/crates/jyc-channels/src/wecom/kf_inbound.rs
@@ -336,6 +336,63 @@ impl InboundAdapter for WecomKfInboundAdapter {
     }
 }
 
+/// WeCom KF channel matcher — stateless pattern matching.
+///
+/// Delegates to `wecom_match_message` for the actual matching logic.
+/// The `channel_type` returns `"wecomkf"` so patterns can be configured
+/// with `channel = "wecomkf"` for KF-specific rules.
+pub struct WecomKfMatcher;
+
+impl ChannelMatcher for WecomKfMatcher {
+    fn channel_type(&self) -> &str {
+        "wecomkf"
+    }
+
+    fn derive_thread_name(
+        &self,
+        message: &InboundMessage,
+        _patterns: &[ChannelPattern],
+        _pattern_match: Option<&PatternMatch>,
+    ) -> String {
+        // Thread name: {channel_name}_{sanitized_open_kfid}_{sanitized_external_userid}
+        let channel_name = message
+            .metadata
+            .get("channel_name")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .unwrap_or("wecomkf");
+
+        let open_kfid = message
+            .metadata
+            .get("open_kfid")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .unwrap_or("unknown_kf");
+
+        let external_userid = message
+            .metadata
+            .get("external_userid")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .unwrap_or("unknown_user");
+
+        format!(
+            "{}_{}_{}",
+            sanitize_for_filesystem(channel_name),
+            sanitize_for_filesystem(open_kfid),
+            sanitize_for_filesystem(external_userid),
+        )
+    }
+
+    fn match_message(
+        &self,
+        message: &InboundMessage,
+        patterns: &[ChannelPattern],
+    ) -> Option<PatternMatch> {
+        wecom_match_message(message, patterns)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/jyc-channels/src/wecom/kf_inbound.rs
+++ b/crates/jyc-channels/src/wecom/kf_inbound.rs
@@ -68,11 +68,6 @@ impl WecomKfInboundAdapter {
     }
 }
 
-/// Sanitize a WeCom user ID for use in thread names.
-fn sanitize_user_id(user_id: &str) -> String {
-    sanitize_for_filesystem(user_id)
-}
-
 /// Convert a synced KF message into an `InboundMessage`.
 fn kf_message_to_inbound(msg: &KfMessage, channel_name: &str, token: &str) -> InboundMessage {
     let mut metadata = HashMap::new();
@@ -218,6 +213,40 @@ fn handle_kf_event(
     Ok(())
 }
 
+/// Shared helper to derive a KF thread name from message metadata.
+///
+/// Format: `{channel_name}_{sanitized_open_kfid}_{sanitized_external_userid}`
+/// One thread per customer per KF account.
+fn wecomkf_derive_thread_name(message: &InboundMessage, default_channel: &str) -> String {
+    let channel_name = message
+        .metadata
+        .get("channel_name")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or(default_channel);
+
+    let open_kfid = message
+        .metadata
+        .get("open_kfid")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("unknown_kf");
+
+    let external_userid = message
+        .metadata
+        .get("external_userid")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("unknown_user");
+
+    format!(
+        "{}_{}_{}",
+        sanitize_for_filesystem(channel_name),
+        sanitize_for_filesystem(open_kfid),
+        sanitize_for_filesystem(external_userid),
+    )
+}
+
 impl ChannelMatcher for WecomKfInboundAdapter {
     fn channel_type(&self) -> &str {
         "wecomkf"
@@ -229,35 +258,7 @@ impl ChannelMatcher for WecomKfInboundAdapter {
         _patterns: &[ChannelPattern],
         _pattern_match: Option<&PatternMatch>,
     ) -> String {
-        // Thread name: {channel_name}_{sanitized_open_kfid}_{sanitized_external_userid}
-        // One thread per customer per KF account.
-        let channel_name = message
-            .metadata
-            .get("channel_name")
-            .and_then(|v| v.as_str())
-            .filter(|s| !s.is_empty())
-            .unwrap_or(&self.channel_name);
-
-        let open_kfid = message
-            .metadata
-            .get("open_kfid")
-            .and_then(|v| v.as_str())
-            .filter(|s| !s.is_empty())
-            .unwrap_or("unknown_kf");
-
-        let external_userid = message
-            .metadata
-            .get("external_userid")
-            .and_then(|v| v.as_str())
-            .filter(|s| !s.is_empty())
-            .unwrap_or("unknown_user");
-
-        format!(
-            "{}_{}_{}",
-            sanitize_for_filesystem(channel_name),
-            sanitize_user_id(open_kfid),
-            sanitize_user_id(external_userid),
-        )
+        wecomkf_derive_thread_name(message, &self.channel_name)
     }
 
     fn match_message(
@@ -274,7 +275,7 @@ impl InboundAdapter for WecomKfInboundAdapter {
     async fn start(
         &self,
         options: InboundAdapterOptions,
-        _cancel: CancellationToken,
+        cancel: CancellationToken,
     ) -> Result<()> {
         let channel_name = self.channel_name.clone();
 
@@ -324,14 +325,9 @@ impl InboundAdapter for WecomKfInboundAdapter {
 
         // KF inbound does not need to run a separate task — the webhook
         // server handles incoming requests. We wait on cancellation.
-        // However, since InboundAdapter::start() requires returning only
-        // when the adapter stops, we wait here.
         // The actual message processing happens in the webhook callbacks.
+        cancel.cancelled().await;
 
-        // Wait indefinitely (cancellation handled by the caller)
-        futures_util::future::pending::<()>().await;
-
-        #[allow(unreachable_code)]
         Ok(())
     }
 }
@@ -354,34 +350,7 @@ impl ChannelMatcher for WecomKfMatcher {
         _patterns: &[ChannelPattern],
         _pattern_match: Option<&PatternMatch>,
     ) -> String {
-        // Thread name: {channel_name}_{sanitized_open_kfid}_{sanitized_external_userid}
-        let channel_name = message
-            .metadata
-            .get("channel_name")
-            .and_then(|v| v.as_str())
-            .filter(|s| !s.is_empty())
-            .unwrap_or("wecomkf");
-
-        let open_kfid = message
-            .metadata
-            .get("open_kfid")
-            .and_then(|v| v.as_str())
-            .filter(|s| !s.is_empty())
-            .unwrap_or("unknown_kf");
-
-        let external_userid = message
-            .metadata
-            .get("external_userid")
-            .and_then(|v| v.as_str())
-            .filter(|s| !s.is_empty())
-            .unwrap_or("unknown_user");
-
-        format!(
-            "{}_{}_{}",
-            sanitize_for_filesystem(channel_name),
-            sanitize_for_filesystem(open_kfid),
-            sanitize_for_filesystem(external_userid),
-        )
+        wecomkf_derive_thread_name(message, "wecomkf")
     }
 
     fn match_message(

--- a/crates/jyc-channels/src/wecom/kf_inbound.rs
+++ b/crates/jyc-channels/src/wecom/kf_inbound.rs
@@ -1,0 +1,557 @@
+//! WeCom KF (Customer Service) inbound adapter implementation.
+//!
+//! Unlike the regular WeCom inbound adapter (which receives direct XML push
+//! messages via webhook), the KF adapter:
+//!
+//! 1. Receives `kf_msg_or_event` event notifications via the shared webhook server
+//! 2. On notification, pulls actual message content via `kf/sync_msg` API
+//! 3. Deduplicates messages by `msgid`
+//! 4. Routes messages through the standard pattern matching
+//!
+//! Thread name follows the pattern `{channel_name}_{sanitized_open_kfid}_{sanitized_external_userid}`.
+//!
+//! Reference: https://developer.work.weixin.qq.com/document/path/94677
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
+
+use jyc_types::{
+    ChannelMatcher, ChannelPattern, InboundAdapter, InboundAdapterOptions, InboundMessage,
+    MessageContent, PatternMatch,
+};
+use jyc_utils::helpers::sanitize_for_filesystem;
+
+use crate::wecom::inbound::wecom_match_message;
+use crate::wecom::kf_client::{KfApiClient, KfMessage};
+use crate::wecom::kf_cursor::KfCursorStore;
+use crate::wecom::kf_dedup::KfDedupStore;
+use crate::wecom::server::{ChannelWebhookConfig, ParsedWecomMessage, WecomWebhookServer};
+use jyc_types::WecomKfConfig;
+
+/// WeCom KF inbound adapter.
+///
+/// Registers a webhook handler with the shared `WecomWebhookServer` and
+/// translates incoming KF event notifications into `InboundMessage`s
+/// by pulling messages from the KF `sync_msg` API.
+pub struct WecomKfInboundAdapter {
+    channel_name: String,
+    config: WecomKfConfig,
+    server: Arc<WecomWebhookServer>,
+    kf_client: Arc<KfApiClient>,
+    cursor_store: Arc<KfCursorStore>,
+    dedup_store: Arc<KfDedupStore>,
+}
+
+impl WecomKfInboundAdapter {
+    /// Create a new KF inbound adapter.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        config: &WecomKfConfig,
+        channel_name: &str,
+        server: Arc<WecomWebhookServer>,
+        kf_client: Arc<KfApiClient>,
+        cursor_store: Arc<KfCursorStore>,
+        dedup_store: Arc<KfDedupStore>,
+    ) -> Self {
+        Self {
+            channel_name: channel_name.to_string(),
+            config: config.clone(),
+            server,
+            kf_client,
+            cursor_store,
+            dedup_store,
+        }
+    }
+}
+
+/// Sanitize a WeCom user ID for use in thread names.
+fn sanitize_user_id(user_id: &str) -> String {
+    sanitize_for_filesystem(user_id)
+}
+
+/// Convert a synced KF message into an `InboundMessage`.
+fn kf_message_to_inbound(
+    msg: &KfMessage,
+    channel_name: &str,
+    token: &str,
+) -> InboundMessage {
+    let mut metadata = HashMap::new();
+    metadata.insert(
+        "open_kfid".to_string(),
+        serde_json::Value::String(msg.open_kfid.clone()),
+    );
+    metadata.insert(
+        "external_userid".to_string(),
+        serde_json::Value::String(msg.external_userid.clone()),
+    );
+    metadata.insert(
+        "msgid".to_string(),
+        serde_json::Value::String(msg.msgid.clone()),
+    );
+    metadata.insert(
+        "token".to_string(),
+        serde_json::Value::String(token.to_string()),
+    );
+    metadata.insert(
+        "channel_name".to_string(),
+        serde_json::Value::String(channel_name.to_string()),
+    );
+    metadata.insert(
+        "msg_type".to_string(),
+        serde_json::Value::String(msg.msgtype.clone()),
+    );
+
+    let text_content = msg
+        .text
+        .as_ref()
+        .map(|t| t.content.clone())
+        .unwrap_or_default();
+
+    InboundMessage {
+        id: uuid::Uuid::new_v4().to_string(),
+        channel: "wecomkf".to_string(),
+        channel_uid: format!(
+            "wecomkf_{}",
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+        ),
+        sender: msg.external_userid.clone(),
+        sender_address: format!("wecomkf:{}", msg.external_userid),
+        recipients: vec![],
+        topic: "WeCom KF Message".to_string(),
+        content: MessageContent {
+            text: if text_content.is_empty() {
+                None
+            } else {
+                Some(text_content)
+            },
+            html: None,
+            markdown: None,
+        },
+        timestamp: chrono::Utc::now(),
+        thread_refs: None,
+        reply_to_id: None,
+        external_id: Some(msg.msgid.clone()),
+        attachments: vec![],
+        metadata,
+        matched_pattern: None,
+    }
+}
+
+/// Handle a KF event notification from the webhook.
+///
+/// This is called when the shared webhook server receives a `kf_msg_or_event`
+/// event. It pulls messages from the KF API, deduplicates them, and routes them.
+fn handle_kf_event(
+    parsed: ParsedWecomMessage,
+    kf_client: Arc<KfApiClient>,
+    cursor_store: Arc<KfCursorStore>,
+    dedup_store: Arc<KfDedupStore>,
+    channel_name: String,
+    on_message: Arc<dyn Fn(InboundMessage) -> Result<()> + Send + Sync>,
+) -> Result<()> {
+    let token = parsed.token.clone();
+    let open_kfid = parsed.open_kfid.clone();
+
+    // Get the current cursor for this open_kfid
+    let cursor = cursor_store.get_cursor(&open_kfid).unwrap_or_default();
+    let limit = 100;
+
+    // Spawn an async task for the actual API call
+    tokio::spawn(async move {
+        // Sync messages from the KF API
+        let mut current_cursor = cursor;
+        loop {
+            match kf_client
+                .sync_messages(&token, &current_cursor, &open_kfid, limit)
+                .await
+            {
+                Ok(response) => {
+                    for msg in &response.msg_list {
+                        // Dedup check
+                        if dedup_store.is_duplicate(&msg.msgid) {
+                            tracing::debug!(
+                                msgid = %msg.msgid,
+                                "KfDedupStore: skipping duplicate message"
+                            );
+                            continue;
+                        }
+
+                        dedup_store.mark_seen(&msg.msgid);
+
+                        // Convert to InboundMessage
+                        let inbound = kf_message_to_inbound(msg, &channel_name, &token);
+
+                        // Call the on_message callback
+                        if let Err(e) = (on_message)(inbound) {
+                            tracing::error!(
+                                error = %e,
+                                msgid = %msg.msgid,
+                                "WeCom KF inbound: on_message callback error"
+                            );
+                        }
+                    }
+
+                    // Save cursor for next sync
+                    if !response.next_cursor.is_empty() {
+                        current_cursor = response.next_cursor.clone();
+                        cursor_store.set_cursor(&open_kfid, &response.next_cursor);
+                    }
+
+                    // Check if there are more messages to sync
+                    let has_more = response.has_more.unwrap_or(0) != 0;
+                    if !has_more || response.next_cursor.is_empty() {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    tracing::error!(
+                        error = %e,
+                        open_kfid = %open_kfid,
+                        "WeCom KF inbound: sync_messages error"
+                    );
+                    break;
+                }
+            }
+        }
+    });
+
+    Ok(())
+}
+
+impl ChannelMatcher for WecomKfInboundAdapter {
+    fn channel_type(&self) -> &str {
+        "wecomkf"
+    }
+
+    fn derive_thread_name(
+        &self,
+        message: &InboundMessage,
+        _patterns: &[ChannelPattern],
+        _pattern_match: Option<&PatternMatch>,
+    ) -> String {
+        // Thread name: {channel_name}_{sanitized_open_kfid}_{sanitized_external_userid}
+        // One thread per customer per KF account.
+        let channel_name = message
+            .metadata
+            .get("channel_name")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .unwrap_or(&self.channel_name);
+
+        let open_kfid = message
+            .metadata
+            .get("open_kfid")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .unwrap_or("unknown_kf");
+
+        let external_userid = message
+            .metadata
+            .get("external_userid")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .unwrap_or("unknown_user");
+
+        format!(
+            "{}_{}_{}",
+            sanitize_for_filesystem(channel_name),
+            sanitize_user_id(open_kfid),
+            sanitize_user_id(external_userid),
+        )
+    }
+
+    fn match_message(
+        &self,
+        message: &InboundMessage,
+        patterns: &[ChannelPattern],
+    ) -> Option<PatternMatch> {
+        wecom_match_message(message, patterns)
+    }
+}
+
+#[async_trait]
+impl InboundAdapter for WecomKfInboundAdapter {
+    async fn start(&self, options: InboundAdapterOptions, _cancel: CancellationToken) -> Result<()> {
+        let channel_name = self.channel_name.clone();
+
+        // Build the webhook config with KF event handler
+        let webhook_config = ChannelWebhookConfig {
+            token: self.config.token.clone(),
+            encoding_aes_key: self.config.encoding_aes_key.clone(),
+            corp_id: self.config.corp_id.clone(),
+            on_message: {
+                let kf_client = self.kf_client.clone();
+                let cursor_store = self.cursor_store.clone();
+                let dedup_store = self.dedup_store.clone();
+                let channel_name = channel_name.clone();
+                let on_message: Arc<dyn Fn(InboundMessage) -> Result<()> + Send + Sync> =
+                    Arc::from(options.on_message);
+
+                Arc::new(move |parsed: ParsedWecomMessage| {
+                    // Only process event type messages (kf_msg_or_event notifications)
+                    if parsed.msg_type != "event" {
+                        tracing::debug!(
+                            msg_type = %parsed.msg_type,
+                            "WeCom KF inbound: skipping non-event message"
+                        );
+                        return Ok(());
+                    }
+
+                    handle_kf_event(
+                        parsed,
+                        kf_client.clone(),
+                        cursor_store.clone(),
+                        dedup_store.clone(),
+                        channel_name.clone(),
+                        on_message.clone(),
+                    )
+                })
+            },
+        };
+
+        self.server
+            .register_channel(&channel_name, webhook_config)
+            .await;
+
+        tracing::info!(
+            channel = %channel_name,
+            "WeCom KF inbound adapter registered webhook handler"
+        );
+
+        // KF inbound does not need to run a separate task — the webhook
+        // server handles incoming requests. We wait on cancellation.
+        // However, since InboundAdapter::start() requires returning only
+        // when the adapter stops, we wait here.
+        // The actual message processing happens in the webhook callbacks.
+
+        // Wait indefinitely (cancellation handled by the caller)
+        futures_util::future::pending::<()>().await;
+
+        #[allow(unreachable_code)]
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wecom::kf_client::KfTextContent;
+    use crate::wecom::token_cache::AccessTokenCache;
+
+    #[test]
+    fn test_derive_thread_name() {
+        let config = WecomKfConfig {
+            token: "test_token".to_string(),
+            encoding_aes_key: "abc123abc123abc123abc123abc123abc123abc123abc123abc12".to_string(),
+            corp_id: "ww12345".to_string(),
+            corp_secret: "secret".to_string(),
+            open_kf_ids: vec![],
+            cursor_store_path: None,
+            metadata: HashMap::new(),
+        };
+        let server = Arc::new(WecomWebhookServer::new("127.0.0.1:1"));
+        let access_token_cache = Arc::new(AccessTokenCache::new(
+            "corp_id".to_string(),
+            "corp_secret".to_string(),
+        ));
+        let kf_client = Arc::new(KfApiClient::new(access_token_cache));
+        let cursor_store = Arc::new(KfCursorStore::new(None));
+        let dedup_store = Arc::new(KfDedupStore::new());
+
+        let adapter = WecomKfInboundAdapter::new(
+            &config,
+            "my_kf_bot",
+            server,
+            kf_client,
+            cursor_store,
+            dedup_store,
+        );
+
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "open_kfid".to_string(),
+            serde_json::Value::String("kf001".to_string()),
+        );
+        metadata.insert(
+            "external_userid".to_string(),
+            serde_json::Value::String("user123".to_string()),
+        );
+        metadata.insert(
+            "channel_name".to_string(),
+            serde_json::Value::String("my_kf_bot".to_string()),
+        );
+
+        let message = InboundMessage {
+            id: "test".to_string(),
+            channel: "wecomkf".to_string(),
+            channel_uid: "test_uid".to_string(),
+            sender: "user123".to_string(),
+            sender_address: "wecomkf:user123".to_string(),
+            recipients: vec![],
+            topic: "Test".to_string(),
+            content: MessageContent {
+                text: Some("Hello".to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: Some("msg_001".to_string()),
+            attachments: vec![],
+            metadata,
+            matched_pattern: None,
+        };
+
+        let name = adapter.derive_thread_name(&message, &[], None);
+        assert_eq!(name, "my_kf_bot_kf001_user123");
+    }
+
+    #[test]
+    fn test_derive_thread_name_missing_fields() {
+        let config = WecomKfConfig {
+            token: "test_token".to_string(),
+            encoding_aes_key: "abc123abc123abc123abc123abc123abc123abc123abc123abc12".to_string(),
+            corp_id: "ww12345".to_string(),
+            corp_secret: "secret".to_string(),
+            open_kf_ids: vec![],
+            cursor_store_path: None,
+            metadata: HashMap::new(),
+        };
+        let server = Arc::new(WecomWebhookServer::new("127.0.0.1:1"));
+        let access_token_cache = Arc::new(AccessTokenCache::new(
+            "corp_id".to_string(),
+            "corp_secret".to_string(),
+        ));
+        let kf_client = Arc::new(KfApiClient::new(access_token_cache));
+        let cursor_store = Arc::new(KfCursorStore::new(None));
+        let dedup_store = Arc::new(KfDedupStore::new());
+
+        let adapter = WecomKfInboundAdapter::new(
+            &config,
+            "my_kf_bot",
+            server,
+            kf_client,
+            cursor_store,
+            dedup_store,
+        );
+
+        // Empty metadata — should fall back to defaults
+        let message = InboundMessage {
+            id: "test".to_string(),
+            channel: "wecomkf".to_string(),
+            channel_uid: "test_uid".to_string(),
+            sender: "user123".to_string(),
+            sender_address: "wecomkf:user123".to_string(),
+            recipients: vec![],
+            topic: "Test".to_string(),
+            content: MessageContent {
+                text: Some("Hello".to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: Some("msg_001".to_string()),
+            attachments: vec![],
+            metadata: HashMap::new(),
+            matched_pattern: None,
+        };
+
+        let name = adapter.derive_thread_name(&message, &[], None);
+        // Falls back to channel_name + unknown_kf + unknown_user
+        assert!(name.contains("my_kf_bot"));
+    }
+
+    #[test]
+    fn test_channel_type() {
+        let config = WecomKfConfig {
+            token: "test_token".to_string(),
+            encoding_aes_key: "abc123abc123abc123abc123abc123abc123abc123abc123abc12".to_string(),
+            corp_id: "ww12345".to_string(),
+            corp_secret: "secret".to_string(),
+            open_kf_ids: vec![],
+            cursor_store_path: None,
+            metadata: HashMap::new(),
+        };
+        let server = Arc::new(WecomWebhookServer::new("127.0.0.1:1"));
+        let access_token_cache = Arc::new(AccessTokenCache::new(
+            "corp_id".to_string(),
+            "corp_secret".to_string(),
+        ));
+        let kf_client = Arc::new(KfApiClient::new(access_token_cache));
+        let cursor_store = Arc::new(KfCursorStore::new(None));
+        let dedup_store = Arc::new(KfDedupStore::new());
+
+        let adapter = WecomKfInboundAdapter::new(
+            &config,
+            "my_kf_bot",
+            server,
+            kf_client,
+            cursor_store,
+            dedup_store,
+        );
+
+        assert_eq!(adapter.channel_type(), "wecomkf");
+    }
+
+    #[test]
+    fn test_kf_message_to_inbound() {
+        let msg = KfMessage {
+            msgid: "msg_001".to_string(),
+            open_kfid: "kf001".to_string(),
+            external_userid: "user123".to_string(),
+            send_time: 1700000000,
+            msgtype: "text".to_string(),
+            text: Some(KfTextContent {
+                content: "Hello, support!".to_string(),
+            }),
+        };
+
+        let inbound = kf_message_to_inbound(&msg, "my_kf_bot", "token_xxx");
+        assert_eq!(inbound.channel, "wecomkf");
+        assert_eq!(inbound.sender, "user123");
+        assert_eq!(inbound.sender_address, "wecomkf:user123");
+        assert_eq!(
+            inbound.content.text.as_deref(),
+            Some("Hello, support!")
+        );
+        assert_eq!(inbound.external_id, Some("msg_001".to_string()));
+        assert_eq!(
+            inbound.metadata.get("open_kfid").and_then(|v| v.as_str()),
+            Some("kf001")
+        );
+        assert_eq!(
+            inbound
+                .metadata
+                .get("external_userid")
+                .and_then(|v| v.as_str()),
+            Some("user123")
+        );
+        assert_eq!(
+            inbound.metadata.get("token").and_then(|v| v.as_str()),
+            Some("token_xxx")
+        );
+    }
+
+    #[test]
+    fn test_kf_message_to_inbound_no_text() {
+        let msg = KfMessage {
+            msgid: "msg_002".to_string(),
+            open_kfid: "kf001".to_string(),
+            external_userid: "user456".to_string(),
+            send_time: 1700000001,
+            msgtype: "image".to_string(),
+            text: None,
+        };
+
+        let inbound = kf_message_to_inbound(&msg, "my_kf_bot", "token_xxx");
+        assert_eq!(inbound.content.text, None);
+        assert_eq!(inbound.metadata.get("msg_type").and_then(|v| v.as_str()), Some("image"));
+    }
+}

--- a/crates/jyc-channels/src/wecom/kf_inbound.rs
+++ b/crates/jyc-channels/src/wecom/kf_inbound.rs
@@ -74,11 +74,7 @@ fn sanitize_user_id(user_id: &str) -> String {
 }
 
 /// Convert a synced KF message into an `InboundMessage`.
-fn kf_message_to_inbound(
-    msg: &KfMessage,
-    channel_name: &str,
-    token: &str,
-) -> InboundMessage {
+fn kf_message_to_inbound(msg: &KfMessage, channel_name: &str, token: &str) -> InboundMessage {
     let mut metadata = HashMap::new();
     metadata.insert(
         "open_kfid".to_string(),
@@ -275,7 +271,11 @@ impl ChannelMatcher for WecomKfInboundAdapter {
 
 #[async_trait]
 impl InboundAdapter for WecomKfInboundAdapter {
-    async fn start(&self, options: InboundAdapterOptions, _cancel: CancellationToken) -> Result<()> {
+    async fn start(
+        &self,
+        options: InboundAdapterOptions,
+        _cancel: CancellationToken,
+    ) -> Result<()> {
         let channel_name = self.channel_name.clone();
 
         // Build the webhook config with KF event handler
@@ -574,10 +574,7 @@ mod tests {
         assert_eq!(inbound.channel, "wecomkf");
         assert_eq!(inbound.sender, "user123");
         assert_eq!(inbound.sender_address, "wecomkf:user123");
-        assert_eq!(
-            inbound.content.text.as_deref(),
-            Some("Hello, support!")
-        );
+        assert_eq!(inbound.content.text.as_deref(), Some("Hello, support!"));
         assert_eq!(inbound.external_id, Some("msg_001".to_string()));
         assert_eq!(
             inbound.metadata.get("open_kfid").and_then(|v| v.as_str()),
@@ -609,6 +606,9 @@ mod tests {
 
         let inbound = kf_message_to_inbound(&msg, "my_kf_bot", "token_xxx");
         assert_eq!(inbound.content.text, None);
-        assert_eq!(inbound.metadata.get("msg_type").and_then(|v| v.as_str()), Some("image"));
+        assert_eq!(
+            inbound.metadata.get("msg_type").and_then(|v| v.as_str()),
+            Some("image")
+        );
     }
 }

--- a/crates/jyc-channels/src/wecom/kf_inbound.rs
+++ b/crates/jyc-channels/src/wecom/kf_inbound.rs
@@ -143,19 +143,29 @@ fn handle_kf_event(
     dedup_store: Arc<KfDedupStore>,
     channel_name: String,
     on_message: Arc<dyn Fn(InboundMessage) -> Result<()> + Send + Sync>,
+    cancel: CancellationToken,
 ) -> Result<()> {
     let token = parsed.token.clone();
     let open_kfid = parsed.open_kfid.clone();
-
-    // Get the current cursor for this open_kfid
-    let cursor = cursor_store.get_cursor(&open_kfid).unwrap_or_default();
     let limit = 100;
 
-    // Spawn an async task for the actual API call
+    // Spawn an async task for the actual API call.
+    // Cursor is read inside the spawned task to avoid a race condition:
+    // if two notifications for the same open_kfid arrive rapidly,
+    // each task reads the latest cursor independently.
     tokio::spawn(async move {
-        // Sync messages from the KF API
-        let mut current_cursor = cursor;
+        // Get the current cursor for this open_kfid
+        let mut current_cursor = cursor_store.get_cursor(&open_kfid).unwrap_or_default();
         loop {
+            // Check for cancellation before each sync request
+            if cancel.is_cancelled() {
+                tracing::debug!(
+                    open_kfid = %open_kfid,
+                    "WeCom KF inbound: sync task cancelled"
+                );
+                break;
+            }
+
             match kf_client
                 .sync_messages(&token, &current_cursor, &open_kfid, limit)
                 .await
@@ -207,6 +217,15 @@ fn handle_kf_event(
                     break;
                 }
             }
+        }
+
+        // Flush cursors to disk after sync completes
+        if let Err(e) = cursor_store.flush_to_disk().await {
+            tracing::warn!(
+                open_kfid = %open_kfid,
+                error = %e,
+                "WeCom KF inbound: failed to flush cursors"
+            );
         }
     });
 
@@ -272,11 +291,7 @@ impl ChannelMatcher for WecomKfInboundAdapter {
 
 #[async_trait]
 impl InboundAdapter for WecomKfInboundAdapter {
-    async fn start(
-        &self,
-        options: InboundAdapterOptions,
-        cancel: CancellationToken,
-    ) -> Result<()> {
+    async fn start(&self, options: InboundAdapterOptions, cancel: CancellationToken) -> Result<()> {
         let channel_name = self.channel_name.clone();
 
         // Build the webhook config with KF event handler
@@ -291,6 +306,7 @@ impl InboundAdapter for WecomKfInboundAdapter {
                 let channel_name = channel_name.clone();
                 let on_message: Arc<dyn Fn(InboundMessage) -> Result<()> + Send + Sync> =
                     Arc::from(options.on_message);
+                let cancel_for_handler = cancel.clone();
 
                 Arc::new(move |parsed: ParsedWecomMessage| {
                     // Only process event type messages (kf_msg_or_event notifications)
@@ -309,6 +325,7 @@ impl InboundAdapter for WecomKfInboundAdapter {
                         dedup_store.clone(),
                         channel_name.clone(),
                         on_message.clone(),
+                        cancel_for_handler.clone(),
                     )
                 })
             },

--- a/crates/jyc-channels/src/wecom/kf_outbound.rs
+++ b/crates/jyc-channels/src/wecom/kf_outbound.rs
@@ -48,7 +48,7 @@ impl WecomKfOutboundAdapter {
     }
 
     /// Build the send message payload for a reply.
-    fn build_payload(reply_text: &str, original: &InboundMessage) -> (String, String, String) {
+    fn build_payload(_reply_text: &str, original: &InboundMessage) -> (String, String, String) {
         let open_kfid = original
             .metadata
             .get("open_kfid")
@@ -63,17 +63,11 @@ impl WecomKfOutboundAdapter {
             .unwrap_or_default()
             .to_string();
 
-        // Detect if the content looks like markdown
-        let is_markdown = reply_text.contains("```")
-            || reply_text.contains("**")
-            || reply_text.contains("##")
-            || reply_text.contains("|")
-            || reply_text.contains("- [")
-            || reply_text.contains("![");
+        // WeCom KF send_msg API supports: text, image, voice, video, file, news, msgmenu, miniprogram.
+        // Markdown is NOT supported. Always send as text.
+        let msgtype = "text".to_string();
 
-        let msgtype = if is_markdown { "markdown" } else { "text" };
-
-        (open_kfid, touser, msgtype.to_string())
+        (open_kfid, touser, msgtype)
     }
 }
 
@@ -84,10 +78,11 @@ impl OutboundAdapter for WecomKfOutboundAdapter {
     }
 
     async fn connect(&self) -> Result<()> {
-        // KF uses stateless HTTP requests. Verify connectivity by
-        // attempting to get an access token (the KfApiClient shares
-        // the AccessTokenCache which handles this).
-        tracing::debug!("WeCom KF outbound: connected (token cache ready)");
+        // Verify connectivity by fetching an access token.
+        // The KfApiClient delegates to AccessTokenCache which handles
+        // the actual API call and caching.
+        self.kf_client.verify_connectivity().await?;
+        tracing::debug!("WeCom KF outbound: connected (access_token obtained)");
         Ok(())
     }
 
@@ -227,7 +222,8 @@ mod tests {
             WecomKfOutboundAdapter::build_payload("## Title\n\n**bold** text", &msg);
         assert_eq!(open_kfid, "kf001");
         assert_eq!(touser, "user123");
-        assert_eq!(msgtype, "markdown");
+        // KF send_msg API does not support "markdown" — always falls back to "text"
+        assert_eq!(msgtype, "text");
     }
 
     #[test]
@@ -235,7 +231,8 @@ mod tests {
         let msg = make_kf_message("kf001", "user123", "Hello");
         let (_, _, msgtype) =
             WecomKfOutboundAdapter::build_payload("```rust\nfn main() {}\n```", &msg);
-        assert_eq!(msgtype, "markdown");
+        // KF send_msg API does not support "markdown" — always falls back to "text"
+        assert_eq!(msgtype, "text");
     }
 
     #[test]

--- a/crates/jyc-channels/src/wecom/kf_outbound.rs
+++ b/crates/jyc-channels/src/wecom/kf_outbound.rs
@@ -1,0 +1,312 @@
+//! WeCom KF (Customer Service) outbound adapter implementation.
+//!
+//! Unlike the regular WeCom outbound adapter (which uses the external contact
+//! message API `cgi-bin/externalcontact/message/send`), the KF outbound
+//! adapter uses `kf/send_msg` API to send replies to individual customers.
+//!
+//! Reference: https://developer.work.weixin.qq.com/document/path/94677
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+
+use jyc_core::message_storage::MessageStorage;
+use jyc_types::{
+    InboundMessage, OutboundAdapter, OutboundAttachment, SendResult,
+    config::OutboundAttachmentConfig,
+};
+
+use crate::wecom::kf_client::KfApiClient;
+
+/// WeCom KF outbound adapter — sends replies via the KF send_msg API.
+///
+/// Messages are sent to specific customers identified by `external_userid`,
+/// through a specific KF account identified by `open_kfid`. Both values
+/// are extracted from the original message's metadata.
+pub struct WecomKfOutboundAdapter {
+    kf_client: Arc<KfApiClient>,
+    storage: Arc<MessageStorage>,
+    #[allow(dead_code)]
+    footer_enabled: bool,
+}
+
+impl WecomKfOutboundAdapter {
+    /// Create a new KF outbound adapter.
+    pub fn new(
+        kf_client: Arc<KfApiClient>,
+        storage: Arc<MessageStorage>,
+        _attachment_config: Option<OutboundAttachmentConfig>,
+        footer_enabled: bool,
+    ) -> Self {
+        Self {
+            kf_client,
+            storage,
+            footer_enabled,
+        }
+    }
+
+    /// Build the send message payload for a reply.
+    fn build_payload(reply_text: &str, original: &InboundMessage) -> (String, String, String) {
+        let open_kfid = original
+            .metadata
+            .get("open_kfid")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+
+        let touser = original
+            .metadata
+            .get("external_userid")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+
+        // Detect if the content looks like markdown
+        let is_markdown = reply_text.contains("```")
+            || reply_text.contains("**")
+            || reply_text.contains("##")
+            || reply_text.contains("|")
+            || reply_text.contains("- [")
+            || reply_text.contains("![");
+
+        let msgtype = if is_markdown {
+            "markdown"
+        } else {
+            "text"
+        };
+
+        (open_kfid, touser, msgtype.to_string())
+    }
+}
+
+#[async_trait]
+impl OutboundAdapter for WecomKfOutboundAdapter {
+    fn channel_type(&self) -> &str {
+        "wecomkf"
+    }
+
+    async fn connect(&self) -> Result<()> {
+        // KF uses stateless HTTP requests. Verify connectivity by
+        // attempting to get an access token (the KfApiClient shares
+        // the AccessTokenCache which handles this).
+        tracing::debug!("WeCom KF outbound: connected (token cache ready)");
+        Ok(())
+    }
+
+    async fn disconnect(&self) -> Result<()> {
+        // No-op for stateless HTTP
+        Ok(())
+    }
+
+    fn clean_body(&self, raw_body: &str) -> String {
+        // WeCom KF is a simple channel with no quoting conventions to strip
+        raw_body.to_string()
+    }
+
+    async fn send_reply(
+        &self,
+        original: &InboundMessage,
+        reply_text: &str,
+        thread_path: &Path,
+        message_dir: &str,
+        _attachments: Option<&[OutboundAttachment]>,
+    ) -> Result<SendResult> {
+        let (open_kfid, touser, msgtype) = Self::build_payload(reply_text, original);
+
+        if open_kfid.is_empty() {
+            anyhow::bail!("WeCom KF outbound: missing open_kfid in message metadata");
+        }
+        if touser.is_empty() {
+            anyhow::bail!("WeCom KF outbound: missing external_userid in message metadata");
+        }
+
+        // Send via KF send_msg API
+        self.kf_client
+            .send_message(&open_kfid, &touser, &msgtype, reply_text)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to send KF message to {} via {}",
+                    touser, open_kfid
+                )
+            })?;
+
+        let message_id = format!("wecomkf_{}", crate::wecom::crypto::generate_nonce());
+        let result = SendResult {
+            message_id: message_id.clone(),
+        };
+
+        // Store the reply
+        self.storage
+            .store_reply(thread_path, message_dir, reply_text)
+            .await
+            .context("failed to store WeCom KF reply")?;
+
+        Ok(result)
+    }
+
+    async fn send_alert(&self, recipient: &str, subject: &str, body: &str) -> Result<SendResult> {
+        // The recipient format is "wecomkf:{open_kfid}:{external_userid}"
+        let parts: Vec<&str> = recipient
+            .strip_prefix("wecomkf:")
+            .unwrap_or(recipient)
+            .splitn(2, ':')
+            .collect();
+
+        if parts.len() < 2 {
+            anyhow::bail!(
+                "WeCom KF outbound: invalid alert recipient format '{}'. Expected 'wecomkf:open_kfid:external_userid'",
+                recipient
+            );
+        }
+
+        let open_kfid = parts[0];
+        let touser = parts[1];
+
+        let content = format!("## {}\n\n{}", subject, body);
+
+        self.kf_client
+            .send_message(open_kfid, touser, "markdown", &content)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to send KF alert to {} via {}",
+                    touser, open_kfid
+                )
+            })?;
+
+        let message_id = format!("wecomkf_{}", crate::wecom::crypto::generate_nonce());
+        Ok(SendResult { message_id })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    use jyc_types::MessageContent;
+
+    fn make_kf_message(
+        open_kfid: &str,
+        external_userid: &str,
+        text: &str,
+    ) -> InboundMessage {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "open_kfid".to_string(),
+            serde_json::Value::String(open_kfid.to_string()),
+        );
+        metadata.insert(
+            "external_userid".to_string(),
+            serde_json::Value::String(external_userid.to_string()),
+        );
+        InboundMessage {
+            id: "test-id".to_string(),
+            channel: "wecomkf".to_string(),
+            channel_uid: "test-uid".to_string(),
+            sender: external_userid.to_string(),
+            sender_address: format!("wecomkf:{}", external_userid),
+            recipients: vec![],
+            topic: "Test".to_string(),
+            content: MessageContent {
+                text: Some(text.to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata,
+            matched_pattern: None,
+        }
+    }
+
+    #[test]
+    fn test_build_payload_text() {
+        let msg = make_kf_message("kf001", "user123", "Hello");
+        let (open_kfid, touser, msgtype) = WecomKfOutboundAdapter::build_payload("Hello World", &msg);
+        assert_eq!(open_kfid, "kf001");
+        assert_eq!(touser, "user123");
+        assert_eq!(msgtype, "text");
+    }
+
+    #[test]
+    fn test_build_payload_markdown() {
+        let msg = make_kf_message("kf001", "user123", "Hello");
+        let (open_kfid, touser, msgtype) =
+            WecomKfOutboundAdapter::build_payload("## Title\n\n**bold** text", &msg);
+        assert_eq!(open_kfid, "kf001");
+        assert_eq!(touser, "user123");
+        assert_eq!(msgtype, "markdown");
+    }
+
+    #[test]
+    fn test_build_payload_markdown_with_code_block() {
+        let msg = make_kf_message("kf001", "user123", "Hello");
+        let (_, _, msgtype) =
+            WecomKfOutboundAdapter::build_payload("```rust\nfn main() {}\n```", &msg);
+        assert_eq!(msgtype, "markdown");
+    }
+
+    #[test]
+    fn test_build_payload_missing_fields() {
+        let msg = InboundMessage {
+            id: "test-id".to_string(),
+            channel: "wecomkf".to_string(),
+            channel_uid: "test-uid".to_string(),
+            sender: "user".to_string(),
+            sender_address: "wecomkf:user".to_string(),
+            recipients: vec![],
+            topic: "Test".to_string(),
+            content: MessageContent {
+                text: Some("Hello".to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata: HashMap::new(),
+            matched_pattern: None,
+        };
+        let (open_kfid, touser, msgtype) =
+            WecomKfOutboundAdapter::build_payload("Hello", &msg);
+        assert_eq!(open_kfid, "");
+        assert_eq!(touser, "");
+        assert_eq!(msgtype, "text");
+    }
+
+    #[test]
+    fn test_channel_type() {
+        let api_client = Arc::new(KfApiClient::new(Arc::new(
+            crate::wecom::token_cache::AccessTokenCache::new(
+                "corp_id".to_string(),
+                "corp_secret".to_string(),
+            ),
+        )));
+        let storage = Arc::new(MessageStorage::new(&std::env::temp_dir()));
+        let adapter = WecomKfOutboundAdapter::new(api_client, storage, None, true);
+        assert_eq!(adapter.channel_type(), "wecomkf");
+    }
+
+    #[test]
+    fn test_clean_body() {
+        let api_client = Arc::new(KfApiClient::new(Arc::new(
+            crate::wecom::token_cache::AccessTokenCache::new(
+                "corp_id".to_string(),
+                "corp_secret".to_string(),
+            ),
+        )));
+        let storage = Arc::new(MessageStorage::new(&std::env::temp_dir()));
+        let adapter = WecomKfOutboundAdapter::new(api_client, storage, None, true);
+        let cleaned = adapter.clean_body("Hello **world**");
+        assert_eq!(cleaned, "Hello **world**");
+    }
+}

--- a/crates/jyc-channels/src/wecom/kf_outbound.rs
+++ b/crates/jyc-channels/src/wecom/kf_outbound.rs
@@ -155,8 +155,10 @@ impl OutboundAdapter for WecomKfOutboundAdapter {
 
         let content = format!("## {}\n\n{}", subject, body);
 
+        // Note: KF send_msg API does not support "markdown". The "## " subject
+        // prefix formatting is sent as plain text, which is acceptable.
         self.kf_client
-            .send_message(open_kfid, touser, "markdown", &content)
+            .send_message(open_kfid, touser, "text", &content)
             .await
             .with_context(|| format!("failed to send KF alert to {} via {}", touser, open_kfid))?;
 

--- a/crates/jyc-channels/src/wecom/kf_outbound.rs
+++ b/crates/jyc-channels/src/wecom/kf_outbound.rs
@@ -71,11 +71,7 @@ impl WecomKfOutboundAdapter {
             || reply_text.contains("- [")
             || reply_text.contains("![");
 
-        let msgtype = if is_markdown {
-            "markdown"
-        } else {
-            "text"
-        };
+        let msgtype = if is_markdown { "markdown" } else { "text" };
 
         (open_kfid, touser, msgtype.to_string())
     }
@@ -127,10 +123,7 @@ impl OutboundAdapter for WecomKfOutboundAdapter {
             .send_message(&open_kfid, &touser, &msgtype, reply_text)
             .await
             .with_context(|| {
-                format!(
-                    "failed to send KF message to {} via {}",
-                    touser, open_kfid
-                )
+                format!("failed to send KF message to {} via {}", touser, open_kfid)
             })?;
 
         let message_id = format!("wecomkf_{}", crate::wecom::crypto::generate_nonce());
@@ -170,12 +163,7 @@ impl OutboundAdapter for WecomKfOutboundAdapter {
         self.kf_client
             .send_message(open_kfid, touser, "markdown", &content)
             .await
-            .with_context(|| {
-                format!(
-                    "failed to send KF alert to {} via {}",
-                    touser, open_kfid
-                )
-            })?;
+            .with_context(|| format!("failed to send KF alert to {} via {}", touser, open_kfid))?;
 
         let message_id = format!("wecomkf_{}", crate::wecom::crypto::generate_nonce());
         Ok(SendResult { message_id })
@@ -189,11 +177,7 @@ mod tests {
 
     use jyc_types::MessageContent;
 
-    fn make_kf_message(
-        open_kfid: &str,
-        external_userid: &str,
-        text: &str,
-    ) -> InboundMessage {
+    fn make_kf_message(open_kfid: &str, external_userid: &str, text: &str) -> InboundMessage {
         let mut metadata = HashMap::new();
         metadata.insert(
             "open_kfid".to_string(),
@@ -229,7 +213,8 @@ mod tests {
     #[test]
     fn test_build_payload_text() {
         let msg = make_kf_message("kf001", "user123", "Hello");
-        let (open_kfid, touser, msgtype) = WecomKfOutboundAdapter::build_payload("Hello World", &msg);
+        let (open_kfid, touser, msgtype) =
+            WecomKfOutboundAdapter::build_payload("Hello World", &msg);
         assert_eq!(open_kfid, "kf001");
         assert_eq!(touser, "user123");
         assert_eq!(msgtype, "text");
@@ -276,8 +261,7 @@ mod tests {
             metadata: HashMap::new(),
             matched_pattern: None,
         };
-        let (open_kfid, touser, msgtype) =
-            WecomKfOutboundAdapter::build_payload("Hello", &msg);
+        let (open_kfid, touser, msgtype) = WecomKfOutboundAdapter::build_payload("Hello", &msg);
         assert_eq!(open_kfid, "");
         assert_eq!(touser, "");
         assert_eq!(msgtype, "text");

--- a/crates/jyc-channels/src/wecom/mod.rs
+++ b/crates/jyc-channels/src/wecom/mod.rs
@@ -16,6 +16,7 @@ pub mod kf_client;
 pub mod kf_cursor;
 pub mod kf_dedup;
 pub mod kf_inbound;
+pub mod kf_outbound;
 pub mod outbound;
 pub mod server;
 pub mod token_cache;

--- a/crates/jyc-channels/src/wecom/mod.rs
+++ b/crates/jyc-channels/src/wecom/mod.rs
@@ -14,3 +14,4 @@ pub mod crypto;
 pub mod inbound;
 pub mod outbound;
 pub mod server;
+pub mod token_cache;

--- a/crates/jyc-channels/src/wecom/mod.rs
+++ b/crates/jyc-channels/src/wecom/mod.rs
@@ -15,6 +15,7 @@ pub mod inbound;
 pub mod kf_client;
 pub mod kf_cursor;
 pub mod kf_dedup;
+pub mod kf_inbound;
 pub mod outbound;
 pub mod server;
 pub mod token_cache;

--- a/crates/jyc-channels/src/wecom/mod.rs
+++ b/crates/jyc-channels/src/wecom/mod.rs
@@ -12,6 +12,7 @@
 
 pub mod crypto;
 pub mod inbound;
+pub mod kf_client;
 pub mod outbound;
 pub mod server;
 pub mod token_cache;

--- a/crates/jyc-channels/src/wecom/mod.rs
+++ b/crates/jyc-channels/src/wecom/mod.rs
@@ -14,6 +14,7 @@ pub mod crypto;
 pub mod inbound;
 pub mod kf_client;
 pub mod kf_cursor;
+pub mod kf_dedup;
 pub mod outbound;
 pub mod server;
 pub mod token_cache;

--- a/crates/jyc-channels/src/wecom/mod.rs
+++ b/crates/jyc-channels/src/wecom/mod.rs
@@ -13,6 +13,7 @@
 pub mod crypto;
 pub mod inbound;
 pub mod kf_client;
+pub mod kf_cursor;
 pub mod outbound;
 pub mod server;
 pub mod token_cache;

--- a/crates/jyc-channels/src/wecom/outbound.rs
+++ b/crates/jyc-channels/src/wecom/outbound.rs
@@ -10,7 +10,6 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use std::path::Path;
 use std::sync::Arc;
-use std::time::Instant;
 
 use jyc_core::message_storage::MessageStorage;
 use jyc_types::{
@@ -19,115 +18,11 @@ use jyc_types::{
 };
 
 use crate::wecom::crypto::generate_nonce;
+use crate::wecom::token_cache::AccessTokenCache;
 
 /// The external contact message send API base URL.
 const EXTERNAL_CONTACT_API: &str =
     "https://qyapi.weixin.qq.com/cgi-bin/externalcontact/message/send";
-
-/// The token refresh API base URL.
-const TOKEN_API: &str = "https://qyapi.weixin.qq.com/cgi-bin/gettoken";
-
-/// The number of seconds before token expiry to proactively refresh.
-const TOKEN_REFRESH_MARGIN_SECS: u64 = 300;
-
-/// Thread-safe access token cache.
-///
-/// Stores the token and its expiry Instant. Refreshes automatically
-/// when the token is missing or will expire within 5 minutes.
-pub struct AccessTokenCache {
-    inner: Arc<std::sync::Mutex<Option<(String, Instant)>>>,
-    corp_id: String,
-    corp_secret: String,
-    client: reqwest::Client,
-}
-
-impl AccessTokenCache {
-    /// Create a new access token cache.
-    pub fn new(corp_id: String, corp_secret: String) -> Self {
-        Self {
-            inner: Arc::new(std::sync::Mutex::new(None)),
-            corp_id,
-            corp_secret,
-            client: reqwest::Client::new(),
-        }
-    }
-
-    /// Get a valid access token, refreshing if necessary.
-    ///
-    /// If the cached token exists and will not expire within
-    /// `TOKEN_REFRESH_MARGIN_SECS` seconds, returns it directly.
-    /// Otherwise calls the WeCom gettoken API to obtain a new one.
-    pub async fn get_token(&self) -> Result<String> {
-        // Check if cached token is still valid
-        {
-            let cache = self.inner.lock().unwrap();
-            if let Some((token, expiry)) = cache.as_ref() {
-                let now = Instant::now();
-                let remaining = if *expiry > now {
-                    *expiry - now
-                } else {
-                    std::time::Duration::from_secs(0)
-                };
-                if remaining.as_secs() > TOKEN_REFRESH_MARGIN_SECS {
-                    return Ok(token.clone());
-                }
-            }
-        }
-
-        // Need to refresh: fetch new token from API
-        let url = format!(
-            "{}?corpid={}&corpsecret={}",
-            TOKEN_API, self.corp_id, self.corp_secret
-        );
-
-        let response = self
-            .client
-            .get(&url)
-            .send()
-            .await
-            .context("failed to request WeCom access_token")?;
-
-        let body: serde_json::Value = response
-            .json()
-            .await
-            .context("failed to parse WeCom access_token response")?;
-
-        let errcode = body["errcode"].as_i64().unwrap_or(-1);
-        if errcode != 0 {
-            let errmsg = body["errmsg"].as_str().unwrap_or("unknown error");
-            anyhow::bail!("WeCom gettoken API returned error {}: {}", errcode, errmsg);
-        }
-
-        let token = body["access_token"]
-            .as_str()
-            .context("missing access_token in gettoken response")?
-            .to_string();
-        let expires_in = body["expires_in"].as_i64().unwrap_or(7200) as u64;
-
-        let expiry = Instant::now()
-            .checked_add(std::time::Duration::from_secs(expires_in))
-            .context("token expiry overflow")?;
-
-        // Update cache
-        {
-            let mut cache = self.inner.lock().unwrap();
-            *cache = Some((token.clone(), expiry));
-        }
-
-        tracing::debug!(
-            expires_in_secs = expires_in,
-            "WeCom access_token obtained and cached"
-        );
-
-        Ok(token)
-    }
-
-    /// Get a clone of the inner mutex for testing/sharing.
-    #[cfg(test)]
-    fn inner_clone(&self) -> Arc<std::sync::Mutex<Option<(String, Instant)>>> {
-        self.inner.clone()
-    }
-}
 
 /// WeCom outbound adapter — sends messages via external contact API.
 ///

--- a/crates/jyc-channels/src/wecom/server.rs
+++ b/crates/jyc-channels/src/wecom/server.rs
@@ -37,6 +37,12 @@ use crate::wecom::crypto;
 ///
 /// Fields correspond to the inner XML body after AES decryption.
 /// Reference: https://developer.work.weixin.qq.com/document/path/90255
+///
+/// This struct is also used for WeCom KF (Customer Service) event notifications.
+/// KF events have:
+/// - `msg_type == "event"`
+/// - empty `content`/`chat_id`/`msg_id`
+/// - `token` and `open_kfid` populated from `<Token>` and `<OpenKfId>` fields
 #[derive(Debug, Clone)]
 pub struct ParsedWecomMessage {
     /// Message content (text from `<Content>`).
@@ -45,13 +51,20 @@ pub struct ParsedWecomMessage {
     pub from_user: String,
     /// Chat ID — the group chat room ID (from `<ChatId>`).
     /// This is used for routing outbound messages to the correct group.
+    /// Optional — KF events may not have this field.
     pub chat_id: String,
-    /// Message type (from `<MsgType>`, e.g. "text", "image").
+    /// Message type (from `<MsgType>`, e.g. "text", "image", "event").
     pub msg_type: String,
     /// Message ID (from `<MsgId>`).
     pub msg_id: String,
     /// Create time (from `<CreateTime>`).
     pub create_time: String,
+    /// Token — used in KF event notifications (from `<Token>`).
+    /// Empty for regular WeCom messages.
+    pub token: String,
+    /// Open KF ID — the KF account ID (from `<OpenKfId>`).
+    /// Empty for regular WeCom messages.
+    pub open_kfid: String,
 }
 
 /// Per-channel configuration stored in the webhook server.
@@ -349,14 +362,30 @@ fn extract_encrypt_from_xml(xml: &str) -> Option<String> {
 /// </xml>
 /// ```
 ///
+/// For KF event notifications, the XML may include `<Token>` and `<OpenKfId>`
+/// instead of `<Content>`, `<ChatId>`, and `<MsgId>`:
+/// ```xml
+/// <xml>
+///   <ToUserName><![CDATA[ww1234567890]]></ToUserName>
+///   <FromUserName><![CDATA[KF_EVENT]]></FromUserName>
+///   <CreateTime>1700000000</CreateTime>
+///   <MsgType><![CDATA[event]]></MsgType>
+///   <Event><![CDATA[kf_msg_or_event]]></Event>
+///   <Token><![CDATA[xxxxxx]]></Token>
+///   <OpenKfId><![CDATA[kf1234567]]></OpenKfId>
+/// </xml>
+/// ```
+///
 /// Uses simple string extraction (same style as `extract_encrypt_from_xml`).
 pub fn parse_decrypted_xml(xml: &str) -> Option<ParsedWecomMessage> {
     let content = extract_xml_field(xml, "Content").unwrap_or_default();
     let from_user = extract_xml_field(xml, "FromUserName")?;
-    let chat_id = extract_xml_field(xml, "ChatId")?;
+    let chat_id = extract_xml_field(xml, "ChatId").unwrap_or_default();
     let msg_type = extract_xml_field(xml, "MsgType")?;
     let msg_id = extract_xml_field(xml, "MsgId").unwrap_or_default();
     let create_time = extract_xml_field(xml, "CreateTime").unwrap_or_default();
+    let token = extract_xml_field(xml, "Token").unwrap_or_default();
+    let open_kfid = extract_xml_field(xml, "OpenKfId").unwrap_or_default();
 
     Some(ParsedWecomMessage {
         content,
@@ -365,6 +394,8 @@ pub fn parse_decrypted_xml(xml: &str) -> Option<ParsedWecomMessage> {
         msg_type,
         msg_id,
         create_time,
+        token,
+        open_kfid,
     })
 }
 
@@ -478,7 +509,12 @@ mod tests {
             <MsgType><![CDATA[text]]></MsgType>
             <Content><![CDATA[Hello]]></Content>
         </xml>"#;
-        assert!(parse_decrypted_xml(xml).is_none());
+        // ChatId is now optional — parsing should succeed with empty chat_id
+        let parsed = parse_decrypted_xml(xml).expect("should parse without ChatId");
+        assert_eq!(parsed.from_user, "user001");
+        assert_eq!(parsed.chat_id, "");
+        assert_eq!(parsed.msg_type, "text");
+        assert_eq!(parsed.content, "Hello");
     }
 
     #[test]
@@ -542,5 +578,84 @@ mod tests {
         let parsed = parse_decrypted_xml(xml).expect("should parse without Content");
         assert_eq!(parsed.content, "");
         assert_eq!(parsed.msg_type, "image");
+    }
+
+    #[test]
+    fn test_parse_kf_event_xml() {
+        let xml = r#"<xml>
+            <ToUserName><![CDATA[ww123456]]></ToUserName>
+            <FromUserName><![CDATA[KF_EVENT]]></FromUserName>
+            <CreateTime>1700000000</CreateTime>
+            <MsgType><![CDATA[event]]></MsgType>
+            <Event><![CDATA[kf_msg_or_event]]></Event>
+            <Token><![CDATA[xxxxxx]]></Token>
+            <OpenKfId><![CDATA[kf1234567]]></OpenKfId>
+        </xml>"#;
+
+        let parsed = parse_decrypted_xml(xml).expect("should parse KF event");
+        assert_eq!(parsed.msg_type, "event");
+        assert_eq!(parsed.content, "");
+        assert_eq!(parsed.chat_id, "");
+        assert_eq!(parsed.msg_id, "");
+        assert_eq!(parsed.token, "xxxxxx");
+        assert_eq!(parsed.open_kfid, "kf1234567");
+        assert_eq!(parsed.from_user, "KF_EVENT");
+    }
+
+    #[test]
+    fn test_parse_kf_event_missing_token() {
+        let xml = r#"<xml>
+            <ToUserName><![CDATA[ww123456]]></ToUserName>
+            <FromUserName><![CDATA[KF_EVENT]]></FromUserName>
+            <CreateTime>1700000000</CreateTime>
+            <MsgType><![CDATA[event]]></MsgType>
+            <Event><![CDATA[kf_msg_or_event]]></Event>
+            <OpenKfId><![CDATA[kf1234567]]></OpenKfId>
+        </xml>"#;
+
+        let parsed = parse_decrypted_xml(xml).expect("should parse KF event without Token");
+        assert_eq!(parsed.msg_type, "event");
+        assert_eq!(parsed.token, "");
+        assert_eq!(parsed.open_kfid, "kf1234567");
+    }
+
+    #[test]
+    fn test_parse_kf_event_missing_open_kfid() {
+        let xml = r#"<xml>
+            <ToUserName><![CDATA[ww123456]]></ToUserName>
+            <FromUserName><![CDATA[KF_EVENT]]></FromUserName>
+            <CreateTime>1700000000</CreateTime>
+            <MsgType><![CDATA[event]]></MsgType>
+            <Event><![CDATA[kf_msg_or_event]]></Event>
+            <Token><![CDATA[xxxxxx]]></Token>
+        </xml>"#;
+
+        let parsed = parse_decrypted_xml(xml).expect("should parse KF event without OpenKfId");
+        assert_eq!(parsed.token, "xxxxxx");
+        assert_eq!(parsed.open_kfid, "");
+    }
+
+    #[test]
+    fn test_parse_regular_message_still_works() {
+        let xml = r#"<xml>
+            <ToUserName><![CDATA[ww123456]]></ToUserName>
+            <FromUserName><![CDATA[user001]]></FromUserName>
+            <CreateTime>1700000000</CreateTime>
+            <MsgType><![CDATA[text]]></MsgType>
+            <Content><![CDATA[Hello World]]></Content>
+            <MsgId>1234567890</MsgId>
+            <ChatId><![CDATA[wr9876543210]]></ChatId>
+        </xml>"#;
+
+        let parsed = parse_decrypted_xml(xml).expect("should parse regular message");
+        assert_eq!(parsed.content, "Hello World");
+        assert_eq!(parsed.from_user, "user001");
+        assert_eq!(parsed.chat_id, "wr9876543210");
+        assert_eq!(parsed.msg_type, "text");
+        assert_eq!(parsed.msg_id, "1234567890");
+        assert_eq!(parsed.create_time, "1700000000");
+        // New fields should be empty for regular messages
+        assert_eq!(parsed.token, "");
+        assert_eq!(parsed.open_kfid, "");
     }
 }

--- a/crates/jyc-channels/src/wecom/token_cache.rs
+++ b/crates/jyc-channels/src/wecom/token_cache.rs
@@ -1,0 +1,115 @@
+//! Thread-safe WeCom access token cache.
+//!
+//! Stores the token and its expiry [`std::time::Instant`]. Refreshes automatically
+//! when the token is missing or will expire within 5 minutes.
+//! Used by both `WecomOutboundAdapter` and `WecomKfOutboundAdapter`.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use anyhow::{Context, Result};
+
+/// The token refresh API base URL.
+const TOKEN_API: &str = "https://qyapi.weixin.qq.com/cgi-bin/gettoken";
+
+/// The number of seconds before token expiry to proactively refresh.
+const TOKEN_REFRESH_MARGIN_SECS: u64 = 300;
+
+/// Thread-safe access token cache.
+///
+/// Stores the token and its expiry Instant. Refreshes automatically
+/// when the token is missing or will expire within 5 minutes.
+pub struct AccessTokenCache {
+    inner: Arc<std::sync::Mutex<Option<(String, Instant)>>>,
+    corp_id: String,
+    corp_secret: String,
+    client: reqwest::Client,
+}
+
+impl AccessTokenCache {
+    /// Create a new access token cache.
+    pub fn new(corp_id: String, corp_secret: String) -> Self {
+        Self {
+            inner: Arc::new(std::sync::Mutex::new(None)),
+            corp_id,
+            corp_secret,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Get a valid access token, refreshing if necessary.
+    ///
+    /// If the cached token exists and will not expire within
+    /// `TOKEN_REFRESH_MARGIN_SECS` seconds, returns it directly.
+    /// Otherwise calls the WeCom gettoken API to obtain a new one.
+    pub async fn get_token(&self) -> Result<String> {
+        // Check if cached token is still valid
+        {
+            let cache = self.inner.lock().unwrap();
+            if let Some((token, expiry)) = cache.as_ref() {
+                let now = Instant::now();
+                let remaining = if *expiry > now {
+                    *expiry - now
+                } else {
+                    std::time::Duration::from_secs(0)
+                };
+                if remaining.as_secs() > TOKEN_REFRESH_MARGIN_SECS {
+                    return Ok(token.clone());
+                }
+            }
+        }
+
+        // Need to refresh: fetch new token from API
+        let url = format!(
+            "{}?corpid={}&corpsecret={}",
+            TOKEN_API, self.corp_id, self.corp_secret
+        );
+
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context("failed to request WeCom access_token")?;
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .context("failed to parse WeCom access_token response")?;
+
+        let errcode = body["errcode"].as_i64().unwrap_or(-1);
+        if errcode != 0 {
+            let errmsg = body["errmsg"].as_str().unwrap_or("unknown error");
+            anyhow::bail!("WeCom gettoken API returned error {}: {}", errcode, errmsg);
+        }
+
+        let token = body["access_token"]
+            .as_str()
+            .context("missing access_token in gettoken response")?
+            .to_string();
+        let expires_in = body["expires_in"].as_i64().unwrap_or(7200) as u64;
+
+        let expiry = Instant::now()
+            .checked_add(std::time::Duration::from_secs(expires_in))
+            .context("token expiry overflow")?;
+
+        // Update cache
+        {
+            let mut cache = self.inner.lock().unwrap();
+            *cache = Some((token.clone(), expiry));
+        }
+
+        tracing::debug!(
+            expires_in_secs = expires_in,
+            "WeCom access_token obtained and cached"
+        );
+
+        Ok(token)
+    }
+
+    /// Get a clone of the inner mutex for testing/sharing.
+    #[cfg(test)]
+    pub fn inner_clone(&self) -> Arc<std::sync::Mutex<Option<(String, Instant)>>> {
+        self.inner.clone()
+    }
+}

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -818,7 +818,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     wecomkf_config
                         .cursor_store_path
                         .as_ref()
-                        .map(|p| std::path::PathBuf::from(p)),
+                        .map(std::path::PathBuf::from),
                 ));
                 let dedup_store = Arc::new(KfDedupStore::new());
 

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -19,8 +19,15 @@ use jyc_channels::github::outbound::GithubOutboundAdapter;
 use jyc_channels::wechat::inbound::WechatInboundAdapter;
 use jyc_channels::wechat::outbound::WechatOutboundAdapter;
 use jyc_channels::wecom::inbound::WecomInboundAdapter;
+use jyc_channels::wecom::kf_client::KfApiClient;
+use jyc_channels::wecom::kf_cursor::KfCursorStore;
+use jyc_channels::wecom::kf_dedup::KfDedupStore;
+use jyc_channels::wecom::kf_inbound::WecomKfInboundAdapter;
+use jyc_channels::wecom::kf_inbound::WecomKfMatcher;
+use jyc_channels::wecom::kf_outbound::WecomKfOutboundAdapter;
 use jyc_channels::wecom::outbound::WecomOutboundAdapter;
 use jyc_channels::wecom::server::WecomWebhookServer;
+use jyc_channels::wecom::token_cache::AccessTokenCache;
 use jyc_core::message_router::MessageRouter;
 use jyc_core::message_storage::MessageStorage;
 use jyc_core::metrics::MetricsCollector;
@@ -85,11 +92,11 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
     let config_snapshot = config.load();
     let agent_config = Arc::new(config_snapshot.agent.clone());
 
-    // Initialize shared WeCom webhook server (if any wecom channel is configured)
+    // Initialize shared WeCom webhook server (if any wecom or wecomkf channel is configured)
     let has_wecom = config_snapshot
         .channels
         .values()
-        .any(|c| c.channel_type == "wecom");
+        .any(|c| c.channel_type == "wecom" || c.channel_type == "wecomkf");
     let wecom_server: Option<Arc<WecomWebhookServer>> = if has_wecom {
         let bind_addr = config_snapshot
             .wecom
@@ -159,6 +166,8 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
         let mut wechat_sender_arc: Option<
             std::sync::Arc<tokio::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<String>>>>,
         > = None;
+        // For wecomkf, we share the KfApiClient between inbound and outbound
+        let mut wecomkf_kf_client: Option<Arc<KfApiClient>> = None;
         let outbound: Arc<dyn OutboundAdapter> = match channel_type {
             "email" => {
                 let outbound_config = channel_config.outbound.as_ref().ok_or_else(|| {
@@ -223,6 +232,29 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                 Arc::new(WecomOutboundAdapter::new_with_attachments(
                     wecom_config.corp_id,
                     wecom_config.corp_secret,
+                    storage.clone(),
+                    outbound_attachment_config,
+                    footer_enabled,
+                ))
+            }
+            "wecomkf" => {
+                let wecomkf_config = channel_config
+                    .wecom_kf
+                    .as_ref()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("channel '{channel_name}': missing wecom_kf config")
+                    })?
+                    .clone();
+
+                let access_token_cache = Arc::new(AccessTokenCache::new(
+                    wecomkf_config.corp_id.clone(),
+                    wecomkf_config.corp_secret.clone(),
+                ));
+                let kf_client = Arc::new(KfApiClient::new(access_token_cache));
+                wecomkf_kf_client = Some(kf_client.clone());
+
+                Arc::new(WecomKfOutboundAdapter::new(
+                    kf_client,
                     storage.clone(),
                     outbound_attachment_config,
                     footer_enabled,
@@ -753,6 +785,86 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                         tracing::error!(
                             error = %e,
                             "WeCom inbound adapter error"
+                        );
+                    }
+
+                    // Shutdown thread manager for this channel
+                    tm.shutdown().await;
+                }.instrument(channel_span));
+
+                tasks.push(task);
+            }
+            "wecomkf" => {
+                let wecomkf_config = channel_config
+                    .wecom_kf
+                    .as_ref()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("channel '{channel_name}': missing wecom_kf config")
+                    })?
+                    .clone();
+
+                let wecom_server = wecom_server
+                    .clone()
+                    .ok_or_else(|| anyhow::anyhow!("WeCom webhook server not initialized"))?;
+                let patterns_for_callback = patterns.clone();
+                let router_for_callback = router.clone();
+                let channel_name_owned = channel_name.clone();
+
+                let kf_client = wecomkf_kf_client.clone().ok_or_else(|| {
+                    anyhow::anyhow!("KfApiClient not initialized for wecomkf channel")
+                })?;
+
+                let cursor_store = Arc::new(KfCursorStore::new(
+                    wecomkf_config
+                        .cursor_store_path
+                        .as_ref()
+                        .map(|p| std::path::PathBuf::from(p)),
+                ));
+                let dedup_store = Arc::new(KfDedupStore::new());
+
+                let task = tokio::spawn(async move {
+                    use jyc_types::InboundAdapter;
+
+                    let adapter = WecomKfInboundAdapter::new(
+                        &wecomkf_config,
+                        &channel_name_owned,
+                        wecom_server,
+                        kf_client,
+                        cursor_store,
+                        dedup_store,
+                    );
+
+                    let thread_manager_clone = thread_manager.clone();
+                    let options = jyc_types::InboundAdapterOptions {
+                        on_message: Box::new(move |message| {
+                            let router = router_for_callback.clone();
+                            let patterns = patterns_for_callback.clone();
+
+                            tokio::spawn(async move {
+                                router.route(&WecomKfMatcher, message, &patterns).await;
+                            });
+
+                            Ok(())
+                        }),
+                        on_thread_close: Some(Box::new(move |thread_name: String| {
+                            let tm = thread_manager_clone.clone();
+                            tokio::spawn(async move {
+                                if let Err(e) = tm.close_thread(&thread_name).await {
+                                    tracing::error!(error = %e, thread = %thread_name, "Failed to close thread");
+                                }
+                            });
+                            Ok(())
+                        })),
+                        on_error: Box::new(|error| {
+                            tracing::error!(error = %error, "WeCom KF inbound error");
+                        }),
+                        attachment_config: inbound_attachment_config.clone(),
+                    };
+
+                    if let Err(e) = adapter.start(options, cancel_child).await {
+                        tracing::error!(
+                            error = %e,
+                            "WeCom KF inbound adapter error"
                         );
                     }
 

--- a/crates/jyc-types/src/config.rs
+++ b/crates/jyc-types/src/config.rs
@@ -8,6 +8,7 @@ use crate::feishu_config::FeishuConfig;
 use crate::github_config::GithubConfig;
 use crate::wechat_config::WechatConfig;
 use crate::wecom_config::WecomConfig;
+use crate::wecom_kf_config::WecomKfConfig;
 
 /// MCP server configuration for agent dynamic tool loading.
 ///
@@ -134,6 +135,10 @@ pub struct ChannelConfig {
 
     /// WeCom configuration (for wecom channels)
     pub wecom: Option<WecomConfig>,
+
+    /// WeCom KF (Customer Service) configuration (for wecomkf channels)
+    #[serde(default)]
+    pub wecom_kf: Option<WecomKfConfig>,
 
     /// Monitoring settings (IDLE vs poll, interval, etc.)
     pub monitor: Option<MonitorConfig>,

--- a/crates/jyc-types/src/lib.rs
+++ b/crates/jyc-types/src/lib.rs
@@ -7,6 +7,7 @@ pub mod inspect;
 pub mod validation;
 pub mod wechat_config;
 pub mod wecom_config;
+pub mod wecom_kf_config;
 
 pub use agent::*;
 pub use channel::*;
@@ -16,3 +17,4 @@ pub use github_config::*;
 pub use inspect::*;
 pub use wechat_config::*;
 pub use wecom_config::*;
+pub use wecom_kf_config::*;

--- a/crates/jyc-types/src/wecom_kf_config.rs
+++ b/crates/jyc-types/src/wecom_kf_config.rs
@@ -1,0 +1,114 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// WeCom KF (Customer Service) channel-specific configuration.
+///
+/// Unlike the regular `WecomConfig`, the KF channel uses the
+/// WeCom Customer Service API (`kf/sync_msg` and `kf/send_msg`)
+/// instead of the external contact message API.
+///
+/// Fields:
+/// - `token`: Token for callback message verification (from WeCom KF callback settings)
+/// - `encoding_aes_key`: Encoding AES Key (with "=" padding) for message decryption
+/// - `corp_id`: Corp ID / Enterprise ID
+/// - `corp_secret`: Corp secret for access_token acquisition
+/// - `open_kf_ids`: Optional list of KF account IDs to filter (empty = accept all)
+/// - `cursor_store_path`: Optional file path for cursor persistence (JSON file)
+/// - `metadata`: Additional metadata
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct WecomKfConfig {
+    /// Token for callback message verification (from WeCom KF callback settings).
+    pub token: String,
+
+    /// Encoding AES Key (with "=" padding) for message decryption.
+    pub encoding_aes_key: String,
+
+    /// Corp ID / Enterprise ID.
+    pub corp_id: String,
+
+    /// Corp secret for access_token acquisition.
+    pub corp_secret: String,
+
+    /// Optional list of KF account IDs to filter (empty = accept all).
+    #[serde(default)]
+    pub open_kf_ids: Vec<String>,
+
+    /// Optional file path for cursor persistence (JSON file).
+    #[serde(default)]
+    pub cursor_store_path: Option<String>,
+
+    /// Additional metadata.
+    #[serde(default)]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_full() {
+        let toml_str = r#"
+            token = "kf_token_xxx"
+            encoding_aes_key = "abc123abc123abc123abc123abc123abc123abc123abc123abc12"
+            corp_id = "ww1234567890abcdef"
+            corp_secret = "my_corp_secret_value"
+            open_kf_ids = ["kf001", "kf002"]
+            cursor_store_path = "/tmp/kf_cursors.json"
+        "#;
+
+        let config: WecomKfConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.token, "kf_token_xxx");
+        assert_eq!(
+            config.encoding_aes_key,
+            "abc123abc123abc123abc123abc123abc123abc123abc123abc12"
+        );
+        assert_eq!(config.corp_id, "ww1234567890abcdef");
+        assert_eq!(config.corp_secret, "my_corp_secret_value");
+        assert_eq!(config.open_kf_ids, vec!["kf001", "kf002"]);
+        assert_eq!(
+            config.cursor_store_path,
+            Some("/tmp/kf_cursors.json".to_string())
+        );
+    }
+
+    #[test]
+    fn test_deserialize_minimal() {
+        let toml_str = r#"
+            token = "kf_token_xxx"
+            encoding_aes_key = "abc123abc123abc123abc123abc123abc123abc123abc123abc12"
+            corp_id = "ww1234567890abcdef"
+            corp_secret = "my_corp_secret_value"
+        "#;
+
+        let config: WecomKfConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.token, "kf_token_xxx");
+        assert!(config.open_kf_ids.is_empty());
+        assert!(config.cursor_store_path.is_none());
+        assert!(config.metadata.is_empty());
+    }
+
+    #[test]
+    fn test_deserialize_with_metadata() {
+        let toml_str = r#"
+            token = "kf_token_xxx"
+            encoding_aes_key = "abc123abc123abc123abc123abc123abc123abc123abc123abc12"
+            corp_id = "ww1234567890abcdef"
+            corp_secret = "my_corp_secret_value"
+
+            [metadata]
+            source = "wecom_kf"
+            priority = 1
+        "#;
+
+        let config: WecomKfConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.metadata.get("source").and_then(|v| v.as_str()),
+            Some("wecom_kf")
+        );
+        assert_eq!(
+            config.metadata.get("priority").and_then(|v| v.as_i64()),
+            Some(1)
+        );
+    }
+}

--- a/docs/channels/wecomkf.md
+++ b/docs/channels/wecomkf.md
@@ -230,18 +230,19 @@ POST /cgi-bin/kf/send_msg?access_token={token}
 }
 ```
 
-The adapter auto-detects markdown content (same logic as regular WeCom channel).
+The adapter always sends as `"text"` since the KF `send_msg` API does
+not support the `"markdown"` type.
 
 ### Alert Format
 
 Alerts use the recipient format `wecomkf:{open_kfid}:{external_userid}` and
-are sent as markdown with the subject as a level-2 heading:
+are sent as text with the subject prefixed by `## `:
 
 ```json
 {
   "touser": "user123",
   "open_kfid": "kf1234567",
-  "msgtype": "markdown",
+  "msgtype": "text",
   "text": {
     "content": "## Alert Title\n\nAlert body content"
   }

--- a/docs/channels/wecomkf.md
+++ b/docs/channels/wecomkf.md
@@ -1,0 +1,321 @@
+# WeCom KF (Customer Service) Channel
+
+WeCom KF (企业微信客服) channel implementation for JYC, using the **WeCom
+Customer Service API** (`kf/sync_msg`, `kf/send_msg`) for both inbound and
+outbound messaging.
+
+Unlike the regular [WeCom channel](./wecom.md) (which receives direct XML push
+messages via webhook and sends through the external contact API), the KF channel:
+
+- Receives `kf_msg_or_event` event **notifications** via the shared webhook server
+- Pulls actual message content via `kf/sync_msg` API (cursor-based incremental sync)
+- Sends replies via `kf/send_msg` API
+- One thread per customer per KF account
+
+## Architecture
+
+```
+┌─────────────────┐     POST /webhook/{name}      ┌──────────────────────────┐
+│   WeCom Server  │  (kf_msg_or_event event       │   Shared HTTP Server     │
+│   (第三方平台) ──────────────────────────────▶   │   (axum, 127.0.0.1:10001)│
+│                 │      notification with         │                          │
+│                 │      Token + OpenKfId)         └────────┬─────────────────┘
+└─────────────────┘                                        │
+                                                            │ event notification
+                                                            ▼
+                                          ┌────────────────────────────────┐
+                                          │  WecomKfInboundAdapter         │
+                                          │  1. Extract token & open_kfid  │
+                                          │  2. Call sync_msg API          │
+                                          │  3. Dedup by msgid             │
+                                          │  4. Convert to InboundMessage  │
+                                          │  5. Route via MessageRouter    │
+                                          └───────┬────────────┬───────────┘
+                                                   │            │
+                                          ┌────────▼──┐  ┌─────▼──────┐
+                                          │ KfCursor  │  │ KfDedup   │
+                                          │ Store     │  │ Store     │
+                                          └───────────┘  └────────────┘
+
+┌────────────────────────────┐   POST /cgi-bin/kf/send_msg    ┌──────────────────┐
+│  WeCom KF API              │ ◀──── ?access_token=...       │  WecomKfOutbound │
+│  (qyapi.weixin.cn)         │     {"touser": "...", ...}    │  Adapter         │
+└────────────────────────────┘                                └──────────────────┘
+
+┌────────────────────────────┐   POST /cgi-bin/kf/sync_msg    ┌──────────────────┐
+│  WeCom KF API              │ ◀──── ?access_token=...       │  KfApiClient     │
+│  (qyapi.weixin.cn)         │     {"token": "...", ...}     │  (via Inbound)   │
+└────────────────────────────┘                                └──────────────────┘
+
+┌────────────────────────────┐   GET /cgi-bin/gettoken        ┌──────────────────┐
+│  WeCom Token API           │ ◀─── ?corpid=...              │  Token Cache     │
+│  (qyapi.weixin.cn)         │       &corpsecret=...          │  (shared)        │
+└────────────────────────────┘                                └──────────────────┘
+```
+
+### Key Design Decisions
+
+- **Shared HTTP Server**: KF channels share the same `WecomWebhookServer` as
+  regular WeCom channels (configured via `[wecom].bind_addr`). Differentiated
+  by URL path `/webhook/{channel_name}`.
+- **Event-Driven Inbound**: The webhook only delivers event notifications
+  (`kf_msg_or_event`). Actual message content is pulled via the `kf/sync_msg` API.
+- **Cursor-Based Sync**: Uses incremental cursor pagination to avoid re-syncing
+  all historical messages on every notification.
+- **Cursor Persistence**: Cursors are persisted to a JSON file (configurable via
+  `cursor_store_path`). If not configured, cursors are memory-only (lost on
+  restart, but dedup prevents double-processing).
+- **Message Dedup**: In-memory `HashSet` capped at 10,000 entries prevents
+  duplicate processing of overlapping sync results.
+- **One Customer Per Thread**: Thread name is `{channel_name}_{open_kfid}_{external_userid}`,
+  ensuring each customer conversation maps to a dedicated agent thread.
+- **Shared Token Cache**: Uses the same `AccessTokenCache` as the regular WeCom
+  channel, shared between inbound and outbound adapters.
+- **Pattern Reuse**: Pattern matching delegates to `wecom_match_message` —
+  no KF-specific matching rules needed initially.
+
+## Configuration
+
+### Global Server Config
+
+The KF channel reuses the global `[wecom]` HTTP server:
+
+```toml
+[wecom]
+bind_addr = "127.0.0.1:10001"
+```
+
+### Channel Config
+
+```toml
+[channels.my_kf_bot]
+type = "wecomkf"
+
+[channels.my_kf_bot.wecom_kf]
+token = "your_kf_token"
+encoding_aes_key = "your_encoding_aes_key_43bytes"
+corp_id = "ww1234567890abcdef"
+corp_secret = "${WECOM_CORP_SECRET}"
+# Optional: filter by KF account IDs (empty = accept all)
+open_kf_ids = ["kf1234567890"]
+# Optional: cursor persistence file path (JSON)
+# If not set, cursors are memory-only (lost on restart)
+cursor_store_path = "./data/kf_cursors.json"
+
+[[channels.my_kf_bot.patterns]]
+name = "catch_all"
+
+[channels.my_kf_bot.patterns.rules]
+keywords = ["help", "问题"]
+```
+
+### Configuration Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `token` | Yes | Token from WeCom KF callback settings |
+| `encoding_aes_key` | Yes | Base64-encoded AES key (43 chars with `=`) |
+| `corp_id` | Yes | Enterprise ID / Corp ID |
+| `corp_secret` | Yes | Corp secret for access_token (use `${ENV_VAR}` syntax) |
+| `open_kf_ids` | No | List of KF account IDs to process (empty = accept all — planned for future use) |
+| `cursor_store_path` | No | File path for cursor persistence JSON file |
+
+## Webhook Protocol
+
+The KF channel reuses the same webhook infrastructure as the regular WeCom channel.
+
+### URL Verification (GET)
+
+Same as regular WeCom — WeCom sends a GET with `msg_signature`, `timestamp`,
+`nonce`, and `echostr` to verify the URL.
+
+### Event Notification (POST)
+
+WeCom sends a POST request with XML body containing a `kf_msg_or_event` event:
+
+```xml
+<xml>
+  <ToUserName><![CDATA[ww123456]]></ToUserName>
+  <FromUserName><![CDATA[KF_EVENT]]></FromUserName>
+  <CreateTime>1700000000</CreateTime>
+  <MsgType><![CDATA[event]]></MsgType>
+  <Event><![CDATA[kf_msg_or_event]]></Event>
+  <Token><![CDATA[xxxxxx]]></Token>
+  <OpenKfId><![CDATA[kf1234567]]></OpenKfId>
+</xml>
+```
+
+The inbound adapter:
+1. Verifies `MsgType == "event"` (non-event messages are skipped)
+2. Extracts `Token` and `OpenKfId` from the parsed XML
+3. Calls `kf/sync_msg` API with the current cursor to pull new messages
+4. Deduplicates by `msgid`
+5. Converts each message to `InboundMessage` and routes via `MessageRouter`
+
+### Parsed Event Fields
+
+| Field | Source | Description |
+|-------|--------|-------------|
+| `msg_type` | `<MsgType>` | Always `"event"` for KF notifications |
+| `token` | `<Token>` | Token from the event (used for sync_msg API call) |
+| `open_kfid` | `<OpenKfId>` | KF account ID that received the message |
+| `from_user` | `<FromUserName>` | Usually `"KF_EVENT"` for event notifications |
+| `content` | `<Content>` | Empty for event notifications |
+| `chat_id` | `<ChatId>` | Empty for KF events |
+| `msg_id` | `<MsgId>` | Empty for KF events |
+| `create_time` | `<CreateTime>` | Event creation timestamp |
+
+## Inbound: KF Sync Message API
+
+After receiving a `kf_msg_or_event` notification, the inbound adapter calls:
+
+```
+POST /cgi-bin/kf/sync_msg?access_token={token}
+```
+
+### Request Body
+
+```json
+{
+  "token": "xxxxxx",
+  "cursor": "next_cursor_from_previous_sync",
+  "open_kfid": "kf1234567",
+  "limit": 100
+}
+```
+
+### Response
+
+```json
+{
+  "errcode": 0,
+  "errmsg": "ok",
+  "next_cursor": "next_cursor_xyz",
+  "has_more": 1,
+  "msg_list": [
+    {
+      "msgid": "msg_001",
+      "open_kfid": "kf1234567",
+      "external_userid": "user123",
+      "send_time": 1700000000,
+      "msgtype": "text",
+      "text": {
+        "content": "Hello, support!"
+      }
+    }
+  ]
+}
+```
+
+The adapter loops until `has_more` is `0`, saving the cursor after each page.
+
+## Outbound: KF Send Message API
+
+Outbound messages are sent via:
+
+```
+POST /cgi-bin/kf/send_msg?access_token={token}
+```
+
+### Request Body
+
+```json
+{
+  "touser": "user123",
+  "open_kfid": "kf1234567",
+  "msgtype": "text",
+  "text": {
+    "content": "Hello, how can I help you?"
+  }
+}
+```
+
+The adapter auto-detects markdown content (same logic as regular WeCom channel).
+
+### Alert Format
+
+Alerts use the recipient format `wecomkf:{open_kfid}:{external_userid}` and
+are sent as markdown with the subject as a level-2 heading:
+
+```json
+{
+  "touser": "user123",
+  "open_kfid": "kf1234567",
+  "msgtype": "markdown",
+  "text": {
+    "content": "## Alert Title\n\nAlert body content"
+  }
+}
+```
+
+## Thread Naming
+
+Threads are named using the `open_kfid` and `external_userid` fields from
+the synced message metadata:
+
+```
+{channel_name}_{sanitized_open_kfid}_{sanitized_external_userid}
+```
+
+For example, a channel named `my_kf_bot` receiving a message from customer
+`user123` through KF account `kf001` will produce thread name
+`my_kf_bot_kf001_user123`.
+
+This ensures:
+- One thread per customer per KF account
+- Clean isolation between different customers
+- Consistent naming with the rest of the JYC channel ecosystem
+
+## Cursor and Dedup
+
+### Cursor Store
+
+The `KfCursorStore` persists the last sync cursor for each `open_kfid` to
+a JSON file. On startup, cursors are loaded from disk, allowing the adapter
+to resume syncing from where it left off.
+
+When `cursor_store_path` is not configured, cursors are kept in memory only.
+The dedup store prevents double-processing of messages that are re-synced
+after a restart.
+
+### Dedup Store
+
+The `KfDedupStore` maintains an in-memory set of seen `msgid` values,
+capped at 10,000 entries. Older entries are evicted (FIFO) when the
+limit is exceeded.
+
+## Testing
+
+```bash
+# Test KF API client (payload building, response deserialization)
+cargo test -p jyc-channels wecom::kf_client
+
+# Test KF cursor store (get/set/persist/load)
+cargo test -p jyc-channels wecom::kf_cursor
+
+# Test KF dedup store (dedup, eviction)
+cargo test -p jyc-channels wecom::kf_dedup
+
+# Test KF inbound adapter (thread name derivation)
+cargo test -p jyc-channels wecom::kf_inbound
+
+# Test KF outbound adapter (payload building, channel type)
+cargo test -p jyc-channels wecom::kf_outbound
+
+# Test KF config deserialization
+cargo test -p jyc-types wecom_kf_config
+
+# Test extended XML parsing (KF event XML)
+cargo test -p jyc-channels wecom::server
+
+# Run all wecom tests (includes KF)
+cargo test -p jyc-channels wecom
+```
+
+## References
+
+- [WeCom KF Development Guide](https://developer.work.weixin.qq.com/document/path/94677)
+- [WeCom KF sync_msg API](https://developer.work.weixin.qq.com/document/path/94681)
+- [WeCom KF send_msg API](https://developer.work.weixin.qq.com/document/path/94682)
+- [WeCom Callback Protocol](https://developer.work.weixin.qq.com/document/path/90968)
+- [WeCom gettoken API](https://developer.work.weixin.qq.com/document/path/91039)


### PR DESCRIPTION
## Spec

Implement a new `wecomkf` channel type for WeCom Customer Service (微信客服).
Unlike the existing `wecom` channel (which receives direct XML push messages),
the KF channel receives `kf_msg_or_event` event notifications via webhook,
pulls actual message content via `kf/sync_msg` API, and sends replies via `kf/send_msg` API.

Maximizes code reuse from the existing `wecom` module: shares crypto, webhook server,
`AccessTokenCache`, and `parse_decrypted_xml` (extended with `Token`/`OpenKfId` fields).

Fixes #229

## Implementation Plan

### Step 1: Extract `AccessTokenCache` to shared module
**What:** Move `AccessTokenCache` struct (currently in `outbound.rs` lines 37-130) into new file
`crates/jyc-channels/src/wecom/token_cache.rs`. Make it `pub`. Update `outbound.rs` to
`use crate::wecom::token_cache::AccessTokenCache`. Add `pub mod token_cache;` to `mod.rs`.
**Why:** Both existing `WecomOutboundAdapter` and new `WecomKfOutboundAdapter` need token management. Extracting avoids duplication.
**Verify:** `cargo check -p jyc-channels` compiles; `cargo test -p jyc-channels` (existing tests pass).

### Step 2: Add `WecomKfConfig` to jyc-types
**What:** Create new file `crates/jyc-types/src/wecom_kf_config.rs` with:
```rust
pub struct WecomKfConfig {
    pub token: String,
    pub encoding_aes_key: String,
    pub corp_id: String,
    pub corp_secret: String,
    #[serde(default)]
    pub open_kf_ids: Vec<String>,
    #[serde(default)]
    pub cursor_store_path: Option<String>,
    #[serde(default)]
    pub metadata: HashMap<String, serde_json::Value>,
}
```
Add `pub mod wecom_kf_config;` and `pub use wecom_kf_config::*;` to `jyc-types/src/lib.rs`.
Add `wecom_kf: Option<WecomKfConfig>` field to `ChannelConfig` in `config.rs`.
**Why:** KF channel needs its own config struct with KF-specific fields (`open_kf_ids`, `cursor_store_path`).
**Verify:** `cargo check -p jyc-types` compiles; add a unit test for `WecomKfConfig` deserialization from TOML.

### Step 3: Extend `ParsedWecomMessage` and `parse_decrypted_xml`
**What:** In `crates/jyc-channels/src/wecom/server.rs`:
- Add `token: String` and `open_kfid: String` fields to `ParsedWecomMessage` (both default to empty string)
- Change `chat_id` extraction in `parse_decrypted_xml` from `?` (required) to `.unwrap_or_default()` (optional), so event notifications without `ChatId` parse successfully
- Add extraction for `<Token>` and `<OpenKfId>` XML fields in `parse_decrypted_xml`
- The parsed struct can represent both regular messages and KF events (KF events have `MsgType=="event"`, empty `Content`/`ChatId`/`MsgId`)
**Why:** The same `parse_decrypted_xml` needs to handle both regular wecom messages and KF event notifications. KF events have `Token` and `OpenKfId` but no `Content`/`ChatId`/`MsgId`.
**Verify:** `cargo test -p jyc-channels` (existing XML parsing tests pass); add new tests for KF event XML parsing.

### Step 4: Implement `KfApiClient` (kf_client.rs)
**What:** Create `crates/jyc-channels/src/wecom/kf_client.rs` with:
```rust
pub struct KfApiClient {
    access_token_cache: Arc<AccessTokenCache>,
    client: reqwest::Client,
}
impl KfApiClient {
    pub fn new(access_token_cache: Arc<AccessTokenCache>) -> Self;
    pub async fn sync_messages(&self, token: &str, cursor: &str, open_kfid: &str, limit: u32) -> Result<KfSyncResponse>;
    pub async fn send_message(&self, open_kfid: &str, touser: &str, msgtype: &str, content: &str) -> Result<()>;
}
```
Define `KfSyncResponse` with `errcode`, `errmsg`, `next_cursor`, `has_more`, `msg_list: Vec<KfMessage>`.
Define `KfMessage` with `msgid`, `open_kfid`, `external_userid`, `send_time`, `msgtype`, `text.content`.
**Why:** KF-specific APIs (`sync_msg` to pull messages, `send_msg` to reply) are different from the external contact API used by regular wecom.
**Verify:** `cargo check -p jyc-channels`; add unit tests for `build_sync_request` / `build_send_payload` (no live HTTP).

### Step 5: Implement `KfCursorStore` (kf_cursor.rs)
**What:** Create `crates/jyc-channels/src/wecom/kf_cursor.rs` with:
```rust
pub struct KfCursorStore {
    cursors: RwLock<HashMap<String, String>>, // key: open_kfid, value: cursor
    persist_path: Option<PathBuf>,
}
impl KfCursorStore {
    pub fn new(persist_path: Option<PathBuf>) -> Self;
    pub async fn get_cursor(&self, open_kfid: &str) -> Option<String>;
    pub async fn set_cursor(&self, open_kfid: &str, cursor: String);
    async fn load_from_disk(&self) -> Result<()>;
    async fn save_to_disk(&self) -> Result<()>;
}
```
**Why:** KF sync uses cursor-based incremental pagination. Cursors must persist across restarts to avoid re-syncing all historical messages.
**Verify:** `cargo test -p jyc-channels` — test cursor get/set/load/save with `tempfile::TempDir`.

### Step 6: Implement `KfDedupStore` (kf_dedup.rs)
**What:** Create `crates/jyc-channels/src/wecom/kf_dedup.rs` with:
```rust
pub struct KfDedupStore {
    seen: RwLock<HashSet<String>>, // dedup by msgid
}
impl KfDedupStore {
    pub fn new() -> Self;
    pub fn is_duplicate(&self, msgid: &str) -> bool;
    pub fn mark_seen(&self, msgid: &str);
    fn maybe_compact(&self); // keep last 10,000 entries
}
```
**Why:** KF `sync_msg` may return overlapping messages across syncs. Dedup by `msgid` prevents duplicate processing.
**Verify:** `cargo test -p jyc-channels` — test basic dedup and compaction behavior.

### Step 7: Implement `WecomKfInboundAdapter` (kf_inbound.rs)
**What:** Create `crates/jyc-channels/src/wecom/kf_inbound.rs` implementing `InboundAdapter` + `ChannelMatcher`:
- `WecomKfInboundAdapter::new(config: &WecomKfConfig, channel_name: &str, server: Arc<WecomWebhookServer>)`
- Register webhook handler via shared `WecomWebhookServer` using `ChannelWebhookConfig`
- In the `on_message` callback (triggered by webhook POST):
  1. Check `parsed.msg_type == "event"` → proceed, otherwise log warning and skip
  2. Extract `token` and `open_kfid` from parsed fields
  3. Call `KfApiClient.sync_messages(token, cursor, open_kfid, 100)`
  4. For each `KfMessage` not dedup'd (`KfDedupStore.is_duplicate`):
     - Convert to `InboundMessage` (metadata: `open_kfid`, `external_userid`, `msgid`, `token`, `channel_name`)
     - Call `on_message` callback
  5. If `has_more`, loop with `next_cursor`
  6. Save new cursor via `KfCursorStore.set_cursor`
- `derive_thread_name`: return `{channel_name}_{sanitized_open_kfid}_{sanitized_external_userid}`
- `match_message`: delegate to shared `wecom_match_message` (reuse existing wecom inbound matcher logic)
- `channel_type`: return `"wecomkf"`
**Why:** The core inbound logic — webhook notification → API pull → dedup → route. This is the most complex component.
**Verify:** `cargo check -p jyc-channels`; add unit test for `derive_thread_name`.

### Step 8: Implement `WecomKfOutboundAdapter` (kf_outbound.rs)
**What:** Create `crates/jyc-channels/src/wecom/kf_outbound.rs` implementing `OutboundAdapter`:
```rust
pub struct WecomKfOutboundAdapter {
    kf_client: Arc<KfApiClient>,
    storage: Arc<MessageStorage>,
    footer_enabled: bool,
}
```
- `send_reply()`: Extract `open_kfid` and `external_userid` from `original.metadata`, call `KfApiClient.send_message(open_kfid, external_userid, msgtype, content)`
- `send_alert()`: Same as send_reply but with alert-appropriate formatting
- `connect()`: Verify token via `AccessTokenCache.get_token()`
- `disconnect()`: No-op
- `clean_body()`: Identity (no quoting to strip)
- `channel_type()`: return `"wecomkf"`
**Why:** KF outbound uses `kf/send_msg` API (different endpoint and payload structure from the external contact API).
**Verify:** `cargo check -p jyc-channels`; add unit test for payload building.

### Step 9: Update `wecom/mod.rs` exports
**What:** Add to `crates/jyc-channels/src/wecom/mod.rs`:
```rust
pub mod token_cache;
pub mod kf_client;
pub mod kf_cursor;
pub mod kf_dedup;
pub mod kf_inbound;
pub mod kf_outbound;
```
**Verify:** `cargo check -p jyc-channels`.

### Step 10: Wire up `wecomkf` in `monitor.rs`
**What:** In `crates/jyc-cli/src/cli/monitor.rs`:
- Update `has_wecom` check (line 89-93) to also match `"wecomkf"`: `|c| c.channel_type == "wecom" || c.channel_type == "wecomkf"`
- Add imports for `WecomKfInboundAdapter`, `WecomKfOutboundAdapter`, `WecomKfConfig`
- Add match arm `"wecomkf"` (after the `"wecom"` arm, around line 699):
  - Extract `channel_config.wecom_kf` config
  - Create `WecomKfOutboundAdapter` (reuses extracted `AccessTokenCache`)
  - Create `WecomKfInboundAdapter` with shared `WecomWebhookServer`
  - Wire `on_message` to router via `WecomKfInboundAdapter`'s `ChannelMatcher` impl
**Why:** The monitor is the entry point that instantiates channel adapters. Must handle the new channel type.
**Verify:** `cargo check` (workspace).

### Step 11: Update `config.example.toml` with KF example
**What:** Add commented-out wecomkf configuration example to `config.example.toml`, following the existing wecom example pattern. Include all fields: `token`, `encoding_aes_key`, `corp_id`, `corp_secret`, optional `open_kf_ids` and `cursor_store_path`, plus sample patterns.
**Why:** Documentation requirement per AGENTS.md (new config items → update config.example.toml).
**Verify:** `cargo check`; visually inspect config.example.toml for completeness.

### Step 12: Final validation
**What:** Run the full PR checklist:
```bash
cargo fmt && cargo fmt --check
cargo clippy --workspace -- -D warnings
cargo test --workspace
```
**Why:** All PRs must pass formatting, clippy, and tests before review.
**Verify:** All three commands exit with status 0.

## Design Decisions

- **Thread naming:** `{channel_name}_{sanitized_open_kfid}_{sanitized_external_userid}` — one thread per customer per KF account, mirroring wecom's `{channel_name}_{chat_id}` pattern.
- **Cursor persistence:** File-based JSON (`cursor_store_path` in config). If path is `None`, fall back to memory-only (cursors lost on restart, but dedup prevents double-processing).
- **Deduplication:** In-memory `HashSet<String>` with 10,000-entry cap. Memory-only (persistent dedup not needed since cursor prevents most re-syncs).
- **Shared webhook server:** `wecomkf` channels share the same `WecomWebhookServer` as `wecom` channels (same `[wecom].bind_addr`). Differentiated by URL path `/webhook/{channel_name}`.
- **Pattern matching:** Reuses `wecom_match_message` (keywords, sender rules) — no KF-specific matching rules needed initially.
- **`open_kf_ids` filtering:** Config field stored but not used as a hard filter initially. All KF messages are processed; routing is handled by patterns.
