### PR TITLE
feat: dedup skills and templates, clarify responsibilities

### DIFF
--- a/.opencode/skills/incremental-dev/SKILL.md
+++ b/.opencode/skills/incremental-dev/SKILL.md
@@ -17,26 +17,9 @@ This applies to both implementation AND planning.
 - NEVER work directly on main
 - See `dev-workflow` skill for branching conventions
 
-### Detect Project Type and Conventions (do this ONCE at the start)
+### Detect Project Type and Conventions
 
-**Step 1: Read project documentation (if present)**
-
-Check for and read these files in the repository root (in order of priority):
-- `AGENTS.md` or `CLAUDE.md` — coding conventions, forbidden actions, toolchain
-- `README.md` — build/test/run commands, prerequisites
-- `.opencode/skills/` — skill files may define specific workflows and commands
-- `.claude/` — may contain project-specific instructions
-
-If these files specify build, test, or check commands, **use those** instead of
-the defaults in Step 2.
-
-**Step 2: Detect project type by config files (fallback)**
-
-| Priority | Type | Detection | Source files | Default commands |
-|----------|------|-----------|-------------|-----------------|
-| 1 | SAP CDS | `.cdsrc.json` exists, OR `package.json` has `@sap/cds` in dependencies | `.cds`, `.js`, `.ts`, `.csv`, `.properties` | Read `scripts` from `package.json` |
-| 2 | Rust | `Cargo.toml` exists | `.rs` | check: `cargo check` / test: `cargo test` / build: `cargo build --release` |
-| 3 | Node.js | `package.json` exists (no `@sap/cds`) | `.js`, `.ts` | check: `npm run lint` / test: `npm test` / build: `npm run build` |
+Project type detection follows the `dev-workflow` skill. That skill has already completed detection during initialization — use the `{check_command}`, `{test_command}`, and `{build_command}` variables directly.
 
 **Important:**
 - Check SAP CDS before Node.js (both have `package.json`)

--- a/.opencode/skills/pr-review/SKILL.md
+++ b/.opencode/skills/pr-review/SKILL.md
@@ -20,7 +20,7 @@ description: |
 **Do NOT trust the developer's completion summary in PR comments.** You MUST:
 1. Read the full code diff (every changed file, every changed line)
 2. Check each claim in the developer's comment — is it actually implemented in the code?
-3. If a claim is not verifiable from the diff, flag it as **High** severity
+3. If a claim is not verifiable from the diff, flag it as **Critical** severity
 4. Do NOT approve if the diff does not match the developer's stated work
 
 This rule is **BLOCKING** — violating it means approving changes you haven't verified, which defeats the purpose of review.

--- a/.opencode/skills/pr-review/SKILL.md
+++ b/.opencode/skills/pr-review/SKILL.md
@@ -5,9 +5,9 @@ description: |
   Use when: review PR, code review, check branch changes.
 ---
 
-## PR Review — STRICTLY READ-ONLY
+## PR Review — Strictly Read-Only Review Methodology
 
-CRITICAL: This skill is strictly read-only.
+### Constraints
 - Do NOT edit, create, or delete any files in the repository
 - Do NOT make commits or push changes
 - Do NOT run builds or tests
@@ -15,133 +15,49 @@ CRITICAL: This skill is strictly read-only.
 - Do NOT fix issues — only describe them and suggest fixes in comments
 - ONLY read, analyze, and post review comments
 
-IMPORTANT: All `gh` and `git` commands MUST be run from inside the repository directory.
-Use `cd repo && <command>` for every command.
+### Trust but Verify — BLOCKING Rule 🔴
 
-### Step 0: Ensure Repository
+**Do NOT trust the developer's completion summary in PR comments.** You MUST:
+1. Read the full code diff (every changed file, every changed line)
+2. Check each claim in the developer's comment — is it actually implemented in the code?
+3. If a claim is not verifiable from the diff, flag it as **High** severity
+4. Do NOT approve if the diff does not match the developer's stated work
 
-```bash
-# Clone repo if not present (use the repository from the trigger message)
-if [ ! -d repo ]; then gh repo clone <owner>/<repo> repo; fi
+This rule is **BLOCKING** — violating it means approving changes you haven't verified, which defeats the purpose of review.
 
-# Fetch latest
-cd repo && git fetch origin
-```
+### Review Checklist
 
-NOTE: `gh` CLI is pre-configured and authenticated. Do NOT run `gh auth login`,
-`gh auth refresh`, or any other auth commands. Just use `gh` directly.
+Evaluate every change against the following criteria:
 
-### Step 1: Understand Project Conventions
+1. **Correctness**: Does the code do what the spec/PR description says? Does it actually fix the issue?
+2. **Design**: Is the approach reasonable? Are there simpler, more maintainable alternatives?
+3. **Code quality**: Readability, naming, error handling, consistent style with the surrounding codebase
+4. **Tests**: Are there tests for the changes? Do they actually test the behavior? Are edge cases covered?
+5. **Edge cases**: Missing error handling, boundary conditions, null/empty inputs, concurrent access
+6. **Project conventions**: Does the code follow the project's own rules from AGENTS.md / CLAUDE.md / README.md?
+7. **Coding principles** (check against `coding-principles` skill):
+   - **Simplicity First (P2)**: Flag overcomplication — code beyond what was asked, unnecessary abstractions
+   - **Surgical Changes (P3)**: Flag unnecessary changes — "improvements" to unrelated code, style changes
+   - **Goal-Driven Execution (P4)**: Check goal traceability — every changed line should trace to user's request
+8. **Documentation**: CHANGELOG.md updated for user-facing changes; DESIGN.md updated for architecture changes (if applicable)
+9. **Commit structure**: Does each commit map to one step from the Implementation Plan? Are commit messages clear?
 
-Before reviewing, read the project's own documentation to understand its standards:
-
-```bash
-cd repo
-# Read coding conventions (check whichever exist)
-cat AGENTS.md 2>/dev/null || cat CLAUDE.md 2>/dev/null || true
-cat README.md 2>/dev/null | head -100 || true
-# Check for project-specific skills or instructions
-ls .opencode/skills/ 2>/dev/null || ls .claude/ 2>/dev/null || true
-```
-
-Use the conventions found in these files as the basis for your review.
-If no project-specific conventions are found, use general best practices.
-
-### Step 2: Fetch PR Information
-
-**With gh:**
-```bash
-cd repo && gh pr view <number> --json title,body,state,commits,files
-cd repo && gh pr diff <number>
-```
-
-**Without gh:**
-```bash
-cd repo && git log --oneline main..<branch>
-cd repo && git diff main..<branch> --stat
-cd repo && git diff main..<branch>
-```
-
-### Step 3: Review Against Project Standards
-
-**Project-specific conventions** (from AGENTS.md / CLAUDE.md / README.md):
-- Apply whatever coding conventions, error handling patterns, logging rules,
-  and documentation requirements the project defines
-- If the project has a DESIGN.md, check that changes align with the architecture
-
-**General code quality** (always apply):
-- New functionality should have tests
-- No secrets in code (API keys, passwords, tokens)
-- No path traversal vulnerabilities in user input handling
-- Consistent naming conventions
-- Dead code cleaned up
-
-**Coding principles** (check against `coding-principles` skill):
-- **Principle 2 (Simplicity First)**: Flag overcomplication — code beyond what was asked, unnecessary abstractions
-- **Principle 3 (Surgical Changes)**: Flag unnecessary changes — "improvements" to unrelated code, style changes
-- **Principle 4 (Goal-Driven Execution)**: Check goal traceability — every changed line should trace to user's request
-
-**Documentation:**
-- CHANGELOG.md updated for user-facing changes
-- DESIGN.md updated for architecture changes (if the project has one)
-
-### Step 4: Format Findings
+### Severity Classification
 
 Categorize each finding by severity:
-- **Critical**: security issues, data loss, crashes
-- **High**: design principle violations, missing error handling, broken functionality
-- **Medium**: missing tests, inconsistent naming, dead code
-- **Low**: documentation gaps, style suggestions
+- **Critical 🔴**: security issues, data loss, crashes, trust-but-verify violations
+- **High 🟠**: design principle violations, missing error handling, broken functionality
+- **Medium 🟡**: missing tests, inconsistent naming, dead code
+- **Low 🟢**: documentation gaps, style suggestions, minor improvements
 
-For each finding:
+For each finding, use this format:
 ```
 **[SEVERITY]** `file:line` — description
 Suggestion: how to fix
 ```
 
-End with overall verdict:
-- **Approve**: no critical or high issues
-- **Request Changes**: critical or high issues found
-- **Comment**: only medium/low issues, approve with suggestions
+### Overall Verdict
 
-### Step 5: Post Review
-
-**With gh (preferred) — run from inside repo/ directory:**
-
-```bash
-cd repo && gh pr review <number> --approve --body "$(cat <<'EOF'
-[Reviewer] ## PR Review
-
-<findings>
-
-**Verdict: Approve**
-EOF
-)"
-```
-
-Use `--request-changes` for critical/high issues:
-```bash
-cd repo && gh pr review <number> --request-changes --body "$(cat <<'EOF'
-[Reviewer] ## PR Review
-
-<findings>
-
-**Verdict: Request Changes**
-EOF
-)"
-```
-
-Use `--comment` for medium/low only:
-```bash
-cd repo && gh pr review <number> --comment --body "$(cat <<'EOF'
-[Reviewer] ## PR Review
-
-<findings>
-
-**Verdict: Comment — approve with suggestions**
-EOF
-)"
-```
-
-**Without gh:**
-Output the full review as text for the user to post manually.
+- **Approve**: no Critical or High issues
+- **Request Changes**: Critical or High issues found
+- **Comment (approve with suggestions)**: only Medium/Low issues

--- a/templates/gitee-reviewer/AGENTS.md
+++ b/templates/gitee-reviewer/AGENTS.md
@@ -132,16 +132,9 @@ fnm install <version> && fnm use <version>
 
 **Lightweight verification only** — use `cargo check` (Rust) or `npm run lint` (Node/CDS) if needed. **NEVER run `cargo build`, `cargo build --release`, or `npm run build`** — full builds are the developer's responsibility.
 
-Check for:
-- **Correctness**: Does the code do what the spec says?
-- **Design**: Is the approach reasonable? Any simpler alternatives?
-- **Code quality**: Readability, naming, error handling
-- **Tests**: Are there tests? Do they cover the changes?
-- **Edge cases**: Missing error handling, boundary conditions
-- **Project conventions**: Does the code follow the project's own rules (from AGENTS.md etc.)?
-- **Commit structure**: Does each commit correspond to one step from the Implementation Plan? Are commit messages clear and descriptive? Flag commits that combine unrelated changes or skip steps.
-- **Initialize commits**: Ignore commits with message matching `^chore: initialize PR for issue #\d+$` — these are created by the Planner agent to enable PR creation on Gitee and contain no code changes. Do not flag them as unnecessary or request their removal.
-- **Coding principles**: Check against the `coding-principles` skill — flag overcomplication (P2) and unnecessary changes (P3)
+Follow the `pr-review` skill's review methodology and severity classification. **Especially note the "Trust but Verify" rule — you MUST check the code diff to verify each claim in the developer's completion comment, not trust the text alone.**
+
+**Initialize commits**: Ignore commits with message matching `^chore: initialize PR for issue #\d+$` — these are created by the Planner agent to enable PR creation on Gitee and contain no code changes. Do not flag them as unnecessary or request their removal.
 
 ### 5. Submit Review
 

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -145,7 +145,7 @@ and wait. Do NOT assume the user wants you to create a PR.**
 
 When the user gives explicit approval, create an empty PR with a **detailed, step-by-step implementation plan**.
 
-**The implementation plan is the most important part of your job.** Each step must be:
+**The implementation plan is the most important part of your job.** Follow the `plan-solution` skill's planning methodology (Understand → Create Plan → Present). Each step must be:
 - **Small and focused** — one logical change per step
 - **Ordered** — later steps can depend on earlier ones
 - **Testable** — each step describes how the developer can verify it works

--- a/templates/github-reviewer/AGENTS.md
+++ b/templates/github-reviewer/AGENTS.md
@@ -132,16 +132,9 @@ fnm install <version> && fnm use <version>
 
 **Lightweight verification only** — use `cargo check` (Rust) or `npm run lint` (Node/CDS) if needed. **NEVER run `cargo build`, `cargo build --release`, or `npm run build`** — full builds are the developer's responsibility.
 
-Check for:
-- **Correctness**: Does the code do what the spec says?
-- **Design**: Is the approach reasonable? Any simpler alternatives?
-- **Code quality**: Readability, naming, error handling
-- **Tests**: Are there tests? Do they cover the changes?
-- **Edge cases**: Missing error handling, boundary conditions
-- **Project conventions**: Does the code follow the project's own rules (from AGENTS.md etc.)?
-- **Commit structure**: Does each commit correspond to one step from the Implementation Plan? Are commit messages clear and descriptive? Flag commits that combine unrelated changes or skip steps.
-- **Initialize commits**: Ignore commits with message matching `^chore: initialize PR for issue #\d+$` — these are created by the Planner agent to enable PR creation on GitHub and contain no code changes. Do not flag them as unnecessary or request their removal.
-- **Coding principles**: Check against the `coding-principles` skill — flag overcomplication (P2) and unnecessary changes (P3)
+Follow the `pr-review` skill's review methodology and severity classification. **Especially note the "Trust but Verify" rule — you MUST check the code diff to verify each claim in the developer's completion comment, not trust the text alone.**
+
+**Initialize commits**: Ignore commits with message matching `^chore: initialize PR for issue #\d+$` — these are created by the Planner agent to enable PR creation on GitHub and contain no code changes. Do not flag them as unnecessary or request their removal.
 
 ### 5. Submit Review
 If changes needed:

--- a/templates/templates.toml
+++ b/templates/templates.toml
@@ -14,7 +14,7 @@ skills = [
 skills = ["coding-principles", "pr-review"]
 
 [templates.github-planner]
-skills = ["coding-principles", "dev-workflow"]
+skills = ["coding-principles", "dev-workflow", "plan-solution"]
 
 [templates.github-developer]
 skills = ["coding-principles", "incremental-dev", "dev-workflow"]


### PR DESCRIPTION
## Spec

消除 `templates/` 中 Agent 模板与 `.opencode/skills/` 中技能之间的重复内容，明确各自职责边界：
- **Template（模板）** = Agent 身份 + 脚手架 + 编排（触发规则、工具限制、沉默规则、label 管理、回复前缀）
- **Skill（技能）** = 可复用的领域知识/方法论（评审标准、计划方法、分支规范、迭代流程）

同时加强 reviewer 的审查纪律：不能相信 developer 在 comment 里的完成总结，必须在代码中逐项核对是否真的实现了。

Fixes #253

## Implementation Plan

### Step 1: 重构 `pr-review` skill — 精简为纯评审方法论
**文件：** `.opencode/skills/pr-review/SKILL.md`

**What:**
- 删除 Step 0（仓库设置）、Step 1（项目规范读取）、Step 2（PR 信息拉取）、Step 5（发布评审 bash 命令）
- 保留：只读约束、Step 3（评审标准清单）、Step 4（严重程度分类格式）
- **新增「Trust but verify」规则：** Reviewer 必须直接检查代码 diff，逐项验证 developer 在 PR comment 中的完成总结是否属实。禁止仅凭 developer 的文字描述通过评审。
- 新增明确的「评审标准清单」作为该 skill 的核心输出（正确性、设计、代码质量、测试、边界情况、项目规范、coding principles）

**Why:** `pr-review` 被 3 个模板共用，当前包含过多 Agent 脚手架逻辑（clone、fetch、gh 命令）。精简后让模板负责编排，skill 负责评审方法论。

**Verify:** 对比修改前后文件，确认 skill 仅包含评审方法论 + 只读约束 + trust-but-verify 规则，不包含仓库操作或 gh 命令。

### Step 2: 更新 `github-reviewer` 模板 — 引用 skill 替代内联
**文件：** `templates/github-reviewer/AGENTS.md`

**What:**
- 在 Workflow Step 4（Review the Code）中，将内联的评审检查清单替换为："遵循 `pr-review` skill 的评审方法论和严重程度分类。**尤其注意：不能相信 developer 的 comment 总结，必须检查代码 diff 逐项核实。**"
- 保留所有 Agent 脚手架：仓库设置、沉默规则、回复格式、label 管理、Node.js 版本管理、commit 结构检查、检查 PR checkout 等
- 确保不丢失模板独有的规则（如 `[Reviewer]` 前缀、`ready-for-dev`/`ready-for-review` label 切换等）

**Why:** 消除与 `pr-review` skill 的重复。模板保持 Agent 身份和行为规则，评审方法由 skill 提供。

**Verify:** 对比修改前后，确认模板中不再有评审标准的内联列表，但仍保留所有 Agent 专有逻辑。

### Step 3: 更新 `gitee-reviewer` 模板 — 与 github-reviewer 一致
**文件：** `templates/gitee-reviewer/AGENTS.md`

**What:** 与 Step 2 相同的变更，但适配 Gitee 的 API（curl + jq）环境。

**Why:** `gitee-reviewer` 与 `github-reviewer` 几乎完全平行，同样使用 `pr-review` skill，应保持一致的引用模式。

**Verify:** 对比 `github-reviewer` 和 `gitee-reviewer` 的 Workflow Step 4，确认两者都引用 `pr-review` skill 且格式一致。

### Step 4: 将 `plan-solution` 加入 `github-planner` 并消除重复
**文件：** `templates/templates.toml`、`templates/github-planner/AGENTS.md`

**What:**
- `templates.toml`：在 `[templates.github-planner]` 的 skills 数组中添加 `"plan-solution"`
- `github-planner/AGENTS.md`：在 Workflow Step 4（Create PR）的 "Implementation Plan" 部分，将步骤格式的方法论细节替换为："遵循 `plan-solution` skill 的规划方法论（Understand → Create Plan → Present）。每个步骤必须 small+focused、ordered、testable、specific。"
- 保留模板独有的 PR 创建流程、label 管理、需求变更通知、PR review on request 等 Agent 逻辑

**Why:** `plan-solution` 是纯规划方法论但未被 planner 使用。加入后 planner 的 Implementation Plan 部分不再需要内联方法论。

**Verify:** 
- `templates.toml` 中 `github-planner` 的 skills 包含 `plan-solution`
- planner 模板中 Implementation Plan 部分引用 `plan-solution` skill

### Step 5: 消除 `dev-workflow` 与 `incremental-dev` 之间的项目类型检测重复
**文件：** `.opencode/skills/dev-workflow/SKILL.md`、`.opencode/skills/incremental-dev/SKILL.md`

**What:**
- `dev-workflow/SKILL.md`：保留项目类型检测表作为**唯一权威来源**（该 skill 的定位是工作流编排，项目检测是其基础）
- `incremental-dev/SKILL.md`：将 Step 2（Detect project type）的完整检测表替换为："项目类型检测遵循 `dev-workflow` skill。该 skill 已在初始化时完成检测，直接使用 `{check_command}`、`{test_command}`、`{build_command}` 变量。"
- 确保两个 skill 的职责边界清晰：
  - `dev-workflow` = 分支规范 + commit 格式 + 发布流程 + 版本号 + CHANGELOG + 项目类型检测
  - `incremental-dev` = 小步迭代方法论 + 每步验证流程 + 交互/自主双模式

**Why:** 两个 skill 的项目检测表完全相同（逐字复制），维护时容易不同步。消除后由 `dev-workflow` 作为唯一来源。

**Verify:** 
- 两个 skill 中不再存在相同的检测表
- `incremental-dev` 明确引用 `dev-workflow` 进行项目检测
- 所有依赖这些 skill 的模板（`github-developer`、`gitee-developer`、`jyc-dev`）的运行时行为不变

## Design Decisions
- **Skill 是纯知识，不包含 Agent 脚手架：** clone/fetch/gh 命令属于模板，不属于 skill
- **职责单一：** 每个 skill 只有一个核心关注点，通过引用（而非复制）组合
- **变更安全：** Skill 修改影响所有使用方，必须确保所有模板仍然兼容（`jyc-review` 等简单模板只引用 skill，天然兼容）
- **trust-but-verify 是 BLOCKING 级别规则：** Reviewer 必须检查代码，不能相信 developer comment。违反此规则应导致 review 不通过