### PR TITLE
fix: use stable external_userid prefix for wecomkf thread names

### DIFF
--- a/crates/jyc-channels/src/wecom/kf_inbound.rs
+++ b/crates/jyc-channels/src/wecom/kf_inbound.rs
@@ -234,23 +234,12 @@ fn handle_kf_event(
 
 /// Shared helper to derive a KF thread name from message metadata.
 ///
-/// Format: `{channel_name}_{sanitized_open_kfid}_{sanitized_external_userid}`
-/// One thread per customer per KF account.
-fn wecomkf_derive_thread_name(message: &InboundMessage, default_channel: &str) -> String {
-    let channel_name = message
-        .metadata
-        .get("channel_name")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .unwrap_or(default_channel);
-
-    let open_kfid = message
-        .metadata
-        .get("open_kfid")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .unwrap_or("unknown_kf");
-
+/// Format: `{sanitized_external_userid_prefix}`
+/// One thread per customer (regardless of which KF account they contact).
+///
+/// WeCom's `external_userid` may contain a variable suffix (session-specific),
+/// so we use only the first 12 chars as the stable customer identifier.
+fn wecomkf_derive_thread_name(message: &InboundMessage, _default_channel: &str) -> String {
     let external_userid = message
         .metadata
         .get("external_userid")
@@ -258,12 +247,15 @@ fn wecomkf_derive_thread_name(message: &InboundMessage, default_channel: &str) -
         .filter(|s| !s.is_empty())
         .unwrap_or("unknown_user");
 
-    format!(
-        "{}_{}_{}",
-        sanitize_for_filesystem(channel_name),
-        sanitize_for_filesystem(open_kfid),
-        sanitize_for_filesystem(external_userid),
-    )
+    // Use first 10 chars of external_userid as stable customer identifier.
+    // WeCom's external_userid has a stable prefix (~10 chars) + variable suffix.
+    let stable_user_id = if external_userid.len() > 10 {
+        &external_userid[..10]
+    } else {
+        external_userid
+    };
+
+    sanitize_for_filesystem(stable_user_id)
 }
 
 impl ChannelMatcher for WecomKfInboundAdapter {
@@ -451,7 +443,44 @@ mod tests {
         };
 
         let name = adapter.derive_thread_name(&message, &[], None);
-        assert_eq!(name, "my_kf_bot_kf001_user123");
+        // external_userid "user123" is < 12 chars, so full value is used
+        assert_eq!(name, "user123");
+    }
+
+    #[test]
+    fn test_derive_thread_name_stable_prefix() {
+        // WeCom external_userid has stable prefix + variable suffix
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "external_userid".to_string(),
+            serde_json::Value::String("wmE8OcHAAA358dWFTX0hH4C_bjM15KSQ".to_string()),
+        );
+
+        let message = InboundMessage {
+            id: "test".to_string(),
+            channel: "wecomkf".to_string(),
+            channel_uid: "test_uid".to_string(),
+            sender: "user".to_string(),
+            sender_address: "wecomkf:user".to_string(),
+            recipients: vec![],
+            topic: "Test".to_string(),
+            content: MessageContent {
+                text: Some("Hello".to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: Some("msg_001".to_string()),
+            attachments: vec![],
+            metadata,
+            matched_pattern: None,
+        };
+
+        let name = wecomkf_derive_thread_name(&message, "my_kf_bot");
+        // First 10 chars of "wmE8OcHAAA358dWFTX0hH4C_bjM15KSQ"
+        assert_eq!(name, "wmE8OcHAAA");
     }
 
     #[test]
@@ -507,8 +536,9 @@ mod tests {
         };
 
         let name = adapter.derive_thread_name(&message, &[], None);
-        // Falls back to channel_name + unknown_kf + unknown_user
-        assert!(name.contains("my_kf_bot"));
+        // Falls back to "unknown_user" when external_userid is missing,
+        // truncated to first 10 chars
+        assert_eq!(name, "unknown_us");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

WeCom's  contains a variable suffix that changes across messages from the same customer, causing each message to create a new thread. This breaks conversation continuity.

Example from logs:
- Message 1:  = 
- Message 2:  = 

Same customer, different suffix → different thread names.

## Fix

- Extract the first 10 chars of  as the stable customer identifier for thread naming
- Removed  and  from the thread name so each customer gets exactly one thread
- This matches the behavior of the regular  channel (which uses  as the thread identifier)

## Verification

- [x] 
- [x] 
- [x] 
running 86 tests
test wecom::crypto::tests::test_decrypt_invalid_key ... ok
test wecom::crypto::tests::test_decrypt_short_key ... ok
test wecom::crypto::tests::test_generate_nonce_is_non_empty ... ok
test wecom::crypto::tests::test_generate_nonce_unique ... ok
test wecom::crypto::tests::test_signature_different_order_fails ... ok
test wecom::crypto::tests::test_signature_verification ... ok
test wecom::inbound::tests::test_adapter_derive_thread_name_matches_matcher ... ok
test wecom::inbound::tests::test_channel_type ... ok
test wecom::inbound::tests::test_derive_thread_name_empty_chat_id_fallback ... ok
test wecom::inbound::tests::test_derive_thread_name_fallback ... ok
test wecom::inbound::tests::test_derive_thread_name_from_chat_id ... ok
test wecom::inbound::tests::test_derive_thread_name_from_chat_id_without_channel_name ... ok
test wecom::inbound::tests::test_disabled_pattern_ignored ... ok
test wecom::inbound::tests::test_empty_rules_matches_all ... ok
test wecom::inbound::tests::test_keywords_and_sender_and ... ok
test wecom::inbound::tests::test_keywords_and_sender_no_match ... ok
test wecom::inbound::tests::test_match_by_keywords ... ok
test wecom::inbound::tests::test_match_by_sender ... ok
test wecom::inbound::tests::test_match_keywords_case_insensitive ... ok
test wecom::inbound::tests::test_no_match_wrong_keywords ... ok
test wecom::inbound::tests::test_no_match_wrong_sender ... ok
test wecom::kf_client::tests::test_build_send_payload ... ok
test wecom::kf_client::tests::test_build_send_payload_markdown ... ok
test wecom::kf_client::tests::test_build_sync_request ... ok
test wecom::kf_client::tests::test_build_sync_request_empty_cursor ... ok
test wecom::kf_client::tests::test_kf_sync_response_deserialize ... ok
test wecom::kf_client::tests::test_kf_sync_response_empty_msg_list ... ok
test wecom::kf_client::tests::test_kf_sync_response_error ... ok
test wecom::kf_client::tests::test_kf_sync_response_missing_fields ... ok
test wecom::kf_cursor::tests::test_cursor_for_different_open_kfid ... ok
test wecom::kf_cursor::tests::test_cursor_get_set ... ok
test wecom::kf_cursor::tests::test_cursor_multiple_kf_accounts ... ok
test wecom::kf_cursor::tests::test_cursor_overwrite ... ok
test wecom::kf_cursor::tests::test_flush_to_disk_noop_without_persist_path ... ok
test wecom::kf_cursor::tests::test_flush_to_disk_not_dirty ... ok
test wecom::crypto::tests::test_decrypt_invalid_encrypt ... ok
test wecom::kf_cursor::tests::test_persist_empty_store ... ok
test wecom::kf_cursor::tests::test_persist_path_none ... ok
test wecom::kf_dedup::tests::test_duplicate_mark_is_idempotent ... ok
test wecom::kf_cursor::tests::test_persist_and_load ... ok
test wecom::kf_dedup::tests::test_eviction_when_max_entries_exceeded ... ok
test wecom::kf_dedup::tests::test_mark_and_check_duplicate ... ok
test wecom::kf_dedup::tests::test_multiple_messages ... ok
test wecom::kf_dedup::tests::test_new_instance_does_not_share_state ... ok
test wecom::kf_dedup::tests::test_new_store_empty ... ok
test wecom::kf_dedup::tests::test_eviction_keeps_most_recent ... ok
test wecom::kf_inbound::tests::test_channel_type ... ok
test wecom::kf_inbound::tests::test_derive_thread_name ... ok
test wecom::kf_inbound::tests::test_derive_thread_name_stable_prefix ... ok
test wecom::kf_inbound::tests::test_kf_message_to_inbound ... ok
test wecom::kf_inbound::tests::test_kf_message_to_inbound_no_text ... ok
test wecom::kf_outbound::tests::test_build_payload_markdown ... ok
test wecom::kf_outbound::tests::test_build_payload_markdown_with_code_block ... ok
test wecom::kf_outbound::tests::test_build_payload_missing_fields ... ok
test wecom::kf_outbound::tests::test_build_payload_text ... ok
test wecom::kf_outbound::tests::test_channel_type ... ok
test wecom::kf_inbound::tests::test_derive_thread_name_missing_fields ... ok
test wecom::outbound::tests::test_access_token_cache_creation ... ok
test wecom::outbound::tests::test_build_alert_payload ... ok
test wecom::outbound::tests::test_build_alert_payload_empty_chat_id ... ok
test wecom::outbound::tests::test_build_payload_empty_chat_id ... ok
test wecom::outbound::tests::test_build_payload_markdown ... ok
test wecom::outbound::tests::test_build_payload_markdown_with_code_block ... ok
test wecom::outbound::tests::test_build_payload_markdown_with_table ... ok
test wecom::outbound::tests::test_build_payload_text ... ok
test wecom::kf_outbound::tests::test_clean_body ... ok
test wecom::outbound::tests::test_clean_body ... ok
test wecom::server::tests::test_callback_query_deserialize ... ok
test wecom::server::tests::test_callback_query_no_echostr ... ok
test wecom::server::tests::test_extract_encrypt_from_xml ... ok
test wecom::server::tests::test_extract_encrypt_from_xml_empty ... ok
test wecom::server::tests::test_extract_encrypt_from_xml_missing ... ok
test wecom::server::tests::test_extract_xml_field_cdata ... ok
test wecom::server::tests::test_extract_xml_field_not_found ... ok
test wecom::server::tests::test_extract_xml_field_plain ... ok
test wecom::server::tests::test_parse_decrypted_xml_empty_content ... ok
test wecom::server::tests::test_parse_decrypted_xml_full ... ok
test wecom::server::tests::test_parse_decrypted_xml_missing_chat_id ... ok
test wecom::server::tests::test_parse_decrypted_xml_missing_content_optional ... ok
test wecom::server::tests::test_parse_decrypted_xml_missing_from_user ... ok
test wecom::server::tests::test_parse_kf_event_missing_open_kfid ... ok
test wecom::server::tests::test_parse_kf_event_missing_token ... ok
test wecom::server::tests::test_parse_kf_event_xml ... ok
test wecom::server::tests::test_parse_regular_message_still_works ... ok
test wecom::server::tests::test_webhook_route_matches_registered_channel ... ok
test wecom::outbound::tests::test_channel_type ... ok

test result: ok. 86 passed; 0 failed; 0 ignored; 0 measured; 189 filtered out; finished in 1.50s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s (86 tests pass)

Refs: PR #230