### PR TITLE
feat: add channel-level MCP configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to JYC will be documented in this file.
 
 ### Added
 
+- **Channel-level MCP configuration.** `ChannelConfig` now supports `mcps`
+  field, allowing MCP servers to be configured per-channel. Resolution
+  priority: pattern-level → channel-level → global. (#241)
+
 - **WeCom KF (Customer Service) channel.** New channel type `wecomkf` supporting
   inbound messages via `kf_msg_or_event` event notifications and `kf/sync_msg`
   API pull, outbound messages via `kf/send_msg` API. Includes cursor-based

--- a/config.example.toml
+++ b/config.example.toml
@@ -477,6 +477,31 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 # # "X-API-Key" = "abc123"
 # # "X-Organization" = "my-org"
 #
+# # --- Channel-Level MCP Example ---
+# # Channel-level MCPs are loaded for all threads in the channel.
+# # Pattern-level mcps overrides channel-level.
+# #
+# [channels.my_wecomkf]
+# type = "wecomkf"
+# #
+# # Channel-level MCP: all threads in this channel share these tools
+# # [[channels.my_wecomkf.mcps]]
+# # name = "kf_helper"
+# # type = "local"
+# # command = ["kf-helper", "mcp"]
+# #
+# # [[channels.my_wecomkf.patterns]]
+# # name = "kf_bot"
+# # enabled = true
+# # # Pattern-level MCP overrides channel-level for this pattern
+# # # [[channels.my_wecomkf.patterns.mcps]]
+# # # name = "special_tool"
+# # # type = "local"
+# # # command = ["special", "mcp"]
+# #
+# # [channels.my_wecomkf.patterns.rules]
+# # keywords = ["help", "support", "问题"]
+
 # # Pattern: No MCP tools at all (empty mcps list)
 # # [[channels.my_repo.patterns]]
 # # name = "simple-reply"

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -112,6 +112,8 @@ pub struct JycAgentService {
     /// `inject_inbound_images`, model/small_model overrides, mcps,
     /// disabled_builtin_tools) by `InboundMessage.matched_pattern`.
     patterns: Vec<ChannelPattern>,
+    /// Channel-level MCP configs (fallback when pattern-level is unset).
+    channel_mcp_configs: Option<Vec<McpServerConfig>>,
     /// Global `[attachments.inbound]` config (used as fallback when a matched
     /// pattern does not specify its own `attachments`).
     global_inbound_attachments: Option<jyc_types::InboundAttachmentConfig>,
@@ -127,6 +129,7 @@ impl JycAgentService {
         config: AgentConfig,
         workdir: PathBuf,
         mcp_configs: Vec<McpServerConfig>,
+        channel_mcp_configs: Option<Vec<McpServerConfig>>,
         patterns: Vec<ChannelPattern>,
         global_inbound_attachments: Option<jyc_types::InboundAttachmentConfig>,
         vision_client: Option<Arc<VisionClient>>,
@@ -136,6 +139,7 @@ impl JycAgentService {
             event_buses: Mutex::new(HashMap::new()),
             workdir,
             mcp_configs,
+            channel_mcp_configs,
             patterns,
             global_inbound_attachments,
             vision_client,
@@ -533,12 +537,13 @@ impl JycAgentService {
         // Add MCP bridge tools (reply_message, etc.)
         crate::tools::mcp_bridge::register_mcp_tools(&mut registry);
 
-        // Resolve MCP configs: per-pattern first, global fallback
+        // Resolve MCP configs: pattern → channel → global
         let mcp_configs: &[McpServerConfig] = matched_pattern_name
             .and_then(|name| self.patterns.iter().find(|p| p.name == name))
             .and_then(|p| p.mcps.as_ref())
             .map(|mcps| mcps.as_slice())
-            .unwrap_or_else(|| self.mcp_configs.as_slice());
+            .or(self.channel_mcp_configs.as_deref())
+            .unwrap_or(self.mcp_configs.as_slice());
 
         // Load external MCP tools from resolved configs
         if !mcp_configs.is_empty() {
@@ -868,6 +873,7 @@ mod tests {
             },
             PathBuf::from("/tmp/test-workdir"),
             vec![],
+            None,
             patterns,
             None,
             None,

--- a/crates/jyc-agent/tests/unit_tests.rs
+++ b/crates/jyc-agent/tests/unit_tests.rs
@@ -692,7 +692,15 @@ mod skills {
 
     /// Helper: create a JycAgentService with a specific workdir.
     fn make_service(workdir: PathBuf) -> JycAgentService {
-        JycAgentService::new(AgentConfig::default(), workdir, vec![], vec![], None, None)
+        JycAgentService::new(
+            AgentConfig::default(),
+            workdir,
+            vec![],
+            None,
+            vec![],
+            None,
+            None,
+        )
     }
 
     #[test]

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -385,6 +385,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     agent_cfg,
                     workdir.to_path_buf(),
                     config_snapshot.mcps.clone(),
+                    channel_config.mcps.clone(),
                     channel_patterns,
                     inbound_attachment_config.clone(),
                     vision_client,

--- a/crates/jyc-types/src/config.rs
+++ b/crates/jyc-types/src/config.rs
@@ -160,6 +160,14 @@ pub struct ChannelConfig {
 
     /// Footer display configuration (omit for default: footer enabled)
     pub footer: Option<FooterConfig>,
+
+    /// Channel-level MCP server configurations.
+    ///
+    /// When set, these MCPs are loaded for all threads in this channel.
+    /// Pattern-level `mcps` takes priority over this. When both are unset,
+    /// falls back to global `[[mcps]]`.
+    #[serde(default)]
+    pub mcps: Option<Vec<McpServerConfig>>,
 }
 
 /// IMAP server configuration.


### PR DESCRIPTION
## Problem

MCP servers can only be configured globally (all channels) or per-pattern (specific matching rules). There is no way to configure MCP tools for an entire channel without repeating the config in every pattern.

## Solution

Add `mcps` field to `ChannelConfig`. MCP resolution priority:

1. **Pattern-level** `mcps` — overrides everything
2. **Channel-level** `mcps` — fallback when pattern has none
3. **Global** `[[mcps]]` — final fallback

## Changes

| File | Change |
|------|--------|
| `jyc-types/src/config.rs` | Add `mcps: Option<Vec<McpServerConfig>>` to `ChannelConfig` |
| `jyc-agent/src/service.rs` | Add `channel_mcp_configs`, update `build_tool_registry` priority |
| `jyc-cli/src/cli/monitor.rs` | Pass `channel_config.mcps` to `JycAgentService::new` |
| `jyc-agent/tests/unit_tests.rs` | Update constructor calls |
| `config.example.toml` | Add channel-level MCP example |
| `CHANGELOG.md` | Document new feature |

## Usage

```toml
[channels.my_wecomkf]
type = "wecomkf"

[[channels.my_wecomkf.mcps]]
name = "kf_helper"
type = "local"
command = ["kf-helper", "mcp"]
```

## Verification
- [x] `cargo fmt && cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` (all pass)

Refs: #241