### PR TITLE
fix: add fnm + Node 22 to Dockerfile full stage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -93,5 +93,11 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 
 RUN mkdir -p /root/.config/gh
 
+# Install fnm (Fast Node Manager) and Node 22
+RUN curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir /root/.fnm
+ENV FNM_DIR="/root/.fnm"
+ENV PATH="/root/.fnm/aliases/default/bin:/root/.fnm:${PATH}"
+RUN fnm install 22 && fnm default 22
+
 # ── Stage 4: Production alias (backward compatible) ──────────────────
 FROM full AS production

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -94,10 +94,15 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
 RUN mkdir -p /root/.config/gh
 
 # Install fnm (Fast Node Manager) and Node 22
-RUN curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir /root/.fnm
+RUN curl -fsSL https://fnm.vercel.app/install | bash -s -- --install-dir /root/.fnm && \
+    export FNM_DIR="/root/.fnm" && \
+    eval "$(/root/.fnm/fnm env --shell bash)" && \
+    fnm install 22 && \
+    fnm default 22 && \
+    node_version=$(ls /root/.fnm/versions/node/ | head -1) && \
+    ln -sf "/root/.fnm/versions/node/$node_version" /root/.node-current
 ENV FNM_DIR="/root/.fnm"
-ENV PATH="/root/.fnm/aliases/default/bin:/root/.fnm:${PATH}"
-RUN fnm install 22 && fnm default 22
+ENV PATH="/root/.node-current/bin:/root/.fnm:${PATH}"
 
 # ── Stage 4: Production alias (backward compatible) ──────────────────
 FROM full AS production


### PR DESCRIPTION
## Spec

在 `docker/Dockerfile` 的 `full` stage 中安装 fnm (Fast Node Manager) 并预装 Node 22，
修复 AI agent 模板声明（`fnm is pre-installed`）与实际 Docker 镜像之间的不一致。

Fixes #249

## Implementation Plan

### Step 1: 在 full stage 中添加 fnm 安装与 Node 22 设置
**What:** 编辑 `docker/Dockerfile`，在 full stage 末尾（约第 94 行 `RUN mkdir -p /root/.config/gh` 之后）添加：
1. 下载安装 fnm 到 `/root/.fnm`
2. 通过 `ENV PATH` 将 fnm 加入 PATH
3. `fnm install 22 && fnm default 22` 安装并默认使用 Node 22
**Why:** AI agent 模板（github-developer, github-reviewer, gitee-developer, gitee-reviewer）均声明 `fnm is pre-installed`，full 镜像需要满足此承诺。
**Verify:** 
```bash
docker build --target full -t jyc-full:test -f docker/Dockerfile .
docker run --rm jyc-full:test fnm --version   # 应输出 fnm 版本号
docker run --rm jyc-full:test node --version   # 应输出 v22.x.x
docker run --rm jyc-full:test npm --version    # 应输出 npm 版本号
```

## Design Decisions
- 使用 `/root/.fnm` 作为 fnm 安装目录，与各 agent 模板中 `fnm install <version> && fnm use <version>` 的预期一致
- 安装完成后 `fnm default 22`，确保运行时 shell 自动使用 Node 22
- 此变更仅影响 `full` stage（及继承它的 `production` alias），不影响 `slim` stage