### PR TITLE
chore: agent 禁止本地运行 coverage，CI 阈值提升至 60%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Check coverage threshold
         run: |
-          threshold=55
+          threshold=60
           pct=$(awk '/^TOTAL/ {gsub(/%/,"",$10); printf "%.0f", $10}' coverage.txt)
           echo "Line coverage: ${pct}%"
           if [ -z "${pct}" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ and uses OpenCode to generate AI replies.
 - 使用连字符（`-`）分隔单词，禁止大写字母
 
 ### PR 前检查清单
-提交 PR 前必须在本地通过以下四步检查：
+提交 PR 前必须在本地通过以下五步检查：
 
 1. **格式化检查**
    ```bash
@@ -55,6 +55,8 @@ and uses OpenCode to generate AI replies.
    ```
    默认并行执行，确保所有测试稳定通过。
 4. **文档确认** — 根据变更类型检查是否需要更新相关文档（参见「文档约定」章节）
+5. **禁止本地运行覆盖率** — `cargo llvm-cov`、`cargo-tarpaulin` 等覆盖率工具禁止在本地运行。
+   覆盖率检查速度太慢，CI（`.github/workflows/ci.yml`）会在 PR 提交后自动运行并检查阈值。
 
 ### 提交信息格式
 遵循 [Conventional Commits](https://www.conventionalcommits.org/) 格式：

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ and uses OpenCode to generate AI replies.
 
 1. **格式化检查**
    ```bash
-   cargo fmt && cargo fmt --check
+   cargo fmt --check
    ```
 2. **Clippy 静态检查**
    ```bash

--- a/crates/jyc-agent/tests/unit_tests.rs
+++ b/crates/jyc-agent/tests/unit_tests.rs
@@ -666,6 +666,7 @@ mod mcp_bridge {
     }
 
     impl MockOutbound {
+        #[allow(clippy::type_complexity)]
         fn new() -> (Self, Arc<Mutex<Vec<(String, String, String)>>>) {
             let calls = Arc::new(Mutex::new(Vec::new()));
             (


### PR DESCRIPTION
## Spec

禁止 agent 在本地运行覆盖率工具（`cargo llvm-cov` 等），因为速度太慢且 CI 已自动处理。
同时修正 `cargo fmt && cargo fmt --check` 为仅 `cargo fmt --check`，
并将 CI 覆盖率阈值从 55% 提升至 60%。

Fixes #242

## Implementation Plan

### Step 1: 修正 AGENTS.md 中的 fmt 检查命令
**What:** 将 `AGENTS.md` 第 46 行的 `cargo fmt && cargo fmt --check` 改为 `cargo fmt --check`
**Why:** `cargo fmt` 自动修改代码后 `cargo fmt --check` 永远不会失败，冗余。仅保留 `--check` 即可验证格式。
**Verify:** 确认 AGENTS.md 中只保留 `cargo fmt --check`

### Step 2: AGENTS.md 增加禁止本地运行覆盖率的规则
**What:** 在 AGENTS.md「PR 前检查清单」末尾（第 56 行「文档确认」之后、第 58 行「提交信息格式」之前）增加第 5 条规则：
```
5. **禁止本地运行覆盖率** — `cargo llvm-cov`、`cargo-tarpaulin` 等覆盖率工具禁止在本地运行。
   覆盖率检查速度太慢，CI（`.github/workflows/ci.yml`）会在 PR 提交后自动运行并检查阈值。
```
**Why:** 明确禁止 agent 在本地跑覆盖率，避免浪费时间。CI 已覆盖此检查。
**Verify:** 确认 AGENTS.md 中新增的规则位置和内容正确，位于「文档确认」和「提交信息格式」之间

### Step 3: 将 CI 覆盖率阈值从 55% 提升到 60%
**What:** 修改 `.github/workflows/ci.yml` 第 54 行：`threshold=55` → `threshold=60`
**Why:** 提高代码覆盖率要求，确保测试质量。
**Verify:** `grep 'threshold=60' .github/workflows/ci.yml` 返回匹配行