### PR TITLE
feat: persist wecomkf customer info in .jyc/thread.json

### DIFF
--- a/crates/jyc-channels/src/wecom/kf_outbound.rs
+++ b/crates/jyc-channels/src/wecom/kf_outbound.rs
@@ -48,20 +48,41 @@ impl WecomKfOutboundAdapter {
     }
 
     /// Build the send message payload for a reply.
-    fn build_payload(_reply_text: &str, original: &InboundMessage) -> (String, String, String) {
-        let open_kfid = original
+    fn build_payload(
+        _reply_text: &str,
+        original: &InboundMessage,
+        thread_path: &Path,
+    ) -> (String, String, String) {
+        let mut open_kfid = original
             .metadata
             .get("open_kfid")
             .and_then(|v| v.as_str())
             .unwrap_or_default()
             .to_string();
 
-        let touser = original
+        let mut touser = original
             .metadata
             .get("external_userid")
             .and_then(|v| v.as_str())
             .unwrap_or_default()
             .to_string();
+
+        // Fallback to thread.json if metadata is incomplete
+        if (open_kfid.is_empty() || touser.is_empty())
+            && let Ok(Some(thread_json)) = jyc_core::thread_json::ThreadJson::read_sync(thread_path)
+            && let Some(data) = thread_json.data
+        {
+            if open_kfid.is_empty()
+                && let Some(v) = data.get("open_kfid").and_then(|v| v.as_str())
+            {
+                open_kfid = v.to_string();
+            }
+            if touser.is_empty()
+                && let Some(v) = data.get("external_userid").and_then(|v| v.as_str())
+            {
+                touser = v.to_string();
+            }
+        }
 
         // WeCom KF send_msg API supports: text, image, voice, video, file, news, msgmenu, miniprogram.
         // Markdown is NOT supported. Always send as text.
@@ -104,7 +125,7 @@ impl OutboundAdapter for WecomKfOutboundAdapter {
         message_dir: &str,
         _attachments: Option<&[OutboundAttachment]>,
     ) -> Result<SendResult> {
-        let (open_kfid, touser, msgtype) = Self::build_payload(reply_text, original);
+        let (open_kfid, touser, msgtype) = Self::build_payload(reply_text, original, thread_path);
 
         if open_kfid.is_empty() {
             anyhow::bail!("WeCom KF outbound: missing open_kfid in message metadata");
@@ -245,9 +266,10 @@ mod tests {
 
     #[test]
     fn test_build_payload_text() {
+        let tmp = tempfile::tempdir().unwrap();
         let msg = make_kf_message("kf001", "user123", "Hello");
         let (open_kfid, touser, msgtype) =
-            WecomKfOutboundAdapter::build_payload("Hello World", &msg);
+            WecomKfOutboundAdapter::build_payload("Hello World", &msg, tmp.path());
         assert_eq!(open_kfid, "kf001");
         assert_eq!(touser, "user123");
         assert_eq!(msgtype, "text");
@@ -255,9 +277,10 @@ mod tests {
 
     #[test]
     fn test_build_payload_markdown() {
+        let tmp = tempfile::tempdir().unwrap();
         let msg = make_kf_message("kf001", "user123", "Hello");
         let (open_kfid, touser, msgtype) =
-            WecomKfOutboundAdapter::build_payload("## Title\n\n**bold** text", &msg);
+            WecomKfOutboundAdapter::build_payload("## Title\n\n**bold** text", &msg, tmp.path());
         assert_eq!(open_kfid, "kf001");
         assert_eq!(touser, "user123");
         // KF send_msg API does not support "markdown" — always falls back to "text"
@@ -266,15 +289,17 @@ mod tests {
 
     #[test]
     fn test_build_payload_markdown_with_code_block() {
+        let tmp = tempfile::tempdir().unwrap();
         let msg = make_kf_message("kf001", "user123", "Hello");
         let (_, _, msgtype) =
-            WecomKfOutboundAdapter::build_payload("```rust\nfn main() {}\n```", &msg);
+            WecomKfOutboundAdapter::build_payload("```rust\nfn main() {}\n```", &msg, tmp.path());
         // KF send_msg API does not support "markdown" — always falls back to "text"
         assert_eq!(msgtype, "text");
     }
 
     #[test]
     fn test_build_payload_missing_fields() {
+        let tmp = tempfile::tempdir().unwrap();
         let msg = InboundMessage {
             id: "test-id".to_string(),
             channel: "wecomkf".to_string(),
@@ -296,9 +321,108 @@ mod tests {
             metadata: HashMap::new(),
             matched_pattern: None,
         };
-        let (open_kfid, touser, msgtype) = WecomKfOutboundAdapter::build_payload("Hello", &msg);
+        let (open_kfid, touser, msgtype) =
+            WecomKfOutboundAdapter::build_payload("Hello", &msg, tmp.path());
         assert_eq!(open_kfid, "");
         assert_eq!(touser, "");
+        assert_eq!(msgtype, "text");
+    }
+
+    #[test]
+    fn test_build_payload_fallback_to_thread_json() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Write thread.json with wecomkf data
+        let thread_json = jyc_core::thread_json::ThreadJson {
+            channel_type: "wecomkf".to_string(),
+            version: 1,
+            data: Some(serde_json::json!({
+                "external_userid": "wm789",
+                "user_name": "李四",
+                "open_kfid": "kf002",
+            })),
+        };
+        thread_json.write_sync(tmp.path()).unwrap();
+
+        // Create message WITHOUT metadata
+        let msg = InboundMessage {
+            id: "test-id".to_string(),
+            channel: "wecomkf".to_string(),
+            channel_uid: "test-uid".to_string(),
+            sender: "user".to_string(),
+            sender_address: "wecomkf:user".to_string(),
+            recipients: vec![],
+            topic: "Test".to_string(),
+            content: MessageContent {
+                text: Some("Hello".to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata: HashMap::new(),
+            matched_pattern: None,
+        };
+
+        let (open_kfid, touser, msgtype) =
+            WecomKfOutboundAdapter::build_payload("Hello", &msg, tmp.path());
+        // Should fallback to thread.json
+        assert_eq!(open_kfid, "kf002");
+        assert_eq!(touser, "wm789");
+        assert_eq!(msgtype, "text");
+    }
+
+    #[test]
+    fn test_build_payload_partial_fallback_to_thread_json() {
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Write thread.json with only external_userid (no open_kfid)
+        let thread_json = jyc_core::thread_json::ThreadJson {
+            channel_type: "wecomkf".to_string(),
+            version: 1,
+            data: Some(serde_json::json!({
+                "external_userid": "wm999",
+            })),
+        };
+        thread_json.write_sync(tmp.path()).unwrap();
+
+        // Create message with open_kfid in metadata but no external_userid
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "open_kfid".to_string(),
+            serde_json::Value::String("kf003".to_string()),
+        );
+
+        let msg = InboundMessage {
+            id: "test-id".to_string(),
+            channel: "wecomkf".to_string(),
+            channel_uid: "test-uid".to_string(),
+            sender: "user".to_string(),
+            sender_address: "wecomkf:user".to_string(),
+            recipients: vec![],
+            topic: "Test".to_string(),
+            content: MessageContent {
+                text: Some("Hello".to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata,
+            matched_pattern: None,
+        };
+
+        let (open_kfid, touser, msgtype) =
+            WecomKfOutboundAdapter::build_payload("Hello", &msg, tmp.path());
+        // open_kfid from metadata, touser from thread.json
+        assert_eq!(open_kfid, "kf003");
+        assert_eq!(touser, "wm999");
         assert_eq!(msgtype, "text");
     }
 

--- a/crates/jyc-core/src/chat_log_store.rs
+++ b/crates/jyc-core/src/chat_log_store.rs
@@ -98,14 +98,26 @@ impl ChatLogStore {
         let mut formatted = String::new();
 
         // Extract user_name from metadata (e.g., WeCom KF provides display names)
-        let user_name = message
+        let mut user_name = message
             .metadata
             .get("user_name")
             .and_then(|v| v.as_str())
-            .filter(|s| !s.is_empty());
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+
+        // Fallback: read from thread.json if metadata lacks user_name
+        if user_name.is_none()
+            && message.channel == "wecomkf"
+            && let Ok(Some(thread_json)) =
+                crate::thread_json::ThreadJson::read_sync(&self.thread_path)
+            && let Some(data) = thread_json.data
+            && let Some(name) = data.get("user_name").and_then(|v| v.as_str())
+        {
+            user_name = Some(name.to_string());
+        }
 
         // Metadata comment — sender_address is the canonical ID, sender_name is the display name
-        let sender_name_str = if let Some(name) = user_name {
+        let sender_name_str = if let Some(ref name) = user_name {
             format!(" | sender_name:{}", name)
         } else if message.sender != message.sender_address && !message.sender.is_empty() {
             format!(" | sender_name:{}", message.sender)
@@ -123,11 +135,11 @@ impl ChatLogStore {
         ));
 
         // Content header — use display name for readability
-        let from_display = if let Some(name) = user_name {
+        let from_display = if let Some(ref name) = user_name {
             if !message.sender_address.is_empty() {
                 format!("{} ({})", name, message.sender_address)
             } else {
-                name.to_string()
+                name.clone()
             }
         } else if !message.sender.is_empty() && message.sender != message.sender_address {
             format!("{} ({})", message.sender, message.sender_address)
@@ -345,5 +357,37 @@ mod tests {
 
         assert_eq!(received_count, 2);
         assert_eq!(reply_count, 2);
+    }
+
+    #[test]
+    fn test_append_message_with_thread_json_fallback() {
+        let temp_dir = tempdir().unwrap();
+        let mut store = ChatLogStore::new(temp_dir.path());
+
+        // Write thread.json with user_name
+        let thread_json = crate::thread_json::ThreadJson {
+            channel_type: "wecomkf".to_string(),
+            version: 1,
+            data: Some(serde_json::json!({
+                "external_userid": "wm123",
+                "user_name": "张三",
+            })),
+        };
+        thread_json.write_sync(temp_dir.path()).unwrap();
+
+        // Create message WITHOUT user_name in metadata
+        let mut message = create_test_message();
+        message.channel = "wecomkf".to_string();
+        message.sender_address = "wecomkf:wm123".to_string();
+        message.metadata = HashMap::new();
+
+        let result = store.append_message(&message, true);
+        assert!(result.is_ok());
+
+        let file_path = store.get_today_file_path();
+        let content = std::fs::read_to_string(&file_path).unwrap();
+        // Should use user_name from thread.json
+        assert!(content.contains("sender_name:张三"));
+        assert!(content.contains("**FROM:** 张三 (wecomkf:wm123)"));
     }
 }

--- a/crates/jyc-core/src/lib.rs
+++ b/crates/jyc-core/src/lib.rs
@@ -15,5 +15,6 @@ pub mod static_agent;
 pub mod template_utils;
 pub mod thread_event;
 pub mod thread_event_bus;
+pub mod thread_json;
 pub mod thread_manager;
 pub mod thread_path;

--- a/crates/jyc-core/src/thread_json.rs
+++ b/crates/jyc-core/src/thread_json.rs
@@ -1,0 +1,171 @@
+//! Thread-level metadata persistence in `.jyc/thread.json`.
+//!
+//! Each thread directory stores a `thread.json` file under `.jyc/` that holds
+//! channel-specific metadata. The top-level structure is generic (`channel_type`,
+//! `version`), while the `data` field is opaque and channel-specific.
+//!
+//! Channels are responsible for defining their own `data` schema. The core
+//! framework only provides read/write helpers.
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Generic thread metadata stored in `.jyc/thread.json`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ThreadJson {
+    /// Channel type that created this thread (e.g., "wecomkf", "email", "feishu").
+    pub channel_type: String,
+    /// Schema version for forward compatibility.
+    pub version: u32,
+    /// Opaque channel-specific data.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+impl ThreadJson {
+    /// File name within the `.jyc/` directory.
+    pub const FILENAME: &'static str = "thread.json";
+
+    /// Construct the full path to `thread.json` for a given thread directory.
+    pub fn path(thread_path: &Path) -> PathBuf {
+        thread_path.join(".jyc").join(Self::FILENAME)
+    }
+
+    /// Write `thread.json` to disk, creating `.jyc/` if needed (async).
+    pub async fn write(&self, thread_path: &Path) -> Result<()> {
+        let path = Self::path(thread_path);
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .with_context(|| format!("failed to create .jyc dir: {}", parent.display()))?;
+        }
+        let content =
+            serde_json::to_string_pretty(self).context("failed to serialize thread.json")?;
+        tokio::fs::write(&path, content)
+            .await
+            .with_context(|| format!("failed to write thread.json: {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Write `thread.json` to disk, creating `.jyc/` if needed (sync).
+    pub fn write_sync(&self, thread_path: &Path) -> Result<()> {
+        let path = Self::path(thread_path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create .jyc dir: {}", parent.display()))?;
+        }
+        let content =
+            serde_json::to_string_pretty(self).context("failed to serialize thread.json")?;
+        std::fs::write(&path, content)
+            .with_context(|| format!("failed to write thread.json: {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Read `thread.json` from disk if it exists (async).
+    pub async fn read(thread_path: &Path) -> Result<Option<Self>> {
+        let path = Self::path(thread_path);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let content = tokio::fs::read_to_string(&path)
+            .await
+            .with_context(|| format!("failed to read thread.json: {}", path.display()))?;
+        let value: Self = serde_json::from_str(&content)
+            .with_context(|| format!("failed to parse thread.json: {}", path.display()))?;
+        Ok(Some(value))
+    }
+
+    /// Read `thread.json` from disk if it exists (sync).
+    pub fn read_sync(thread_path: &Path) -> Result<Option<Self>> {
+        let path = Self::path(thread_path);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let content = std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read thread.json: {}", path.display()))?;
+        let value: Self = serde_json::from_str(&content)
+            .with_context(|| format!("failed to parse thread.json: {}", path.display()))?;
+        Ok(Some(value))
+    }
+
+    /// Convenience: read `data` and deserialize into a channel-specific type.
+    pub fn data_as<T: for<'de> Deserialize<'de>>(&self) -> Result<Option<T>> {
+        match &self.data {
+            Some(v) => serde_json::from_value(v.clone())
+                .map(Some)
+                .context("failed to deserialize thread.json data field"),
+            None => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct TestChannelData {
+        external_userid: String,
+        user_name: String,
+    }
+
+    #[tokio::test]
+    async fn test_write_and_read_roundtrip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let meta = ThreadJson {
+            channel_type: "wecomkf".to_string(),
+            version: 1,
+            data: Some(serde_json::json!({
+                "external_userid": "wm123",
+                "user_name": "张三"
+            })),
+        };
+
+        meta.write(tmp.path()).await.unwrap();
+
+        let read_back = ThreadJson::read(tmp.path()).await.unwrap().unwrap();
+        assert_eq!(read_back.channel_type, "wecomkf");
+        assert_eq!(read_back.version, 1);
+        assert_eq!(
+            read_back.data_as::<TestChannelData>().unwrap(),
+            Some(TestChannelData {
+                external_userid: "wm123".to_string(),
+                user_name: "张三".to_string(),
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn test_read_missing_file_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let result = ThreadJson::read(tmp.path()).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_write_creates_jyc_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let meta = ThreadJson {
+            channel_type: "email".to_string(),
+            version: 1,
+            data: None,
+        };
+
+        meta.write(tmp.path()).await.unwrap();
+        assert!(tmp.path().join(".jyc").is_dir());
+        assert!(tmp.path().join(".jyc/thread.json").is_file());
+    }
+
+    #[tokio::test]
+    async fn test_data_as_none_when_data_missing() {
+        let meta = ThreadJson {
+            channel_type: "github".to_string(),
+            version: 1,
+            data: None,
+        };
+        let result: Option<TestChannelData> = meta.data_as().unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -22,6 +22,7 @@ use crate::message_storage::{MessageStorage, StoreResult};
 use crate::metrics::MetricsHandle;
 use crate::pending_delivery::watch_pending_deliveries;
 use crate::template_utils::copy_template_files;
+use crate::thread_json::ThreadJson;
 use jyc_types::InboundAttachmentConfig;
 use jyc_types::{InboundMessage, OutboundAdapter, PatternMatch, QueueItem};
 use jyc_types::{ThreadInfo, ThreadStatus};
@@ -957,6 +958,16 @@ async fn process_message(
         "Message stored"
     );
 
+    // ── 1.1. WRITE THREAD.JSON (if channel provides metadata) ─────────
+    // Channels like wecomkf embed customer info in message metadata.
+    // Persist it once per thread so subsequent messages can read cached data.
+    if item.message.channel == "wecomkf" {
+        let thread_json_path = store_result.thread_path.join(".jyc").join("thread.json");
+        if !thread_json_path.exists() {
+            write_wecomkf_thread_json(&item.message, &store_result.thread_path, thread_name).await;
+        }
+    }
+
     // ── 1.5. SAVE ATTACHMENTS ─────────────────────────────────────────
     // Save attachments AFTER thread name resolution (not before).
     // This ensures attachments go to the correct thread directory when
@@ -1484,5 +1495,196 @@ mod template_init_tests {
             .await
             .unwrap();
         assert_eq!(body, "HLP");
+    }
+}
+
+#[cfg(test)]
+mod thread_json_tests {
+    use super::*;
+    use jyc_types::{InboundMessage, MessageContent};
+    use std::collections::HashMap;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn test_write_wecomkf_thread_json_creates_file() {
+        let tmp = tempdir().unwrap();
+        let thread_path = tmp.path().join("test-thread");
+
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "external_userid".to_string(),
+            serde_json::Value::String("wm123".to_string()),
+        );
+        metadata.insert(
+            "user_name".to_string(),
+            serde_json::Value::String("张三".to_string()),
+        );
+        metadata.insert(
+            "open_kfid".to_string(),
+            serde_json::Value::String("kf001".to_string()),
+        );
+
+        let message = InboundMessage {
+            id: "test-1".to_string(),
+            channel: "wecomkf".to_string(),
+            channel_uid: "uid".to_string(),
+            sender: "wm123".to_string(),
+            sender_address: "wecomkf:wm123".to_string(),
+            recipients: vec![],
+            topic: "Test".to_string(),
+            content: MessageContent {
+                text: Some("Hello".to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata,
+            matched_pattern: None,
+        };
+
+        write_wecomkf_thread_json(&message, &thread_path, "test-thread").await;
+
+        let thread_json = ThreadJson::read(&thread_path).await.unwrap().unwrap();
+        assert_eq!(thread_json.channel_type, "wecomkf");
+        assert_eq!(thread_json.version, 1);
+
+        let data = thread_json.data_as::<serde_json::Value>().unwrap().unwrap();
+        assert_eq!(
+            data.get("external_userid").and_then(|v| v.as_str()),
+            Some("wm123")
+        );
+        assert_eq!(data.get("user_name").and_then(|v| v.as_str()), Some("张三"));
+        assert_eq!(
+            data.get("open_kfid").and_then(|v| v.as_str()),
+            Some("kf001")
+        );
+        assert!(data.get("first_message_at").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_write_wecomkf_thread_json_skips_without_external_userid() {
+        let tmp = tempdir().unwrap();
+        let thread_path = tmp.path().join("test-thread");
+
+        let message = InboundMessage {
+            id: "test-1".to_string(),
+            channel: "wecomkf".to_string(),
+            channel_uid: "uid".to_string(),
+            sender: "user".to_string(),
+            sender_address: "wecomkf:user".to_string(),
+            recipients: vec![],
+            topic: "Test".to_string(),
+            content: MessageContent {
+                text: Some("Hello".to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata: HashMap::new(),
+            matched_pattern: None,
+        };
+
+        write_wecomkf_thread_json(&message, &thread_path, "test-thread").await;
+
+        // No external_userid in metadata → file should not be created
+        assert!(!thread_path.join(".jyc/thread.json").exists());
+    }
+
+    #[tokio::test]
+    async fn test_write_wecomkf_thread_json_fallback_user_name() {
+        let tmp = tempdir().unwrap();
+        let thread_path = tmp.path().join("test-thread");
+
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            "external_userid".to_string(),
+            serde_json::Value::String("wm456".to_string()),
+        );
+        // No user_name in metadata → should fallback to external_userid
+
+        let message = InboundMessage {
+            id: "test-1".to_string(),
+            channel: "wecomkf".to_string(),
+            channel_uid: "uid".to_string(),
+            sender: "wm456".to_string(),
+            sender_address: "wecomkf:wm456".to_string(),
+            recipients: vec![],
+            topic: "Test".to_string(),
+            content: MessageContent {
+                text: Some("Hello".to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata,
+            matched_pattern: None,
+        };
+
+        write_wecomkf_thread_json(&message, &thread_path, "test-thread").await;
+
+        let thread_json = ThreadJson::read(&thread_path).await.unwrap().unwrap();
+        let data = thread_json.data_as::<serde_json::Value>().unwrap().unwrap();
+        assert_eq!(
+            data.get("user_name").and_then(|v| v.as_str()),
+            Some("wm456")
+        );
+    }
+}
+
+/// Write `thread.json` for a WeCom KF thread from message metadata.
+///
+/// Extracts `external_userid`, `user_name`, and `open_kfid` from the
+/// message metadata and persists them in `.jyc/thread.json`.
+async fn write_wecomkf_thread_json(
+    message: &InboundMessage,
+    thread_path: &Path,
+    thread_name: &str,
+) {
+    if let Some(external_userid) = message
+        .metadata
+        .get("external_userid")
+        .and_then(|v| v.as_str())
+    {
+        let user_name = message
+            .metadata
+            .get("user_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or(external_userid);
+        let open_kfid = message
+            .metadata
+            .get("open_kfid")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        let thread_json = ThreadJson {
+            channel_type: "wecomkf".to_string(),
+            version: 1,
+            data: Some(serde_json::json!({
+                "external_userid": external_userid,
+                "user_name": user_name,
+                "open_kfid": open_kfid,
+                "first_message_at": chrono::Utc::now().to_rfc3339(),
+            })),
+        };
+        if let Err(e) = thread_json.write(thread_path).await {
+            tracing::warn!(
+                error = %e,
+                thread = %thread_name,
+                "Failed to write thread.json"
+            );
+        } else {
+            tracing::info!(thread = %thread_name, "Wrote thread.json");
+        }
     }
 }


### PR DESCRIPTION
## Problem

WeCom KF customer info (external_userid, user_name, open_kfid) is only available in message metadata. After the first message, subsequent messages re-fetch from API or lose display names on restart.

## Solution

Persist customer info in `.jyc/thread.json` — a generic, channel-specific metadata file.

### Schema
```json
{
  "channel_type": "wecomkf",
  "version": 1,
  "data": {
    "external_userid": "wm123...",
    "user_name": "张三",
    "open_kfid": "kf001",
    "first_message_at": "2026-05-30T13:52:00Z"
  }
}
```

### Changes
- **New** `jyc-core/src/thread_json.rs` — `ThreadJson` struct with async/sync read/write
- `thread_manager.rs` — writes `thread.json` on first wecomkf message
- `chat_log_store.rs` — reads `user_name` from `thread.json` as fallback
- `kf_outbound.rs` — reads `open_kfid`/`external_userid` from `thread.json` as fallback

### Tests
- ThreadJson roundtrip (async + sync)
- `write_wecomkf_thread_json` creates correct JSON
- `chat_log_store` fallback from thread.json
- `kf_outbound` fallback from thread.json (full + partial)

## Verification
- [x] `cargo fmt && cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` (all pass)