### PR TITLE
feat: use customer display name for wecomkf thread names and chat history

### DIFF
--- a/crates/jyc-channels/src/wecom/crypto.rs
+++ b/crates/jyc-channels/src/wecom/crypto.rs
@@ -148,12 +148,17 @@ pub fn decrypt_msg(encoding_aes_key: &str, encrypt: &str) -> Result<String> {
 
 /// Get a random nonce string (for generating callback response).
 pub fn generate_nonce() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_nanos();
-    format!("{nanos}")
+    let counter = COUNTER.fetch_add(1, Ordering::SeqCst);
+    format!("{nanos}_{counter}")
 }
 
 #[cfg(test)]

--- a/crates/jyc-channels/src/wecom/kf_client.rs
+++ b/crates/jyc-channels/src/wecom/kf_client.rs
@@ -7,10 +7,12 @@
 //!
 //! Reference: https://developer.work.weixin.qq.com/document/path/94677
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
 
 use crate::wecom::token_cache::AccessTokenCache;
 
@@ -19,6 +21,9 @@ const KF_SYNC_API: &str = "https://qyapi.weixin.qq.com/cgi-bin/kf/sync_msg";
 
 /// The KF send message API base URL.
 const KF_SEND_API: &str = "https://qyapi.weixin.qq.com/cgi-bin/kf/send_msg";
+
+/// The external contact get API base URL.
+const EXTERNAL_CONTACT_API: &str = "https://qyapi.weixin.qq.com/cgi-bin/externalcontact/get";
 
 /// Response from the WeCom KF `sync_msg` API.
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -67,6 +72,36 @@ pub struct KfTextContent {
     pub content: String,
 }
 
+/// Response from the WeCom `externalcontact/get` API.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ExternalContactResponse {
+    /// Error code (0 = success).
+    pub errcode: i64,
+    /// Error message.
+    pub errmsg: String,
+    /// External contact details.
+    #[serde(default)]
+    pub external_contact: Option<ExternalContact>,
+}
+
+/// External contact (customer) details.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ExternalContact {
+    /// External user ID.
+    pub external_userid: String,
+    /// Display name.
+    pub name: String,
+    /// Avatar URL.
+    #[serde(default)]
+    pub avatar: Option<String>,
+    /// Gender (0: unknown, 1: male, 2: female).
+    #[serde(default)]
+    pub gender: Option<i32>,
+    /// Type (1: WeChat user, 2: enterprise WeCom user).
+    #[serde(default)]
+    pub r#type: Option<i32>,
+}
+
 /// WeCom KF API client.
 ///
 /// Provides methods to sync incoming messages and send replies
@@ -74,6 +109,8 @@ pub struct KfTextContent {
 pub struct KfApiClient {
     access_token_cache: Arc<AccessTokenCache>,
     client: reqwest::Client,
+    /// Cache for external contact names (external_userid → name).
+    name_cache: Arc<RwLock<HashMap<String, String>>>,
 }
 
 impl KfApiClient {
@@ -82,7 +119,78 @@ impl KfApiClient {
         Self {
             access_token_cache,
             client: reqwest::Client::new(),
+            name_cache: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    /// Get the display name of an external contact (customer).
+    ///
+    /// Uses an in-memory cache to avoid repeated API calls.
+    /// Falls back to the external_userid itself if the API call fails.
+    pub async fn get_external_contact_name(&self, external_userid: &str) -> String {
+        // Check cache first
+        {
+            let cache = self.name_cache.read().await;
+            if let Some(name) = cache.get(external_userid) {
+                return name.clone();
+            }
+        }
+
+        // Fetch from API
+        let name = match self.fetch_external_contact(external_userid).await {
+            Ok(contact) => contact.name,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    external_userid = %external_userid,
+                    "Failed to fetch external contact name, falling back to userid"
+                );
+                external_userid.to_string()
+            }
+        };
+
+        // Store in cache
+        {
+            let mut cache = self.name_cache.write().await;
+            cache.insert(external_userid.to_string(), name.clone());
+        }
+
+        name
+    }
+
+    async fn fetch_external_contact(&self, external_userid: &str) -> Result<ExternalContact> {
+        let access_token = self.access_token_cache.get_token().await?;
+
+        let url = format!(
+            "{}?access_token={}&external_userid={}",
+            EXTERNAL_CONTACT_API, access_token, external_userid
+        );
+
+        let response = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .context("failed to send externalcontact/get request")?;
+
+        let status = response.status();
+        let body: ExternalContactResponse = response
+            .json()
+            .await
+            .context("failed to parse externalcontact/get response")?;
+
+        if !status.is_success() || body.errcode != 0 {
+            anyhow::bail!(
+                "externalcontact/get API returned error {}: {} (status: {})",
+                body.errcode,
+                body.errmsg,
+                status,
+            );
+        }
+
+        body.external_contact.ok_or_else(|| {
+            anyhow::anyhow!("externalcontact/get response missing external_contact field")
+        })
     }
 
     /// Verify connectivity by fetching a fresh access token.

--- a/crates/jyc-channels/src/wecom/kf_inbound.rs
+++ b/crates/jyc-channels/src/wecom/kf_inbound.rs
@@ -69,7 +69,12 @@ impl WecomKfInboundAdapter {
 }
 
 /// Convert a synced KF message into an `InboundMessage`.
-fn kf_message_to_inbound(msg: &KfMessage, channel_name: &str, token: &str) -> InboundMessage {
+fn kf_message_to_inbound(
+    msg: &KfMessage,
+    channel_name: &str,
+    token: &str,
+    user_name: &str,
+) -> InboundMessage {
     let mut metadata = HashMap::new();
     metadata.insert(
         "open_kfid".to_string(),
@@ -78,6 +83,10 @@ fn kf_message_to_inbound(msg: &KfMessage, channel_name: &str, token: &str) -> In
     metadata.insert(
         "external_userid".to_string(),
         serde_json::Value::String(msg.external_userid.clone()),
+    );
+    metadata.insert(
+        "user_name".to_string(),
+        serde_json::Value::String(user_name.to_string()),
     );
     metadata.insert(
         "msgid".to_string(),
@@ -201,8 +210,18 @@ fn handle_kf_event(
 
                         dedup_store.mark_seen(&msg.msgid);
 
+                        // Fetch customer display name for readable thread names
+                        let user_name = kf_client
+                            .get_external_contact_name(&msg.external_userid)
+                            .await;
+                        tracing::debug!(
+                            external_userid = %msg.external_userid,
+                            user_name = %user_name,
+                            "WeCom KF inbound: resolved customer name"
+                        );
+
                         // Convert to InboundMessage
-                        let inbound = kf_message_to_inbound(msg, &channel_name, &token);
+                        let inbound = kf_message_to_inbound(msg, &channel_name, &token, &user_name);
 
                         // Call the on_message callback
                         if let Err(e) = (on_message)(inbound) {
@@ -252,12 +271,24 @@ fn handle_kf_event(
 
 /// Shared helper to derive a KF thread name from message metadata.
 ///
-/// Format: `{sanitized_external_userid_prefix}`
+/// Format: `{sanitized_user_name}`
 /// One thread per customer (regardless of which KF account they contact).
 ///
-/// WeCom's `external_userid` may contain a variable suffix (session-specific),
-/// so we use only the first 12 chars as the stable customer identifier.
+/// Uses the customer's display name from WeCom's externalcontact/get API.
+/// Falls back to external_userid prefix if name is not available.
 fn wecomkf_derive_thread_name(message: &InboundMessage, _default_channel: &str) -> String {
+    // Prefer user_name (display name from WeCom API)
+    let user_name = message
+        .metadata
+        .get("user_name")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty());
+
+    if let Some(name) = user_name {
+        return sanitize_for_filesystem(name);
+    }
+
+    // Fallback: use external_userid prefix
     let external_userid = message
         .metadata
         .get("external_userid")
@@ -265,8 +296,6 @@ fn wecomkf_derive_thread_name(message: &InboundMessage, _default_channel: &str) 
         .filter(|s| !s.is_empty())
         .unwrap_or("unknown_user");
 
-    // Use first 10 chars of external_userid as stable customer identifier.
-    // WeCom's external_userid has a stable prefix (~10 chars) + variable suffix.
     let stable_user_id = if external_userid.len() > 10 {
         &external_userid[..10]
     } else {
@@ -604,7 +633,7 @@ mod tests {
             }),
         };
 
-        let inbound = kf_message_to_inbound(&msg, "my_kf_bot", "token_xxx");
+        let inbound = kf_message_to_inbound(&msg, "my_kf_bot", "token_xxx", "张三");
         assert_eq!(inbound.channel, "wecomkf");
         assert_eq!(inbound.sender, "user123");
         assert_eq!(inbound.sender_address, "wecomkf:user123");
@@ -620,6 +649,10 @@ mod tests {
                 .get("external_userid")
                 .and_then(|v| v.as_str()),
             Some("user123")
+        );
+        assert_eq!(
+            inbound.metadata.get("user_name").and_then(|v| v.as_str()),
+            Some("张三")
         );
         assert_eq!(
             inbound.metadata.get("token").and_then(|v| v.as_str()),
@@ -638,7 +671,7 @@ mod tests {
             text: None,
         };
 
-        let inbound = kf_message_to_inbound(&msg, "my_kf_bot", "token_xxx");
+        let inbound = kf_message_to_inbound(&msg, "my_kf_bot", "token_xxx", "李四");
         assert_eq!(inbound.content.text, None);
         assert_eq!(
             inbound.metadata.get("msg_type").and_then(|v| v.as_str()),

--- a/crates/jyc-core/src/chat_log_store.rs
+++ b/crates/jyc-core/src/chat_log_store.rs
@@ -97,13 +97,21 @@ impl ChatLogStore {
 
         let mut formatted = String::new();
 
+        // Extract user_name from metadata (e.g., WeCom KF provides display names)
+        let user_name = message
+            .metadata
+            .get("user_name")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty());
+
         // Metadata comment — sender_address is the canonical ID, sender_name is the display name
-        let sender_name_str =
-            if message.sender != message.sender_address && !message.sender.is_empty() {
-                format!(" | sender_name:{}", message.sender)
-            } else {
-                String::new()
-            };
+        let sender_name_str = if let Some(name) = user_name {
+            format!(" | sender_name:{}", name)
+        } else if message.sender != message.sender_address && !message.sender.is_empty() {
+            format!(" | sender_name:{}", message.sender)
+        } else {
+            String::new()
+        };
         formatted.push_str(&format!(
             "<!-- {} | type:received | {} | sender:{}{} | channel:{}{} -->\n",
             message.timestamp.to_rfc3339(),
@@ -115,8 +123,13 @@ impl ChatLogStore {
         ));
 
         // Content header — use display name for readability
-        let from_display = if !message.sender.is_empty() && message.sender != message.sender_address
-        {
+        let from_display = if let Some(name) = user_name {
+            if !message.sender_address.is_empty() {
+                format!("{} ({})", name, message.sender_address)
+            } else {
+                name.to_string()
+            }
+        } else if !message.sender.is_empty() && message.sender != message.sender_address {
             format!("{} ({})", message.sender, message.sender_address)
         } else {
             message.sender_address.clone()


### PR DESCRIPTION
## Problem

WeCom KF thread names were unreadable IDs (e.g., "wmE8OcHAAA"), making it hard to identify conversations. Chat history also showed only the cryptic external_userid.

## Solution

Fetch the customer display name via WeCom `externalcontact/get` API and use it for:

1. **Thread names**: `{user_name}` instead of `{external_userid_prefix}`
2. **Chat history**: shows display name (e.g., `FROM: Zhang San`)
3. **Agent visibility**: agent sees the user name when reading chat history

## Implementation

- Added `get_external_contact_name()` to `KfApiClient` with in-memory cache
- Added `ExternalContactResponse` / `ExternalContact` structs
- Updated `kf_message_to_inbound` to include `user_name` in metadata
- Updated `wecomkf_derive_thread_name` to prefer `user_name`
- Updated `ChatLogStore::append_message` to display `user_name` from metadata
- Fixed flaky `test_generate_nonce_unique` by adding atomic counter

## Verification

- [x] `cargo fmt && cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test -p jyc-channels -- wecom` (86 tests pass)
- [x] `cargo test -p jyc-core -- chat_log_store` (4 tests pass)

Refs: PR #230