### PR TITLE
fix: reorder skill section before AGENTS.md in system prompt

### DIFF
--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -788,6 +788,11 @@ pub fn format_skills_section(skills: &[SkillMeta]) -> String {
 
     let mut section = String::new();
     section.push_str("## Available Skills\n\n");
+    section.push_str(concat!(
+        "**IMPORTANT: Before processing any user request, you MUST read the relevant SKILL.md file(s) ",
+        "using the `read <skill-path>/SKILL.md` tool. The descriptions below are summaries only and ",
+        "do NOT contain the full instructions you need to follow.**\n\n",
+    ));
 
     for skill in skills {
         section.push_str(&format!(

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -285,26 +285,6 @@ impl JycAgentService {
             thread_path.display()
         ));
 
-        // Load AGENTS.md if present in the working directory
-        let agents_md = thread_path.join("AGENTS.md");
-        if agents_md.exists()
-            && let Ok(content) = std::fs::read_to_string(&agents_md)
-        {
-            prompt.push_str("## Project Instructions (from AGENTS.md)\n\n");
-            prompt.push_str(&content);
-            prompt.push_str("\n\n");
-        }
-
-        // Load repo/AGENTS.md if present (for GitHub channel)
-        let repo_agents_md = thread_path.join("repo").join("AGENTS.md");
-        if repo_agents_md.exists()
-            && let Ok(content) = std::fs::read_to_string(&repo_agents_md)
-        {
-            prompt.push_str("## Repository Instructions (from repo/AGENTS.md)\n\n");
-            prompt.push_str(&content);
-            prompt.push_str("\n\n");
-        }
-
         // Resolve skill filters: pattern > channel > none
         let pattern =
             matched_pattern.and_then(|name| self.patterns.iter().find(|p| p.name == name));
@@ -330,7 +310,8 @@ impl JycAgentService {
             Some(&exclude_list)
         };
 
-        // Discover and inject skill metadata
+        // Discover and inject skill metadata (before AGENTS.md so instructions
+        // to read SKILL.md files are seen first)
         let skills = self.discover_skills(thread_path, include_list, exclude_slice);
         if !skills.is_empty() {
             prompt.push_str(&format_skills_section(&skills));
@@ -340,6 +321,26 @@ impl JycAgentService {
         let skill_names: Vec<&str> = skills.iter().map(|s| s.name.as_str()).collect();
         if let Err(e) = persist_skill_names(thread_path, &skill_names) {
             tracing::warn!(error = %e, "Failed to persist skill names to skills.json");
+        }
+
+        // Load AGENTS.md if present in the working directory
+        let agents_md = thread_path.join("AGENTS.md");
+        if agents_md.exists()
+            && let Ok(content) = std::fs::read_to_string(&agents_md)
+        {
+            prompt.push_str("## Project Instructions (from AGENTS.md)\n\n");
+            prompt.push_str(&content);
+            prompt.push_str("\n\n");
+        }
+
+        // Load repo/AGENTS.md if present (for GitHub channel)
+        let repo_agents_md = thread_path.join("repo").join("AGENTS.md");
+        if repo_agents_md.exists()
+            && let Ok(content) = std::fs::read_to_string(&repo_agents_md)
+        {
+            prompt.push_str("## Repository Instructions (from repo/AGENTS.md)\n\n");
+            prompt.push_str(&content);
+            prompt.push_str("\n\n");
         }
 
         // Reply instructions


### PR DESCRIPTION
## Spec

Move the skills section before AGENTS.md in `build_system_prompt`, and
add a prominent instruction for the LLM to read SKILL.md files before
processing user requests.

When a thread is first created (e.g. WeCom Bot), the LLM receives a long
system prompt where AGENTS.md content pushes the skills section to the
very end. On the first message the LLM often skips reading SKILL.md files,
only doing so on the second message when chat history provides additional
context. Reordering ensures the skills instruction is seen before the
potentially lengthy AGENTS.md content.

Fixes #255

## Implementation Plan

### Step 1: Reorder `build_system_prompt` to place skills section before AGENTS.md
**What:** In `crates/jyc-agent/src/service.rs`, `build_system_prompt()`,
move the `discover_skills` + `format_skills_section` call (lines 334-337)
to after the working directory prompt (line 286) and before the AGENTS.md
loading (line 288). Keep the AGENTS.md and repo/AGENTS.md sections after.

**Why:** The LLM sees the prompt top-to-bottom. Placing the skills
instruction before AGENTS.md ensures it's seen even when AGENTS.md is
very long.

**Verify:** `cargo check -p jyc-agent` compiles. Unit tests pass with
`cargo test -p jyc-agent discover_skills`. Manually verify by checking
that `build_system_prompt` output has skills section before
"## Project Instructions (from AGENTS.md)".

### Step 2: Add prominent instruction in `format_skills_section` header
**What:** In `crates/jyc-agent/src/service.rs`, `format_skills_section()`
(line 783), add a prominent instruction text right after the "## Available Skills"
header, before the per-skill listing. The text should tell the LLM to read
SKILL.md files before processing, noting that descriptions are summaries only.

**Why:** The current instruction "To load a skill's full instructions, use
`read <skill-path>/SKILL.md`" at the END of the section is too passive
and easily missed. A strong note at the beginning of the section increases
the chance the LLM will follow it.

**Verify:** `cargo test -p jyc-agent discover_skills_include_filter_retains_only_matched`
and other `discover_skills` tests pass. Manual inspection of the prompt output.

### Step 3: Run full workspace checks
**What:** Run `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`,
and `cargo test --workspace`.

**Why:** Ensure no regressions from the prompt reordering.

**Verify:** All three commands exit with code 0.

## Design Decisions
- Full SKILL.md content is NOT injected into the prompt (would be too long
  with multiple skills). The instruction to read via the `read` tool is
  preserved.
- No skill names are hardcoded — `format_skills_section` generates all text
  dynamically from discovered skills.
- AGENTS.md content is still fully injected as before — no change to that
  behavior.