### PR TITLE
fix: restore WeCom crypto fixes from local stash

### DIFF
--- a/crates/jyc-channels/src/wecom/crypto.rs
+++ b/crates/jyc-channels/src/wecom/crypto.rs
@@ -6,16 +6,29 @@
 //!
 //! Reference: https://developer.work.weixin.qq.com/document/path/90968
 
-use aes::cipher::{BlockDecryptMut, KeyIvInit, block_padding::Pkcs7};
+use aes::cipher::{BlockDecryptMut, KeyIvInit};
 use anyhow::{Context, Result};
+use base64::{Engine, alphabet, engine::GeneralPurpose};
 use sha1::{Digest, Sha1};
+
+/// Permissive base64 engine that allows non-zero trailing bits.
+///
+/// WeCom's EncodingAESKey may have non-zero trailing bits in base64 padding,
+/// which the standard strict decoder rejects. This engine accepts them.
+static PERMISSIVE_BASE64: GeneralPurpose = GeneralPurpose::new(
+    &alphabet::STANDARD,
+    base64::engine::GeneralPurposeConfig::new().with_decode_allow_trailing_bits(true),
+);
 
 type Aes256CbcDec = cbc::Decryptor<aes::Aes256>;
 
 /// Verify the callback signature.
 ///
-/// The signature is computed as SHA1(token || timestamp || nonce || encrypt).
+/// The signature is computed as SHA1(sorted(token, timestamp, nonce, encrypt)).
+/// The four parameters are sorted lexicographically before concatenation.
 /// Returns `true` if the computed signature matches the provided one.
+///
+/// Reference: <https://developer.work.weixin.qq.com/document/path/90968>
 pub fn verify_signature(
     token: &str,
     timestamp: &str,
@@ -23,11 +36,13 @@ pub fn verify_signature(
     encrypt: &str,
     msg_signature: &str,
 ) -> bool {
+    let mut params = [token, timestamp, nonce, encrypt];
+    params.sort_unstable();
+
     let mut hasher = Sha1::new();
-    hasher.update(token.as_bytes());
-    hasher.update(timestamp.as_bytes());
-    hasher.update(nonce.as_bytes());
-    hasher.update(encrypt.as_bytes());
+    for param in &params {
+        hasher.update(param.as_bytes());
+    }
     let computed = hex::encode(hasher.finalize());
     computed == msg_signature
 }
@@ -35,63 +50,96 @@ pub fn verify_signature(
 /// Decrypt AES-256-CBC encrypted message with PKCS7 padding.
 ///
 /// The raw key is the Base64-decoded `encoding_aes_key` (with "=" padding).
-/// The AES key is the first 32 bytes of the decoded key.
-/// The IV is the last 16 bytes of the decoded key (after first 32 bytes).
+/// The AES key is all 32 bytes of the decoded key.
+/// The IV is the first 16 bytes of the decoded key.
 ///
 /// The decrypted plaintext format is:
 /// ```text
-/// [4-byte network byte order content length][content][receiveid (corpid)]
+/// [16-byte random][4-byte network byte order content length][content][receiveid (corpid)]
 /// [padding]
 /// ```
 ///
 /// Returns the decrypted content string (the inner XML).
 pub fn decrypt_msg(encoding_aes_key: &str, encrypt: &str) -> Result<String> {
-    let raw_key =
-        base64::Engine::decode(&base64::engine::general_purpose::STANDARD, encoding_aes_key)
-            .context("failed to decode encoding_aes_key from base64")?;
+    // Trim whitespace (including newlines) that may sneak in from env vars
+    let encoding_aes_key = encoding_aes_key.trim();
 
-    if raw_key.len() != 43 {
+    if encoding_aes_key.is_empty() {
         anyhow::bail!(
-            "encoding_aes_key decoded length is {}, expected 43 bytes",
+            "encoding_aes_key is empty (check config: if using ${{VAR}} syntax, ensure the environment variable is set)"
+        );
+    }
+
+    // WeCom's encoding_aes_key is 43 chars with trailing '=' padding removed.
+    // Re-add padding so standard base64 decoding works.
+    let padded_key = match encoding_aes_key.len() % 4 {
+        0 => encoding_aes_key.to_string(),
+        n => format!("{}{}", encoding_aes_key, "=".repeat(4 - n)),
+    };
+
+    let raw_key = PERMISSIVE_BASE64.decode(&padded_key)
+    .with_context(|| {
+        format!(
+            "failed to decode encoding_aes_key from base64 (len={}, padded_len={}, has_non_ascii={:?})",
+            encoding_aes_key.len(),
+            padded_key.len(),
+            encoding_aes_key.bytes().any(|b| !b.is_ascii_alphanumeric()),
+        )
+    })?;
+
+    if raw_key.len() != 32 {
+        anyhow::bail!(
+            "encoding_aes_key decoded length is {}, expected 32 bytes (AES-256 key)",
             raw_key.len()
         );
     }
 
-    // The AES key is the first 32 bytes of the decoded encoding_aes_key
+    // The AES key is all 32 bytes of the decoded encoding_aes_key
     let aes_key = &raw_key[..32];
-    // The IV is the last 16 bytes (bytes 32..48, but raw_key is only 43 bytes;
-    // WeCom spec says the key is Base64-decoded to 43 bytes, of which:
-    // - first 32 bytes = AES key
-    // - remaining 11 bytes + 5 zero bytes = IV
-    let iv_partial = &raw_key[32..43];
+    // IV is the first 16 bytes of the AES key, per WeCom spec
     let mut iv = [0u8; 16];
-    iv[..iv_partial.len()].copy_from_slice(iv_partial);
+    iv.copy_from_slice(&raw_key[..16]);
 
-    let ciphertext = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, encrypt)
+    let ciphertext = PERMISSIVE_BASE64
+        .decode(encrypt)
         .context("failed to decode encrypt from base64")?;
 
     let mut buf = ciphertext;
     let decrypted = Aes256CbcDec::new(aes_key.into(), &iv.into())
-        .decrypt_padded_mut::<Pkcs7>(&mut buf)
+        .decrypt_padded_mut::<aes::cipher::block_padding::NoPadding>(&mut buf)
         .map_err(|e| anyhow::anyhow!("AES decryption failed: {:?}", e))?;
 
-    // Parse: [4-byte content length (network byte order)][content][receiveid]
-    if decrypted.len() < 4 {
+    // WeCom uses PKCS#7 with block_size=32 (not the AES block size of 16).
+    // Manual unpadding required.
+    let pad_len = decrypted.last().copied().unwrap_or(0) as usize;
+    if pad_len == 0 || pad_len > 32 {
+        anyhow::bail!("invalid PKCS#7 padding length: {}", pad_len);
+    }
+    if !decrypted[decrypted.len() - pad_len..]
+        .iter()
+        .all(|&b| b == pad_len as u8)
+    {
+        anyhow::bail!("invalid PKCS#7 padding bytes");
+    }
+    let decrypted = &decrypted[..decrypted.len() - pad_len];
+
+    // Parse: [16-byte random][4-byte content length (network byte order)][content][receiveid]
+    if decrypted.len() < 16 + 4 {
         anyhow::bail!("decrypted content too short: {} bytes", decrypted.len());
     }
 
     let content_len =
-        u32::from_be_bytes([decrypted[0], decrypted[1], decrypted[2], decrypted[3]]) as usize;
+        u32::from_be_bytes([decrypted[16], decrypted[17], decrypted[18], decrypted[19]]) as usize;
 
-    if decrypted.len() < 4 + content_len {
+    if decrypted.len() < 16 + 4 + content_len {
         anyhow::bail!(
             "decrypted content length mismatch: header says {} but remaining is {}",
             content_len,
-            decrypted.len() - 4
+            decrypted.len() - 16 - 4
         );
     }
 
-    let content = &decrypted[4..4 + content_len];
+    let content = &decrypted[16 + 4..16 + 4 + content_len];
     let content_str =
         String::from_utf8(content.to_vec()).context("decrypted content is not valid UTF-8")?;
 
@@ -137,11 +185,13 @@ mod tests {
     }
 
     fn compute_signature(token: &str, timestamp: &str, nonce: &str, encrypt: &str) -> String {
+        let mut params = [token, timestamp, nonce, encrypt];
+        params.sort_unstable();
+
         let mut hasher = Sha1::new();
-        hasher.update(token.as_bytes());
-        hasher.update(timestamp.as_bytes());
-        hasher.update(nonce.as_bytes());
-        hasher.update(encrypt.as_bytes());
+        for param in &params {
+            hasher.update(param.as_bytes());
+        }
         hex::encode(hasher.finalize())
     }
 


### PR DESCRIPTION
## Problem

PR #230 introduced the  channel but **lost all crypto fixes** that were previously working in local stash. This broke both  and  webhook reception.

## Fixes Restored

1. **Signature verification**: add lexicographic sort before SHA1 per WeCom spec. Without this all callbacks fail with "signature mismatch".

2. **Base64 padding**: WeCom's EncodingAESKey is 43 chars (trailing  removed). Re-add padding before decoding.

3. **Permissive base64**: Use  with  to accept WeCom's non-zero trailing bits.

4. **Key length check**: 43 bytes was wrong; decoded key is 32 bytes (AES-256).

5. **IV extraction**:  was wrong; IV is  per WeCom spec.

6. **16-byte random prefix**: Decrypted plaintext starts with a 16-byte random block before the 4-byte length header.

7. **PKCS7 block_size=32**: WeCom uses 32-byte blocks, not standard AES 16-byte blocks. Manual unpadding required.

## Verification

- [x] 
- [x] 
- [x] 
running 85 tests
test wecom::crypto::tests::test_decrypt_invalid_encrypt ... ok
test wecom::crypto::tests::test_decrypt_short_key ... ok
test wecom::crypto::tests::test_generate_nonce_is_non_empty ... ok
test wecom::crypto::tests::test_generate_nonce_unique ... ok
test wecom::crypto::tests::test_signature_different_order_fails ... ok
test wecom::crypto::tests::test_signature_verification ... ok
test wecom::inbound::tests::test_adapter_derive_thread_name_matches_matcher ... ok
test wecom::inbound::tests::test_channel_type ... ok
test wecom::inbound::tests::test_derive_thread_name_empty_chat_id_fallback ... ok
test wecom::inbound::tests::test_derive_thread_name_fallback ... ok
test wecom::inbound::tests::test_derive_thread_name_from_chat_id ... ok
test wecom::inbound::tests::test_derive_thread_name_from_chat_id_without_channel_name ... ok
test wecom::inbound::tests::test_disabled_pattern_ignored ... ok
test wecom::inbound::tests::test_empty_rules_matches_all ... ok
test wecom::inbound::tests::test_keywords_and_sender_and ... ok
test wecom::inbound::tests::test_keywords_and_sender_no_match ... ok
test wecom::inbound::tests::test_match_by_keywords ... ok
test wecom::inbound::tests::test_match_by_sender ... ok
test wecom::inbound::tests::test_match_keywords_case_insensitive ... ok
test wecom::inbound::tests::test_no_match_wrong_keywords ... ok
test wecom::inbound::tests::test_no_match_wrong_sender ... ok
test wecom::kf_client::tests::test_build_send_payload ... ok
test wecom::kf_client::tests::test_build_send_payload_markdown ... ok
test wecom::kf_client::tests::test_build_sync_request ... ok
test wecom::kf_client::tests::test_build_sync_request_empty_cursor ... ok
test wecom::kf_client::tests::test_kf_sync_response_deserialize ... ok
test wecom::kf_client::tests::test_kf_sync_response_empty_msg_list ... ok
test wecom::kf_client::tests::test_kf_sync_response_error ... ok
test wecom::kf_client::tests::test_kf_sync_response_missing_fields ... ok
test wecom::kf_cursor::tests::test_cursor_for_different_open_kfid ... ok
test wecom::kf_cursor::tests::test_cursor_get_set ... ok
test wecom::kf_cursor::tests::test_cursor_multiple_kf_accounts ... ok
test wecom::kf_cursor::tests::test_cursor_overwrite ... ok
test wecom::kf_cursor::tests::test_flush_to_disk_noop_without_persist_path ... ok
test wecom::kf_cursor::tests::test_flush_to_disk_not_dirty ... ok
test wecom::crypto::tests::test_decrypt_invalid_key ... ok
test wecom::kf_cursor::tests::test_persist_and_load ... ok
test wecom::kf_cursor::tests::test_persist_path_none ... ok
test wecom::kf_dedup::tests::test_duplicate_mark_is_idempotent ... ok
test wecom::kf_cursor::tests::test_persist_empty_store ... ok
test wecom::kf_dedup::tests::test_eviction_keeps_most_recent ... ok
test wecom::kf_dedup::tests::test_mark_and_check_duplicate ... ok
test wecom::kf_dedup::tests::test_eviction_when_max_entries_exceeded ... ok
test wecom::kf_dedup::tests::test_new_instance_does_not_share_state ... ok
test wecom::kf_dedup::tests::test_new_store_empty ... ok
test wecom::kf_dedup::tests::test_multiple_messages ... ok
test wecom::kf_inbound::tests::test_channel_type ... ok
test wecom::kf_inbound::tests::test_derive_thread_name ... ok
test wecom::kf_inbound::tests::test_kf_message_to_inbound ... ok
test wecom::kf_inbound::tests::test_kf_message_to_inbound_no_text ... ok
test wecom::kf_outbound::tests::test_build_payload_markdown ... ok
test wecom::kf_outbound::tests::test_build_payload_markdown_with_code_block ... ok
test wecom::kf_outbound::tests::test_build_payload_missing_fields ... ok
test wecom::kf_outbound::tests::test_build_payload_text ... ok
test wecom::kf_inbound::tests::test_derive_thread_name_missing_fields ... ok
test wecom::kf_outbound::tests::test_channel_type ... ok
test wecom::outbound::tests::test_access_token_cache_creation ... ok
test wecom::outbound::tests::test_build_alert_payload ... ok
test wecom::outbound::tests::test_build_alert_payload_empty_chat_id ... ok
test wecom::outbound::tests::test_build_payload_empty_chat_id ... ok
test wecom::outbound::tests::test_build_payload_markdown ... ok
test wecom::outbound::tests::test_build_payload_markdown_with_code_block ... ok
test wecom::outbound::tests::test_build_payload_markdown_with_table ... ok
test wecom::outbound::tests::test_build_payload_text ... ok
test wecom::kf_outbound::tests::test_clean_body ... ok
test wecom::outbound::tests::test_channel_type ... ok
test wecom::server::tests::test_callback_query_deserialize ... ok
test wecom::server::tests::test_callback_query_no_echostr ... ok
test wecom::server::tests::test_extract_encrypt_from_xml ... ok
test wecom::server::tests::test_extract_encrypt_from_xml_empty ... ok
test wecom::server::tests::test_extract_encrypt_from_xml_missing ... ok
test wecom::server::tests::test_extract_xml_field_cdata ... ok
test wecom::server::tests::test_extract_xml_field_not_found ... ok
test wecom::server::tests::test_extract_xml_field_plain ... ok
test wecom::server::tests::test_parse_decrypted_xml_empty_content ... ok
test wecom::server::tests::test_parse_decrypted_xml_full ... ok
test wecom::server::tests::test_parse_decrypted_xml_missing_chat_id ... ok
test wecom::server::tests::test_parse_decrypted_xml_missing_content_optional ... ok
test wecom::server::tests::test_parse_decrypted_xml_missing_from_user ... ok
test wecom::server::tests::test_parse_kf_event_missing_open_kfid ... ok
test wecom::server::tests::test_parse_kf_event_missing_token ... ok
test wecom::server::tests::test_parse_kf_event_xml ... ok
test wecom::server::tests::test_parse_regular_message_still_works ... ok
test wecom::server::tests::test_webhook_route_matches_registered_channel ... ok
test wecom::outbound::tests::test_clean_body ... ok

test result: ok. 85 passed; 0 failed; 0 ignored; 0 measured; 189 filtered out; finished in 1.52s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s (85 tests pass)

Refs: PR #230