### PR TITLE
fix: correct store_reply parameter order and filter empty external_userid

### DIFF
--- a/crates/jyc-channels/src/wecom/kf_inbound.rs
+++ b/crates/jyc-channels/src/wecom/kf_inbound.rs
@@ -172,6 +172,24 @@ fn handle_kf_event(
             {
                 Ok(response) => {
                     for msg in &response.msg_list {
+                        tracing::debug!(
+                            msgid = %msg.msgid,
+                            msgtype = %msg.msgtype,
+                            external_userid = %msg.external_userid,
+                            open_kfid = %msg.open_kfid,
+                            "WeCom KF inbound: received message from sync_msg"
+                        );
+
+                        // Skip messages without external_userid (system messages, etc.)
+                        if msg.external_userid.is_empty() {
+                            tracing::debug!(
+                                msgid = %msg.msgid,
+                                msgtype = %msg.msgtype,
+                                "WeCom KF inbound: skipping message with empty external_userid"
+                            );
+                            continue;
+                        }
+
                         // Dedup check
                         if dedup_store.is_duplicate(&msg.msgid) {
                             tracing::debug!(

--- a/crates/jyc-channels/src/wecom/kf_outbound.rs
+++ b/crates/jyc-channels/src/wecom/kf_outbound.rs
@@ -128,7 +128,7 @@ impl OutboundAdapter for WecomKfOutboundAdapter {
 
         // Store the reply
         self.storage
-            .store_reply(thread_path, message_dir, reply_text)
+            .store_reply(thread_path, reply_text, message_dir)
             .await
             .context("failed to store WeCom KF reply")?;
 

--- a/crates/jyc-channels/src/wecom/outbound.rs
+++ b/crates/jyc-channels/src/wecom/outbound.rs
@@ -194,7 +194,7 @@ impl OutboundAdapter for WecomOutboundAdapter {
 
         // Store the reply
         self.storage
-            .store_reply(thread_path, message_dir, reply_text)
+            .store_reply(thread_path, reply_text, message_dir)
             .await
             .context("failed to store WeCom reply")?;
 


### PR DESCRIPTION
## Problem

1. ** and ** called  with swapped arguments:
   - Actual: 
   - Expected: 
   
   This caused the chat log to receive the timestamp string instead of the actual reply text, making outbound messages invisible in chat history.

2. **** did not filter messages with empty , causing spurious "unknown_us" threads.

## Fix

- Correct parameter order in both  and 
- Add debug logging for each message from  to diagnose empty 
- Skip messages with empty 

## Verification

- [x] 
- [x] 
- [x] 
running 86 tests
test wecom::crypto::tests::test_decrypt_invalid_encrypt ... ok
test wecom::crypto::tests::test_decrypt_short_key ... ok
test wecom::crypto::tests::test_decrypt_invalid_key ... ok
test wecom::crypto::tests::test_generate_nonce_unique ... ok
test wecom::crypto::tests::test_signature_different_order_fails ... ok
test wecom::crypto::tests::test_generate_nonce_is_non_empty ... ok
test wecom::crypto::tests::test_signature_verification ... ok
test wecom::inbound::tests::test_channel_type ... ok
test wecom::inbound::tests::test_adapter_derive_thread_name_matches_matcher ... ok
test wecom::inbound::tests::test_derive_thread_name_empty_chat_id_fallback ... ok
test wecom::inbound::tests::test_derive_thread_name_from_chat_id ... ok
test wecom::inbound::tests::test_derive_thread_name_from_chat_id_without_channel_name ... ok
test wecom::inbound::tests::test_disabled_pattern_ignored ... ok
test wecom::inbound::tests::test_empty_rules_matches_all ... ok
test wecom::inbound::tests::test_keywords_and_sender_and ... ok
test wecom::inbound::tests::test_keywords_and_sender_no_match ... ok
test wecom::inbound::tests::test_match_by_keywords ... ok
test wecom::inbound::tests::test_match_by_sender ... ok
test wecom::inbound::tests::test_match_keywords_case_insensitive ... ok
test wecom::inbound::tests::test_no_match_wrong_keywords ... ok
test wecom::inbound::tests::test_no_match_wrong_sender ... ok
test wecom::kf_client::tests::test_build_send_payload ... ok
test wecom::kf_client::tests::test_build_send_payload_markdown ... ok
test wecom::kf_client::tests::test_build_sync_request ... ok
test wecom::kf_client::tests::test_build_sync_request_empty_cursor ... ok
test wecom::kf_client::tests::test_kf_sync_response_deserialize ... ok
test wecom::kf_client::tests::test_kf_sync_response_empty_msg_list ... ok
test wecom::inbound::tests::test_derive_thread_name_fallback ... ok
test wecom::kf_client::tests::test_kf_sync_response_missing_fields ... ok
test wecom::kf_cursor::tests::test_cursor_for_different_open_kfid ... ok
test wecom::kf_cursor::tests::test_cursor_get_set ... ok
test wecom::kf_cursor::tests::test_cursor_multiple_kf_accounts ... ok
test wecom::kf_cursor::tests::test_cursor_overwrite ... ok
test wecom::kf_cursor::tests::test_flush_to_disk_noop_without_persist_path ... ok
test wecom::kf_cursor::tests::test_flush_to_disk_not_dirty ... ok
test wecom::kf_cursor::tests::test_persist_and_load ... ok
test wecom::kf_client::tests::test_kf_sync_response_error ... ok
test wecom::kf_cursor::tests::test_persist_path_none ... ok
test wecom::kf_dedup::tests::test_duplicate_mark_is_idempotent ... ok
test wecom::kf_cursor::tests::test_persist_empty_store ... ok
test wecom::kf_dedup::tests::test_eviction_keeps_most_recent ... ok
test wecom::kf_dedup::tests::test_mark_and_check_duplicate ... ok
test wecom::kf_dedup::tests::test_multiple_messages ... ok
test wecom::kf_dedup::tests::test_new_instance_does_not_share_state ... ok
test wecom::kf_dedup::tests::test_new_store_empty ... ok
test wecom::kf_dedup::tests::test_eviction_when_max_entries_exceeded ... ok
test wecom::kf_inbound::tests::test_channel_type ... ok
test wecom::kf_inbound::tests::test_derive_thread_name ... ok
test wecom::kf_inbound::tests::test_derive_thread_name_stable_prefix ... ok
test wecom::kf_inbound::tests::test_kf_message_to_inbound ... ok
test wecom::kf_inbound::tests::test_kf_message_to_inbound_no_text ... ok
test wecom::kf_outbound::tests::test_build_payload_markdown ... ok
test wecom::kf_outbound::tests::test_build_payload_markdown_with_code_block ... ok
test wecom::kf_outbound::tests::test_build_payload_missing_fields ... ok
test wecom::kf_outbound::tests::test_build_payload_text ... ok
test wecom::kf_inbound::tests::test_derive_thread_name_missing_fields ... ok
test wecom::kf_outbound::tests::test_channel_type ... ok
test wecom::kf_outbound::tests::test_clean_body ... ok
test wecom::outbound::tests::test_build_alert_payload ... ok
test wecom::outbound::tests::test_build_alert_payload_empty_chat_id ... ok
test wecom::outbound::tests::test_build_payload_empty_chat_id ... ok
test wecom::outbound::tests::test_build_payload_markdown ... ok
test wecom::outbound::tests::test_build_payload_markdown_with_code_block ... ok
test wecom::outbound::tests::test_build_payload_markdown_with_table ... ok
test wecom::outbound::tests::test_build_payload_text ... ok
test wecom::outbound::tests::test_access_token_cache_creation ... ok
test wecom::outbound::tests::test_channel_type ... ok
test wecom::server::tests::test_callback_query_deserialize ... ok
test wecom::server::tests::test_callback_query_no_echostr ... ok
test wecom::server::tests::test_extract_encrypt_from_xml ... ok
test wecom::server::tests::test_extract_encrypt_from_xml_empty ... ok
test wecom::server::tests::test_extract_encrypt_from_xml_missing ... ok
test wecom::server::tests::test_extract_xml_field_cdata ... ok
test wecom::server::tests::test_extract_xml_field_not_found ... ok
test wecom::server::tests::test_extract_xml_field_plain ... ok
test wecom::server::tests::test_parse_decrypted_xml_empty_content ... ok
test wecom::server::tests::test_parse_decrypted_xml_full ... ok
test wecom::server::tests::test_parse_decrypted_xml_missing_chat_id ... ok
test wecom::server::tests::test_parse_decrypted_xml_missing_content_optional ... ok
test wecom::server::tests::test_parse_decrypted_xml_missing_from_user ... ok
test wecom::server::tests::test_parse_kf_event_missing_open_kfid ... ok
test wecom::server::tests::test_parse_kf_event_missing_token ... ok
test wecom::server::tests::test_parse_kf_event_xml ... ok
test wecom::server::tests::test_parse_regular_message_still_works ... ok
test wecom::server::tests::test_webhook_route_matches_registered_channel ... ok
test wecom::outbound::tests::test_clean_body ... ok

test result: ok. 86 passed; 0 failed; 0 ignored; 0 measured; 189 filtered out; finished in 3.72s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s (86 tests pass)

Refs: PR #230