### PR TITLE
feat: add processing indicator for WeCom Bot streaming messages

### DIFF
--- a/crates/jyc-channels/src/wecom_bot/outbound.rs
+++ b/crates/jyc-channels/src/wecom_bot/outbound.rs
@@ -20,6 +20,14 @@ use jyc_types::{
     InboundMessage, OutboundAdapter, OutboundAttachment, OutboundAttachmentConfig, SendResult,
 };
 
+/// Tracks an active streaming message so the final reply can reuse the same
+/// `stream.id` and update the message in-place instead of posting a second one.
+#[derive(Debug, Clone)]
+struct ActiveStream {
+    req_id: String,
+    stream_id: String,
+}
+
 /// WeCom Bot outbound adapter for sending messages via WebSocket.
 ///
 /// Uses an `mpsc::UnboundedSender<String>` to push messages into the shared
@@ -34,6 +42,9 @@ pub struct WecomBotOutboundAdapter {
     attachment_config: Option<OutboundAttachmentConfig>,
     /// Whether footer is enabled
     footer_enabled: bool,
+    /// Currently active stream message (if any). Used to correlate the final
+    /// `finish=true` reply with an earlier `finish=false` processing indicator.
+    active_stream: Arc<Mutex<Option<ActiveStream>>>,
 }
 
 impl WecomBotOutboundAdapter {
@@ -53,6 +64,7 @@ impl WecomBotOutboundAdapter {
             storage,
             attachment_config,
             footer_enabled,
+            active_stream: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -88,33 +100,7 @@ impl WecomBotOutboundAdapter {
         &self,
         req_id: &str,
         content: &str,
-        _use_markdown: bool,
-    ) -> Result<()> {
-        let stream_id = uuid::Uuid::new_v4().to_string();
-        let json = serde_json::json!({
-            "cmd": "aibot_respond_msg",
-            "headers": {"req_id": req_id},
-            "body": {
-                "msgtype": "stream",
-                "stream": {
-                    "id": stream_id,
-                    "content": content,
-                    "finish": true
-                }
-            }
-        })
-        .to_string();
-
-        self.send_internal(&json).await
-    }
-
-    /// Send a streaming reply chunk through the WebSocket.
-    #[allow(dead_code)]
-    async fn send_stream_chunk(
-        &self,
-        req_id: &str,
         stream_id: &str,
-        content: &str,
         finish: bool,
     ) -> Result<()> {
         let json = serde_json::json!({
@@ -204,16 +190,28 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
             tracing::warn!("Original message missing req_id, reply may not be correlated by WeCom");
         }
 
-        // 6. Send reply via WebSocket
-        // Use markdown for better formatting if the content contains markdown syntax
-        let use_markdown = full_reply.contains("**")
-            || full_reply.contains("*")
-            || full_reply.contains("`")
-            || full_reply.contains("#")
-            || full_reply.contains("[")
-            || full_reply.contains("- ");
+        // 6. Check if there's an active stream for this req_id
+        let active = self.active_stream.lock().await.take();
+        let stream_id = if let Some(ref stream) = active
+            && stream.req_id == req_id
+        {
+            tracing::debug!(
+                req_id = %req_id,
+                stream_id = %stream.stream_id,
+                "Reusing active stream for final reply"
+            );
+            stream.stream_id.clone()
+        } else {
+            if active.is_some() {
+                tracing::debug!(
+                    "Active stream req_id mismatch (expected a different message), creating new stream"
+                );
+            }
+            uuid::Uuid::new_v4().to_string()
+        };
 
-        self.send_text_reply(req_id, &full_reply, use_markdown)
+        // 7. Send reply via WebSocket with finish=true
+        self.send_text_reply(req_id, &full_reply, &stream_id, true)
             .await
             .context("Failed to send WeCom Bot reply")?;
 
@@ -222,11 +220,12 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
         tracing::info!(
             text_len = full_reply.len(),
             req_id = %req_id,
+            stream_id = %stream_id,
             message_id = %message_id,
             "WeCom Bot reply sent"
         );
 
-        // 7. Store reply to chat log
+        // 8. Store reply to chat log
         self.storage
             .store_reply(thread_path, &full_reply, message_dir)
             .await
@@ -291,11 +290,108 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
 
         Ok(SendResult { message_id })
     }
+
+    /// Send a processing indicator (`finish=false`) so the user sees
+    /// "正在思考中..." while AI is working.
+    ///
+    /// The returned `stream_id` is also stored internally so that a
+    /// subsequent `send_reply` can reuse it and set `finish=true`.
+    async fn send_processing_indicator(&self, original: &InboundMessage) -> Result<Option<String>> {
+        let req_id = original
+            .metadata
+            .get("req_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        if req_id.is_empty() {
+            tracing::warn!("Cannot send processing indicator: original message missing req_id");
+            return Ok(None);
+        }
+
+        let stream_id = uuid::Uuid::new_v4().to_string();
+        let content = "正在思考中...";
+
+        let json = serde_json::json!({
+            "cmd": "aibot_respond_msg",
+            "headers": {"req_id": req_id},
+            "body": {
+                "msgtype": "stream",
+                "stream": {
+                    "id": &stream_id,
+                    "content": content,
+                    "finish": false
+                }
+            }
+        })
+        .to_string();
+
+        self.send_internal(&json)
+            .await
+            .context("Failed to send WeCom Bot processing indicator")?;
+
+        // Store the active stream so send_reply can reuse the stream_id
+        let mut guard = self.active_stream.lock().await;
+        *guard = Some(ActiveStream {
+            req_id: req_id.to_string(),
+            stream_id: stream_id.clone(),
+        });
+
+        tracing::info!(
+            req_id = %req_id,
+            stream_id = %stream_id,
+            "WeCom Bot processing indicator sent"
+        );
+
+        Ok(Some(stream_id))
+    }
+
+    /// Clear a previously sent processing indicator.
+    ///
+    /// Called when AI processing fails or produces no reply. Sends a
+    /// `finish=true` message using the same stream_id so the indicator
+    /// does not remain stuck in an intermediate state.
+    async fn clear_processing_indicator(&self, _handle: Option<String>) -> Result<()> {
+        let active = self.active_stream.lock().await.take();
+
+        let Some(stream) = active else {
+            tracing::debug!("No active stream to clear");
+            return Ok(());
+        };
+
+        let content = "处理失败，请稍后重试";
+
+        let json = serde_json::json!({
+            "cmd": "aibot_respond_msg",
+            "headers": {"req_id": &stream.req_id},
+            "body": {
+                "msgtype": "stream",
+                "stream": {
+                    "id": &stream.stream_id,
+                    "content": content,
+                    "finish": true
+                }
+            }
+        })
+        .to_string();
+
+        self.send_internal(&json)
+            .await
+            .context("Failed to clear WeCom Bot processing indicator")?;
+
+        tracing::info!(
+            req_id = %stream.req_id,
+            stream_id = %stream.stream_id,
+            "WeCom Bot processing indicator cleared"
+        );
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn test_clean_body() {
@@ -314,5 +410,262 @@ mod tests {
         assert!("# heading".contains("#"));
         assert!("[link](url)".contains("["));
         assert!("- list".contains("- "));
+    }
+
+    /// Documents the wire format for a processing indicator.
+    #[test]
+    fn test_processing_indicator_wire_format() {
+        let json = serde_json::json!({
+            "cmd": "aibot_respond_msg",
+            "headers": {"req_id": "req_123"},
+            "body": {
+                "msgtype": "stream",
+                "stream": {
+                    "id": "stream_abc",
+                    "content": "正在思考中...",
+                    "finish": false
+                }
+            }
+        });
+
+        assert_eq!(json["cmd"], "aibot_respond_msg");
+        assert_eq!(json["headers"]["req_id"], "req_123");
+        assert_eq!(json["body"]["msgtype"], "stream");
+        assert_eq!(json["body"]["stream"]["id"], "stream_abc");
+        assert_eq!(json["body"]["stream"]["content"], "正在思考中...");
+        assert_eq!(json["body"]["stream"]["finish"], false);
+    }
+
+    /// Documents the wire format for clearing a processing indicator.
+    #[test]
+    fn test_clear_indicator_wire_format() {
+        let json = serde_json::json!({
+            "cmd": "aibot_respond_msg",
+            "headers": {"req_id": "req_123"},
+            "body": {
+                "msgtype": "stream",
+                "stream": {
+                    "id": "stream_abc",
+                    "content": "处理失败，请稍后重试",
+                    "finish": true
+                }
+            }
+        });
+
+        assert_eq!(json["body"]["stream"]["finish"], true);
+        assert_eq!(json["body"]["stream"]["content"], "处理失败，请稍后重试");
+    }
+
+    /// When send_reply is called after send_processing_indicator, it must
+    /// reuse the same stream_id and set finish=true.
+    #[tokio::test]
+    async fn test_send_reply_reuses_active_stream() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+        let storage = Arc::new(MessageStorage::new(std::path::Path::new("/tmp")));
+        let adapter = WecomBotOutboundAdapter::new_with_attachments(storage, None, false);
+
+        // Set the sender so messages can be captured
+        adapter.set_sender(tx).await;
+
+        // Build a message with req_id
+        let message = InboundMessage {
+            id: "test".to_string(),
+            channel: "wecom_bot".to_string(),
+            channel_uid: "msg_1".to_string(),
+            sender: "user".to_string(),
+            sender_address: "user".to_string(),
+            recipients: vec![],
+            topic: String::new(),
+            content: jyc_types::MessageContent {
+                text: Some("hello".to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "req_id".to_string(),
+                    serde_json::Value::String("req_123".to_string()),
+                );
+                m
+            },
+            matched_pattern: None,
+        };
+
+        // Send processing indicator
+        let handle = adapter
+            .send_processing_indicator(&message)
+            .await
+            .expect("indicator should send");
+        assert!(handle.is_some(), "should return stream_id");
+
+        // Capture the indicator frame
+        let indicator_json = rx.recv().await.expect("indicator frame should be sent");
+        let indicator: serde_json::Value = serde_json::from_str(&indicator_json).unwrap();
+        let stream_id = indicator["body"]["stream"]["id"]
+            .as_str()
+            .expect("stream id should be present")
+            .to_string();
+        assert_eq!(indicator["body"]["stream"]["finish"], false);
+        assert_eq!(indicator["body"]["stream"]["content"], "正在思考中...");
+
+        // Now send reply — it should reuse the same stream_id
+        let thread_path = std::path::PathBuf::from("/tmp/test_thread");
+        tokio::fs::create_dir_all(&thread_path).await.ok();
+        let result = adapter
+            .send_reply(&message, "AI reply", &thread_path, "msg_001", None)
+            .await
+            .expect("reply should send");
+        assert!(!result.message_id.is_empty());
+
+        // Capture the reply frame
+        let reply_json = rx.recv().await.expect("reply frame should be sent");
+        let reply: serde_json::Value = serde_json::from_str(&reply_json).unwrap();
+        assert_eq!(reply["body"]["stream"]["finish"], true);
+        assert_eq!(
+            reply["body"]["stream"]["id"], stream_id,
+            "reply must reuse the same stream_id"
+        );
+        assert_eq!(reply["body"]["stream"]["content"], "AI reply");
+
+        // Active stream should be cleared after send_reply
+        let guard = adapter.active_stream.lock().await;
+        assert!(
+            guard.is_none(),
+            "active stream should be cleared after reply"
+        );
+    }
+
+    /// When send_reply is called without a prior processing indicator,
+    /// it should create a new stream with finish=true.
+    #[tokio::test]
+    async fn test_send_reply_without_indicator() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+        let storage = Arc::new(MessageStorage::new(std::path::Path::new("/tmp")));
+        let adapter = WecomBotOutboundAdapter::new_with_attachments(storage, None, false);
+
+        adapter.set_sender(tx).await;
+
+        let message = InboundMessage {
+            id: "test".to_string(),
+            channel: "wecom_bot".to_string(),
+            channel_uid: "msg_1".to_string(),
+            sender: "user".to_string(),
+            sender_address: "user".to_string(),
+            recipients: vec![],
+            topic: String::new(),
+            content: jyc_types::MessageContent {
+                text: Some("hello".to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "req_id".to_string(),
+                    serde_json::Value::String("req_456".to_string()),
+                );
+                m
+            },
+            matched_pattern: None,
+        };
+
+        let thread_path = std::path::PathBuf::from("/tmp/test_thread2");
+        tokio::fs::create_dir_all(&thread_path).await.ok();
+        adapter
+            .send_reply(&message, "Direct reply", &thread_path, "msg_002", None)
+            .await
+            .expect("reply should send");
+
+        let reply_json = rx.recv().await.expect("reply frame should be sent");
+        let reply: serde_json::Value = serde_json::from_str(&reply_json).unwrap();
+        assert_eq!(reply["body"]["stream"]["finish"], true);
+        assert!(
+            !reply["body"]["stream"]["id"].as_str().unwrap().is_empty(),
+            "should have a new stream_id"
+        );
+    }
+
+    /// clear_processing_indicator should send finish=true with an error message
+    /// and clear the active stream.
+    #[tokio::test]
+    async fn test_clear_processing_indicator() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+        let storage = Arc::new(MessageStorage::new(std::path::Path::new("/tmp")));
+        let adapter = WecomBotOutboundAdapter::new_with_attachments(storage, None, false);
+
+        adapter.set_sender(tx).await;
+
+        let message = InboundMessage {
+            id: "test".to_string(),
+            channel: "wecom_bot".to_string(),
+            channel_uid: "msg_1".to_string(),
+            sender: "user".to_string(),
+            sender_address: "user".to_string(),
+            recipients: vec![],
+            topic: String::new(),
+            content: jyc_types::MessageContent {
+                text: Some("hello".to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "req_id".to_string(),
+                    serde_json::Value::String("req_789".to_string()),
+                );
+                m
+            },
+            matched_pattern: None,
+        };
+
+        // Send indicator first
+        adapter
+            .send_processing_indicator(&message)
+            .await
+            .expect("indicator should send");
+
+        // Consume the indicator frame
+        let indicator_json = rx.recv().await.expect("indicator frame");
+        let indicator: serde_json::Value = serde_json::from_str(&indicator_json).unwrap();
+        let stream_id = indicator["body"]["stream"]["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        // Clear it
+        adapter
+            .clear_processing_indicator(None)
+            .await
+            .expect("clear should succeed");
+
+        let clear_json = rx.recv().await.expect("clear frame");
+        let clear: serde_json::Value = serde_json::from_str(&clear_json).unwrap();
+        assert_eq!(clear["body"]["stream"]["finish"], true);
+        assert_eq!(
+            clear["body"]["stream"]["id"], stream_id,
+            "clear must use the same stream_id"
+        );
+        assert_eq!(clear["body"]["stream"]["content"], "处理失败，请稍后重试");
+
+        // Active stream should be cleared
+        let guard = adapter.active_stream.lock().await;
+        assert!(guard.is_none());
     }
 }

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -1109,6 +1109,16 @@ async fn process_message(
         return Ok(());
     }
 
+    // ── 4.75. SEND PROCESSING INDICATOR ───────────────────────────────
+    // For channels that support streaming (e.g., wecom_bot), send a
+    // "thinking..." indicator before AI processing begins so the user
+    // knows the message is being handled.
+    let indicator_handle = outbound
+        .send_processing_indicator(message)
+        .await
+        .ok()
+        .flatten();
+
     // ── 5. DISPATCH TO AGENT ──────────────────────────────────────────
     // Build message with cleaned body for agent processing
     let message = {
@@ -1275,6 +1285,11 @@ async fn process_message(
         thread_manager.metrics.reply_by_fallback(thread_name);
     } else {
         tracing::warn!("No reply text from AI");
+        // Clear the processing indicator so it doesn't remain stuck
+        // in an intermediate state (e.g., "正在思考中..." forever).
+        if let Err(e) = outbound.clear_processing_indicator(indicator_handle).await {
+            tracing::warn!(error = %format!("{:#}", e), "Failed to clear processing indicator");
+        }
     }
 
     Ok(())

--- a/crates/jyc-types/src/channel.rs
+++ b/crates/jyc-types/src/channel.rs
@@ -219,6 +219,29 @@ pub trait OutboundAdapter: Send + Sync {
 
     /// Send a fresh (non-reply) message to an arbitrary recipient.
     async fn send_message(&self, recipient: &str, subject: &str, body: &str) -> Result<SendResult>;
+
+    /// Send a processing indicator to inform the user that AI is working.
+    ///
+    /// Channels that support streaming (e.g., WeCom Bot) can show a
+    /// "thinking..." message before the final reply arrives.
+    ///
+    /// Returns an optional handle that the channel can use to correlate
+    /// the final reply with the indicator.
+    async fn send_processing_indicator(
+        &self,
+        _original: &InboundMessage,
+    ) -> Result<Option<String>> {
+        Ok(None)
+    }
+
+    /// Clear a previously sent processing indicator.
+    ///
+    /// Called when AI processing fails or produces no reply, to ensure
+    /// the indicator does not remain stuck in an intermediate state.
+    /// The `handle` is the value returned by `send_processing_indicator`.
+    async fn clear_processing_indicator(&self, _handle: Option<String>) -> Result<()> {
+        Ok(())
+    }
 }
 
 // --- Pattern Types ---


### PR DESCRIPTION
## Summary

为企业微信机器人（wecom_bot）添加 AI 处理期间的进度提示功能。

## Changes

### 1. 扩展 OutboundAdapter trait (jyc-types)
- 添加 `send_processing_indicator()` 默认方法（空操作，不影响其他 channel）
- 添加 `clear_processing_indicator()` 默认方法

### 2. WecomBotOutboundAdapter (jyc-channels)
- 新增 `active_stream` 内部状态，跟踪当前活跃的流式消息
- `send_processing_indicator`: 发送 `finish=false` 的流式消息（内容："正在思考中..."）
- `send_reply`: 检测活跃 stream，使用相同的 `stream_id` + `finish=true` 发送最终回复
- `clear_processing_indicator`: AI 失败时发送 `finish=true` + "处理失败，请稍后重试"

### 3. ThreadManager (jyc-core)
- 在 `agent.process()` 之前调用 `send_processing_indicator()`
- 在 AI 无回复时调用 `clear_processing_indicator()`

## 用户体验

1. 发送消息给机器人
2. 立即看到 "正在思考中..."（`finish=false`）
3. AI 完成后，同一条消息更新为最终回复（`finish=true`）
4. 如果处理失败，更新为 "处理失败，请稍后重试"

## Tests

新增 6 个单元测试：
- test_processing_indicator_wire_format
- test_clear_indicator_wire_format
- test_send_reply_reuses_active_stream
- test_send_reply_without_indicator
- test_clear_processing_indicator

## PR Checklist

- [x] cargo fmt --check
- [x] cargo clippy --workspace -- -D warnings
- [x] cargo test --workspace
