### PR TITLE
feat: add dynamic spinner progress indicator for WeCom Bot

### DIFF
--- a/crates/jyc-channels/src/wecom_bot/outbound.rs
+++ b/crates/jyc-channels/src/wecom_bot/outbound.rs
@@ -119,6 +119,21 @@ impl WecomBotOutboundAdapter {
 
         self.send_internal(&json).await
     }
+
+    /// Update an existing processing indicator with new content.
+    ///
+    /// Unlike `send_reply`, this does NOT clear the `active_stream` state,
+    /// allowing subsequent updates to reuse the same `stream_id`.
+    pub async fn update_processing_indicator(
+        &self,
+        req_id: &str,
+        stream_id: &str,
+        content: &str,
+    ) -> Result<()> {
+        self.send_text_reply(req_id, content, stream_id, false)
+            .await
+            .context("Failed to update WeCom Bot processing indicator")
+    }
 }
 
 #[async_trait]
@@ -382,6 +397,41 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
             req_id = %stream.req_id,
             stream_id = %stream.stream_id,
             "WeCom Bot processing indicator cleared"
+        );
+
+        Ok(())
+    }
+
+    /// Update an existing processing indicator with new content.
+    ///
+    /// Sends `finish=false` with the same `stream_id` so the message
+    /// is updated in-place rather than creating a new one.
+    async fn update_processing_indicator(
+        &self,
+        original: &InboundMessage,
+        handle: &str,
+        content: &str,
+    ) -> Result<()> {
+        let req_id = original
+            .metadata
+            .get("req_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        if req_id.is_empty() {
+            tracing::warn!("Cannot update processing indicator: original message missing req_id");
+            return Ok(());
+        }
+
+        self.send_text_reply(req_id, content, handle, false)
+            .await
+            .context("Failed to update WeCom Bot processing indicator")?;
+
+        tracing::debug!(
+            req_id = %req_id,
+            stream_id = %handle,
+            content = %content,
+            "WeCom Bot processing indicator updated"
         );
 
         Ok(())

--- a/crates/jyc-channels/tests/close_handler_test.rs
+++ b/crates/jyc-channels/tests/close_handler_test.rs
@@ -85,6 +85,7 @@ async fn test_close_command_deletes_thread_directory() {
         PathBuf::from("/tmp/templates"),
         test_config_swap(),
         "test".to_string(),
+        "email".to_string(),
         workspace.clone(),
         MetricsHandle::noop(),
     ));
@@ -128,6 +129,7 @@ async fn test_close_command_nonexistent_thread_succeeds() {
         PathBuf::from("/tmp/templates"),
         test_config_swap(),
         "test".to_string(),
+        "email".to_string(),
         workspace.clone(),
         MetricsHandle::noop(),
     ));
@@ -168,6 +170,7 @@ async fn test_close_command_invalid_thread_path() {
         PathBuf::from("/tmp/templates"),
         test_config_swap(),
         "test".to_string(),
+        "email".to_string(),
         workspace.clone(),
         MetricsHandle::noop(),
     ));

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -471,6 +471,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
             template_dir,
             config.clone(),
             channel_name.clone(),
+            channel_type.to_string(),
             workspace_dir.clone(),
             metrics_handle.clone(),
         ));

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -69,6 +69,8 @@ pub struct ThreadManager {
 
     // Channel name this ThreadManager belongs to
     channel_name: String,
+    // Channel type (e.g., "email", "wecom_bot")
+    channel_type: String,
 
     // Workspace directory for this channel (<workdir>/<channel>/workspace/)
     workspace_dir: PathBuf,
@@ -99,6 +101,7 @@ impl ThreadManager {
         template_dir: PathBuf,
         config: Arc<ArcSwap<jyc_types::AppConfig>>,
         channel_name: String,
+        channel_type: String,
         workspace_dir: PathBuf,
         metrics: MetricsHandle,
     ) -> Self {
@@ -113,6 +116,7 @@ impl ThreadManager {
             template_dir,
             config,
             channel_name,
+            channel_type,
             workspace_dir,
             metrics,
         )
@@ -131,6 +135,7 @@ impl ThreadManager {
         template_dir: PathBuf,
         config: Arc<ArcSwap<jyc_types::AppConfig>>,
         channel_name: String,
+        channel_type: String,
         workspace_dir: PathBuf,
         metrics: MetricsHandle,
     ) -> Self {
@@ -146,6 +151,7 @@ impl ThreadManager {
             thread_cancels: Mutex::new(HashMap::new()),
             template_dir,
             channel_name,
+            channel_type,
             workspace_dir,
             config,
             metrics,
@@ -269,6 +275,7 @@ impl ThreadManager {
             thread_cancels: Mutex::new(HashMap::new()),
             template_dir: self.template_dir.clone(),
             channel_name: self.channel_name.clone(),
+            channel_type: self.channel_type.clone(),
             workspace_dir: self.workspace_dir.clone(),
             config: self.config.clone(),
             metrics: self.metrics.clone(),
@@ -596,6 +603,11 @@ impl ThreadManager {
     /// Return the channel name this ThreadManager belongs to.
     pub fn channel_name(&self) -> &str {
         &self.channel_name
+    }
+
+    /// Return the channel type (e.g., "email", "wecom_bot").
+    pub fn channel_type(&self) -> &str {
+        &self.channel_type
     }
 
     /// Return the max concurrent threads (semaphore capacity).
@@ -1119,6 +1131,32 @@ async fn process_message(
         .ok()
         .flatten();
 
+    // ── 4.8. START PROGRESS UPDATER ───────────────────────────────────
+    // For wecom_bot, spawn a background task that updates the processing
+    // indicator with a rotating spinner every 3 seconds.
+    let progress_cancel = tokio_util::sync::CancellationToken::new();
+    let progress_handle = if thread_manager.channel_type() == "wecom_bot" {
+        if let Some(ref stream_id) = indicator_handle {
+            let progress_outbound = outbound.clone();
+            let progress_message = message.clone();
+            let progress_stream_id = stream_id.clone();
+            let progress_cancel_child = progress_cancel.clone();
+            Some(tokio::spawn(async move {
+                update_progress_indicator(
+                    progress_outbound,
+                    progress_message,
+                    progress_stream_id,
+                    progress_cancel_child,
+                )
+                .await;
+            }))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
     // ── 5. DISPATCH TO AGENT ──────────────────────────────────────────
     // Build message with cleaned body for agent processing
     let message = {
@@ -1185,6 +1223,12 @@ async fn process_message(
     // Stop the delivery watcher
     delivery_cancel.cancel();
     let _ = delivery_handle.await;
+
+    // Stop the progress updater
+    progress_cancel.cancel();
+    if let Some(handle) = progress_handle {
+        let _ = handle.await;
+    }
 
     // ── 5.5. GUARD: skip reply if thread directory no longer exists ──
     // If the thread was closed while AI was processing, the directory gets
@@ -1293,6 +1337,51 @@ async fn process_message(
     }
 
     Ok(())
+}
+
+/// Braille spinner frames for dynamic progress indicator.
+const SPINNER: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Background task that updates the WeCom Bot processing indicator
+/// with a rotating spinner and elapsed time every 3 seconds.
+///
+/// The indicator content cycles through spinner frames while maintaining
+/// a consistent activity message, giving the user a sense of progress.
+async fn update_progress_indicator(
+    outbound: Arc<dyn OutboundAdapter>,
+    message: InboundMessage,
+    stream_id: String,
+    cancel: CancellationToken,
+) {
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(3));
+    let mut frame_idx = 0usize;
+    let mut elapsed_secs = 0u64;
+
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                let frame = SPINNER[frame_idx % SPINNER.len()];
+                let content = format!(
+                    "{} 正在处理中... (已用 {}s)",
+                    frame, elapsed_secs
+                );
+
+                if let Err(e) = outbound
+                    .update_processing_indicator(&message, &stream_id, &content)
+                    .await
+                {
+                    tracing::debug!(
+                        error = %format!("{:#}", e),
+                        "Failed to update progress indicator"
+                    );
+                }
+
+                frame_idx += 1;
+                elapsed_secs += 3;
+            }
+            _ = cancel.cancelled() => break,
+        }
+    }
 }
 
 /// Read attachment filenames from the reply-sent.flag signal file.

--- a/crates/jyc-types/src/channel.rs
+++ b/crates/jyc-types/src/channel.rs
@@ -234,6 +234,21 @@ pub trait OutboundAdapter: Send + Sync {
         Ok(None)
     }
 
+    /// Update a previously sent processing indicator with new content.
+    ///
+    /// Channels that support streaming can update the indicator text
+    /// in-place (e.g., showing a rotating spinner or changing activity).
+    ///
+    /// The `handle` is the value returned by `send_processing_indicator`.
+    async fn update_processing_indicator(
+        &self,
+        _original: &InboundMessage,
+        _handle: &str,
+        _content: &str,
+    ) -> Result<()> {
+        Ok(())
+    }
+
     /// Clear a previously sent processing indicator.
     ///
     /// Called when AI processing fails or produces no reply, to ensure


### PR DESCRIPTION
## Summary

为企业微信机器人（wecom_bot）添加动态旋转动画进度指示器。

## Changes

### 1. 动态旋转动画
- 使用 Braille 图案（⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏）制作旋转效果
- 每 3 秒更新一次，循环 10 帧
- 显示已用时间：`正在处理中... (已用 12s)`

### 2. OutboundAdapter trait 扩展 (jyc-types)
- 新增 `update_processing_indicator()` 默认方法（空操作）
- 允许 channel 在不创建新消息的情况下更新已有 indicator

### 3. WecomBotOutboundAdapter (jyc-channels)
- 实现 `update_processing_indicator()`
- 发送 `finish=false` + 相同 `stream_id` 更新流式消息内容

### 4. ThreadManager (jyc-core)
- AI 处理前启动后台任务 `update_progress_indicator()`
- 每 3 秒更新 indicator 内容和旋转符号
- AI 完成后自动停止 updater

## 用户体验

```
用户: "帮我查一下天气"
    ↓
机器人: "⠋ 正在处理中... (已用 0s)"
    ↓
机器人: "⠙ 正在处理中... (已用 3s)"   ← 同一条消息更新
    ↓
机器人: "⠹ 正在处理中... (已用 6s)"   ← 旋转符号变化
    ↓
机器人: "今天北京天气晴..."          ← 最终回复 (finish=true)
```

## PR Checklist

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` (1 flaky test unrelated to changes)
