### PR TITLE
feat: support outbound attachment upload for WeCom Bot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to JYC will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **WeCom Bot outbound attachment upload.** The `wecom_bot` channel now
+  supports uploading and sending attachments in replies. Files are uploaded
+  over the existing WebSocket using `aibot_upload_media_init`,
+  `aibot_upload_media_chunk`, and `aibot_upload_media_finish`, then sent as
+  separate `file`, `image`, `voice`, or `video` messages. Common document
+  types (pdf, xlsx, csv, ppt, doc, etc.) are supported as file messages.
+  Validation reuses the generic `OutboundAttachmentConfig`, consistent with
+  Feishu and email. (#257)
+
 ## [0.3.10] - 2026-06-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,6 +1660,7 @@ dependencies = [
  "jyc-types",
  "jyc-utils",
  "mail-parser",
+ "md5",
  "openlark",
  "regex",
  "reqwest 0.12.28",
@@ -1988,6 +1989,12 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"

--- a/config.example.toml
+++ b/config.example.toml
@@ -728,6 +728,7 @@ bind = "127.0.0.1:9876"  # Default; localhost only for security
 #
 # Uses WebSocket long connection (wss://openws.work.weixin.qq.com).
 # No token or encoding_aes_key required (unlike wecom HTTP callback).
+# Supports outbound attachments (file/image/voice/video) via WebSocket upload.
 #
 # [channels.my_wecom_bot]
 # type = "wecom_bot"

--- a/crates/jyc-channels/Cargo.toml
+++ b/crates/jyc-channels/Cargo.toml
@@ -25,6 +25,7 @@ reqwest = { version = "0.12", features = ["json", "stream"] }
 comrak = "0.37"
 regex = "1"
 base64 = "0.22"
+md5 = "0.7"
 uuid = { version = "1", features = ["v4"] }
 tokio-tungstenite = { version = "0.24", features = ["native-tls"] }
 futures-util = "0.3"

--- a/crates/jyc-channels/src/wecom_bot/client.rs
+++ b/crates/jyc-channels/src/wecom_bot/client.rs
@@ -99,9 +99,11 @@ impl WecomBotConnectionHandle {
         })
         .to_string();
 
-        self.sender
-            .send(frame)
-            .map_err(|e| anyhow::anyhow!("Failed to send WeCom Bot {cmd} command: {e}"))?;
+        if let Err(e) = self.sender.send(frame) {
+            let mut guard = self.pending_responses.lock().await;
+            guard.remove(req_id);
+            anyhow::bail!("Failed to send WeCom Bot {cmd} command: {e}");
+        }
 
         let response = tokio::time::timeout(timeout, rx)
             .await
@@ -771,5 +773,34 @@ mod tests {
             .await;
 
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_handle_send_and_wait_cleans_up_on_send_failure() {
+        let (tx, rx) = mpsc::unbounded_channel::<String>();
+        let pending = std::sync::Arc::new(Mutex::new(HashMap::<
+            String,
+            oneshot::Sender<serde_json::Value>,
+        >::new()));
+        let handle = WecomBotConnectionHandle::new(tx, pending.clone());
+
+        // Drop the receiver so the sender's send() fails.
+        drop(rx);
+
+        let result = handle
+            .send_and_wait(
+                "aibot_upload_media_init",
+                "req_cleanup",
+                serde_json::json!({"type": "file"}),
+                Duration::from_secs(1),
+            )
+            .await;
+
+        assert!(result.is_err());
+        let guard = pending.lock().await;
+        assert!(
+            guard.is_empty(),
+            "pending_responses should be cleaned up when send fails"
+        );
     }
 }

--- a/crates/jyc-channels/src/wecom_bot/client.rs
+++ b/crates/jyc-channels/src/wecom_bot/client.rs
@@ -5,11 +5,12 @@
 //!
 //! Reference: doc 101463 - Smart Robot WebSocket Long Connection
 
+use std::collections::HashMap;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use futures_util::{SinkExt, StreamExt};
-use tokio::sync::mpsc;
+use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::time::interval;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tokio_util::sync::CancellationToken;
@@ -19,7 +20,7 @@ use jyc_types::WecomBotConfig;
 use super::types::{BotEvent, BotMessage};
 
 /// Generate a req_id matching the Node.js SDK format: `{prefix}_{timestamp}_{random}`.
-fn generate_req_id(prefix: &str) -> String {
+pub(crate) fn generate_req_id(prefix: &str) -> String {
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
@@ -46,6 +47,69 @@ pub enum ServerMessage {
     Event(BotEvent),
 }
 
+/// Shared handle for sending outbound messages and awaiting ack responses.
+///
+/// Created by `WecomBotWsClient` after the WebSocket connection is established
+/// and shared with the outbound adapter.
+#[derive(Debug, Clone)]
+pub struct WecomBotConnectionHandle {
+    /// Sender for outbound JSON frames.
+    pub sender: mpsc::UnboundedSender<String>,
+    /// Registry for correlating server ack frames with in-flight requests.
+    pub pending_responses:
+        std::sync::Arc<Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>>,
+}
+
+impl WecomBotConnectionHandle {
+    /// Create a new connection handle.
+    pub fn new(
+        sender: mpsc::UnboundedSender<String>,
+        pending_responses: std::sync::Arc<Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>>,
+    ) -> Self {
+        Self {
+            sender,
+            pending_responses,
+        }
+    }
+
+    /// Send a JSON command through the WebSocket and await the matching ack frame.
+    ///
+    /// Registers a one-shot receiver keyed by `req_id`, sends the frame, and waits
+    /// for `timeout`. Returns the full ack JSON value so the caller can parse the
+    /// response body and check `errcode`.
+    pub async fn send_and_wait(
+        &self,
+        cmd: &str,
+        req_id: &str,
+        body: serde_json::Value,
+        timeout: Duration,
+    ) -> Result<serde_json::Value> {
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut guard = self.pending_responses.lock().await;
+            guard.insert(req_id.to_string(), tx);
+        }
+
+        let frame = serde_json::json!({
+            "cmd": cmd,
+            "headers": {"req_id": req_id},
+            "body": body,
+        })
+        .to_string();
+
+        self.sender
+            .send(frame)
+            .map_err(|e| anyhow::anyhow!("Failed to send WeCom Bot {cmd} command: {e}"))?;
+
+        let response = tokio::time::timeout(timeout, rx)
+            .await
+            .with_context(|| format!("WeCom Bot {cmd} command timed out waiting for ack"))?
+            .with_context(|| format!("WeCom Bot {cmd} ack channel closed"))?;
+
+        Ok(response)
+    }
+}
+
 /// WeCom Bot WebSocket client.
 ///
 /// Handles low-level WebSocket operations: connect, subscribe, heartbeat, reconnect.
@@ -59,6 +123,9 @@ pub struct WecomBotWsClient {
     reconnect_count: u32,
     /// Sender for outbound messages. Set after WebSocket connection is established.
     outbound_sender: Option<mpsc::UnboundedSender<String>>,
+    /// Registry for routing server ack frames to awaiting requests.
+    pending_responses:
+        std::sync::Arc<Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>>,
 }
 
 impl WecomBotWsClient {
@@ -69,6 +136,7 @@ impl WecomBotWsClient {
             state: ConnectionState::Disconnected,
             reconnect_count: 0,
             outbound_sender: None,
+            pending_responses: std::sync::Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -96,7 +164,7 @@ impl WecomBotWsClient {
     pub async fn run(
         &mut self,
         on_message: &(dyn Fn(ServerMessage) -> Result<()> + Send + Sync),
-        on_connect: Option<&(dyn Fn(mpsc::UnboundedSender<String>) + Send + Sync)>,
+        on_connect: Option<&(dyn Fn(WecomBotConnectionHandle) + Send + Sync)>,
         cancel: &CancellationToken,
     ) -> Result<()> {
         loop {
@@ -161,7 +229,7 @@ impl WecomBotWsClient {
     async fn connect_and_listen(
         &mut self,
         on_message: &(dyn Fn(ServerMessage) -> Result<()> + Send + Sync),
-        on_connect: Option<&(dyn Fn(mpsc::UnboundedSender<String>) + Send + Sync)>,
+        on_connect: Option<&(dyn Fn(WecomBotConnectionHandle) + Send + Sync)>,
         cancel: &CancellationToken,
     ) -> Result<()> {
         self.state = ConnectionState::Connecting;
@@ -282,9 +350,15 @@ impl WecomBotWsClient {
         let (outbound_tx, mut outbound_rx) = mpsc::unbounded_channel::<String>();
         self.outbound_sender = Some(outbound_tx.clone());
 
+        // Create the shared connection handle used by the outbound adapter.
+        let handle = WecomBotConnectionHandle::new(
+            outbound_tx.clone(),
+            self.pending_responses.clone(),
+        );
+
         // Notify caller that connection is ready (for shared sender setup)
         if let Some(callback) = on_connect {
-            callback(outbound_tx.clone());
+            callback(handle);
         }
 
         // Spawn writer task: handles heartbeat + outbound messages
@@ -453,8 +527,22 @@ impl WecomBotWsClient {
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
 
+            // Route ack frames to any awaiting request (e.g. media upload).
+            let routed = {
+                let mut guard = self.pending_responses.lock().await;
+                guard
+                    .remove(req_id)
+                    .map(|tx| tx.send(raw.clone()).is_ok())
+                    .unwrap_or(false)
+            };
+
             if errcode == 0 {
                 tracing::info!(req_id = %req_id, errmsg = %errmsg, "WeCom Bot operation succeeded");
+                return Ok(());
+            }
+
+            // If the frame was routed to an awaiting request, let the awaiter handle the error.
+            if routed {
                 return Ok(());
             }
 
@@ -616,5 +704,70 @@ mod tests {
         client.reconnect_count = 5;
         client.reset_reconnect_count();
         assert_eq!(client.reconnect_count, 0);
+    }
+
+    #[tokio::test]
+    async fn test_handle_send_and_wait_receives_ack() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+        let pending = std::sync::Arc::new(Mutex::new(HashMap::<
+            String,
+            oneshot::Sender<serde_json::Value>,
+        >::new()));
+        let handle = WecomBotConnectionHandle::new(tx, pending.clone());
+
+        let wait_task = tokio::spawn(async move {
+            handle
+                .send_and_wait(
+                    "aibot_upload_media_init",
+                    "req_test_1",
+                    serde_json::json!({"type": "file"}),
+                    Duration::from_secs(1),
+                )
+                .await
+        });
+
+        let sent = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("recv timeout")
+            .expect("channel open");
+        let sent_json: serde_json::Value = serde_json::from_str(&sent).unwrap();
+        assert_eq!(sent_json["cmd"], "aibot_upload_media_init");
+        assert_eq!(sent_json["headers"]["req_id"], "req_test_1");
+
+        let mut guard = pending.lock().await;
+        let sender = guard.remove("req_test_1").expect("pending registered");
+        sender
+            .send(serde_json::json!({
+                "headers": {"req_id": "req_test_1"},
+                "errcode": 0,
+                "errmsg": "ok",
+                "body": {"upload_id": "upload_abc"}
+            }))
+            .unwrap();
+        drop(guard);
+
+        let response = wait_task.await.expect("task completed").expect("wait succeeded");
+        assert_eq!(response["body"]["upload_id"], "upload_abc");
+    }
+
+    #[tokio::test]
+    async fn test_handle_send_and_wait_timeout() {
+        let (tx, _rx) = mpsc::unbounded_channel::<String>();
+        let pending = std::sync::Arc::new(Mutex::new(HashMap::<
+            String,
+            oneshot::Sender<serde_json::Value>,
+        >::new()));
+        let handle = WecomBotConnectionHandle::new(tx, pending);
+
+        let result = handle
+            .send_and_wait(
+                "ping",
+                "req_timeout",
+                serde_json::json!({}),
+                Duration::from_millis(10),
+            )
+            .await;
+
+        assert!(result.is_err());
     }
 }

--- a/crates/jyc-channels/src/wecom_bot/client.rs
+++ b/crates/jyc-channels/src/wecom_bot/client.rs
@@ -64,7 +64,9 @@ impl WecomBotConnectionHandle {
     /// Create a new connection handle.
     pub fn new(
         sender: mpsc::UnboundedSender<String>,
-        pending_responses: std::sync::Arc<Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>>,
+        pending_responses: std::sync::Arc<
+            Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>,
+        >,
     ) -> Self {
         Self {
             sender,
@@ -124,8 +126,7 @@ pub struct WecomBotWsClient {
     /// Sender for outbound messages. Set after WebSocket connection is established.
     outbound_sender: Option<mpsc::UnboundedSender<String>>,
     /// Registry for routing server ack frames to awaiting requests.
-    pending_responses:
-        std::sync::Arc<Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>>,
+    pending_responses: std::sync::Arc<Mutex<HashMap<String, oneshot::Sender<serde_json::Value>>>>,
 }
 
 impl WecomBotWsClient {
@@ -351,10 +352,8 @@ impl WecomBotWsClient {
         self.outbound_sender = Some(outbound_tx.clone());
 
         // Create the shared connection handle used by the outbound adapter.
-        let handle = WecomBotConnectionHandle::new(
-            outbound_tx.clone(),
-            self.pending_responses.clone(),
-        );
+        let handle =
+            WecomBotConnectionHandle::new(outbound_tx.clone(), self.pending_responses.clone());
 
         // Notify caller that connection is ready (for shared sender setup)
         if let Some(callback) = on_connect {
@@ -746,7 +745,10 @@ mod tests {
             .unwrap();
         drop(guard);
 
-        let response = wait_task.await.expect("task completed").expect("wait succeeded");
+        let response = wait_task
+            .await
+            .expect("task completed")
+            .expect("wait succeeded");
         assert_eq!(response["body"]["upload_id"], "upload_abc");
     }
 

--- a/crates/jyc-channels/src/wecom_bot/inbound.rs
+++ b/crates/jyc-channels/src/wecom_bot/inbound.rs
@@ -164,10 +164,8 @@ pub struct WecomBotInboundAdapter {
     channel_name: String,
     #[allow(dead_code)]
     workspace_root: std::path::PathBuf,
-    /// Shared sender Arc for outbound adapter
-    sender_arc: Option<
-        std::sync::Arc<tokio::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<String>>>>,
-    >,
+    /// Shared connection handle Arc for outbound adapter
+    handle_arc: Option<std::sync::Arc<tokio::sync::Mutex<Option<super::client::WecomBotConnectionHandle>>>>,
 }
 
 impl WecomBotInboundAdapter {
@@ -180,16 +178,16 @@ impl WecomBotInboundAdapter {
             config: config.clone(),
             channel_name,
             workspace_root,
-            sender_arc: None,
+            handle_arc: None,
         }
     }
 
-    /// Create a new adapter with a shared sender Arc for outbound adapter.
-    pub fn with_shared_sender(
+    /// Create a new adapter with a shared connection handle Arc for outbound adapter.
+    pub fn with_shared_handle(
         config: &WecomBotConfig,
         channel_name: String,
-        sender_arc: std::sync::Arc<
-            tokio::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<String>>>,
+        handle_arc: std::sync::Arc<
+            tokio::sync::Mutex<Option<super::client::WecomBotConnectionHandle>>,
         >,
     ) -> Self {
         let workspace_root =
@@ -199,7 +197,7 @@ impl WecomBotInboundAdapter {
             config: config.clone(),
             channel_name,
             workspace_root,
-            sender_arc: Some(sender_arc),
+            handle_arc: Some(handle_arc),
         }
     }
 
@@ -214,25 +212,25 @@ impl WecomBotInboundAdapter {
             config: config.clone(),
             channel_name,
             workspace_root,
-            sender_arc: None,
+            handle_arc: None,
         }
     }
 
-    /// Create a new adapter with custom workspace root and shared sender.
+    /// Create a new adapter with custom workspace root and shared handle.
     #[allow(dead_code)]
-    pub fn with_workspace_and_sender(
+    pub fn with_workspace_and_handle(
         config: &WecomBotConfig,
         channel_name: String,
         workspace_root: std::path::PathBuf,
-        sender_arc: std::sync::Arc<
-            tokio::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<String>>>,
+        handle_arc: std::sync::Arc<
+            tokio::sync::Mutex<Option<super::client::WecomBotConnectionHandle>>,
         >,
     ) -> Self {
         Self {
             config: config.clone(),
             channel_name,
             workspace_root,
-            sender_arc: Some(sender_arc),
+            handle_arc: Some(handle_arc),
         }
     }
 }
@@ -270,7 +268,7 @@ impl jyc_types::InboundAdapter for WecomBotInboundAdapter {
         let (raw_tx, mut raw_rx) = tokio::sync::mpsc::unbounded_channel::<ServerMessage>();
         let channel_name = self.channel_name.clone();
         let config = self.config.clone();
-        let shared_sender = self.sender_arc.clone();
+        let shared_handle = self.handle_arc.clone();
         let ws_cancel = cancel.child_token();
 
         // Spawn WebSocket client task that forwards raw messages to the channel
@@ -284,13 +282,13 @@ impl jyc_types::InboundAdapter for WecomBotInboundAdapter {
                 Ok(())
             };
 
-            let on_connect = move |sender: tokio::sync::mpsc::UnboundedSender<String>| {
-                if let Some(ref shared) = shared_sender {
+            let on_connect = move |handle: super::client::WecomBotConnectionHandle| {
+                if let Some(ref shared) = shared_handle {
                     let shared = shared.clone();
                     tokio::spawn(async move {
                         let mut guard = shared.lock().await;
-                        *guard = Some(sender);
-                        tracing::info!("WeCom Bot outbound sender updated");
+                        *guard = Some(handle);
+                        tracing::info!("WeCom Bot outbound handle updated");
                     });
                 }
             };

--- a/crates/jyc-channels/src/wecom_bot/inbound.rs
+++ b/crates/jyc-channels/src/wecom_bot/inbound.rs
@@ -165,7 +165,8 @@ pub struct WecomBotInboundAdapter {
     #[allow(dead_code)]
     workspace_root: std::path::PathBuf,
     /// Shared connection handle Arc for outbound adapter
-    handle_arc: Option<std::sync::Arc<tokio::sync::Mutex<Option<super::client::WecomBotConnectionHandle>>>>,
+    handle_arc:
+        Option<std::sync::Arc<tokio::sync::Mutex<Option<super::client::WecomBotConnectionHandle>>>>,
 }
 
 impl WecomBotInboundAdapter {

--- a/crates/jyc-channels/src/wecom_bot/outbound.rs
+++ b/crates/jyc-channels/src/wecom_bot/outbound.rs
@@ -12,12 +12,20 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::Mutex;
 
 use jyc_core::email_parser;
 use jyc_core::message_storage::MessageStorage;
 use jyc_types::{
     InboundMessage, OutboundAdapter, OutboundAttachment, OutboundAttachmentConfig, SendResult,
+};
+
+use jyc_utils::attachment_validator;
+
+use super::client::{WecomBotConnectionHandle, generate_req_id};
+use super::types::{
+    CMD_AIBOT_UPLOAD_MEDIA_CHUNK, CMD_AIBOT_UPLOAD_MEDIA_FINISH, CMD_AIBOT_UPLOAD_MEDIA_INIT,
+    UploadMediaChunkBody, UploadMediaFinishBody, UploadMediaInitBody,
 };
 
 /// Tracks an active streaming message so the final reply can reuse the same
@@ -30,15 +38,15 @@ struct ActiveStream {
 
 /// WeCom Bot outbound adapter for sending messages via WebSocket.
 ///
-/// Uses an `mpsc::UnboundedSender<String>` to push messages into the shared
-/// WebSocket connection established by the inbound adapter.
+/// Uses a shared `WecomBotConnectionHandle` to push messages into the shared
+/// WebSocket connection established by the inbound adapter and to await ack
+/// responses (needed for media upload).
 pub struct WecomBotOutboundAdapter {
-    /// Sender to push outbound messages through the WebSocket
-    sender: Arc<Mutex<Option<mpsc::UnboundedSender<String>>>>,
+    /// Shared connection handle for sending frames and awaiting responses.
+    handle: Arc<Mutex<Option<WecomBotConnectionHandle>>>,
     /// Message storage for logging replies
     storage: Arc<MessageStorage>,
     /// Attachment configuration
-    #[allow(dead_code)]
     attachment_config: Option<OutboundAttachmentConfig>,
     /// Whether footer is enabled
     footer_enabled: bool,
@@ -60,7 +68,7 @@ impl WecomBotOutboundAdapter {
         footer_enabled: bool,
     ) -> Self {
         Self {
-            sender: Arc::new(Mutex::new(None)),
+            handle: Arc::new(Mutex::new(None)),
             storage,
             attachment_config,
             footer_enabled,
@@ -68,26 +76,31 @@ impl WecomBotOutboundAdapter {
         }
     }
 
-    /// Get the shared sender Arc so the monitor can set it after WebSocket creation.
-    pub fn sender_arc(&self) -> Arc<Mutex<Option<mpsc::UnboundedSender<String>>>> {
-        self.sender.clone()
+    /// Get the shared connection handle Arc so the monitor can set it after
+    /// WebSocket creation.
+    pub fn handle_arc(
+        &self,
+    ) -> Arc<Mutex<Option<WecomBotConnectionHandle>>> {
+        self.handle.clone()
     }
 
-    /// Set the WebSocket sender after the WebSocket connection is established.
-    pub async fn set_sender(&self, sender: mpsc::UnboundedSender<String>) {
-        let mut guard = self.sender.lock().await;
-        *guard = Some(sender);
+    /// Set the WebSocket connection handle after the WebSocket connection is established.
+    #[allow(dead_code)]
+    pub async fn set_handle(&self, handle: WecomBotConnectionHandle) {
+        let mut guard = self.handle.lock().await;
+        *guard = Some(handle);
     }
 
     /// Send a JSON-formatted message through the WebSocket.
     async fn send_internal(&self, json_msg: &str) -> Result<()> {
-        let guard = self.sender.lock().await;
+        let guard = self.handle.lock().await;
         match guard.as_ref() {
-            Some(sender) => sender
+            Some(handle) => handle
+                .sender
                 .send(json_msg.to_string())
                 .map_err(|e| anyhow::anyhow!("Failed to send WeCom Bot outbound message: {}", e)),
             None => Err(anyhow::anyhow!(
-                "WeCom Bot outbound sender not set (WebSocket not initialized)"
+                "WeCom Bot outbound handle not set (WebSocket not initialized)"
             )),
         }
     }
@@ -143,12 +156,12 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
     }
 
     async fn connect(&self) -> Result<()> {
-        let guard = self.sender.lock().await;
+        let guard = self.handle.lock().await;
         if guard.is_some() {
-            tracing::info!("WeCom Bot outbound adapter connected (sender available)");
+            tracing::info!("WeCom Bot outbound adapter connected (handle available)");
         } else {
             tracing::warn!(
-                "WeCom Bot outbound adapter: no sender set yet (WebSocket may not be connected)"
+                "WeCom Bot outbound adapter: no handle set yet (WebSocket may not be connected)"
             );
         }
         Ok(())
@@ -169,7 +182,7 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
         reply_text: &str,
         thread_path: &Path,
         message_dir: &str,
-        _attachments: Option<&[OutboundAttachment]>,
+        attachments: Option<&[OutboundAttachment]>,
     ) -> Result<SendResult> {
         // 1. Read model/mode from reply context file
         let reply_ctx = jyc_mcp::context::load_reply_context(thread_path).await.ok();
@@ -205,7 +218,17 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
             tracing::warn!("Original message missing req_id, reply may not be correlated by WeCom");
         }
 
-        // 6. Check if there's an active stream for this req_id
+        // 6. Validate attachments if configuration is present
+        if let Some(attachments) = attachments
+            && let Some(ref config) = self.attachment_config
+        {
+            attachment_validator::validate_outbound_attachments(attachments, config)
+                .await
+                .context("Failed to validate outbound attachments")?;
+            tracing::debug!("Outbound attachments validated successfully for WeCom Bot");
+        }
+
+        // 7. Check if there's an active stream for this req_id
         let active = self.active_stream.lock().await.take();
         let stream_id = if let Some(ref stream) = active
             && stream.req_id == req_id
@@ -225,7 +248,7 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
             uuid::Uuid::new_v4().to_string()
         };
 
-        // 7. Send reply via WebSocket with finish=true
+        // 8. Send reply via WebSocket with finish=true
         self.send_text_reply(req_id, &full_reply, &stream_id, true)
             .await
             .context("Failed to send WeCom Bot reply")?;
@@ -240,7 +263,52 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
             "WeCom Bot reply sent"
         );
 
-        // 8. Store reply to chat log
+        // 9. Upload and send attachments as separate media messages.
+        if let Some(attachments) = attachments {
+            let handle = {
+                let guard = self.handle.lock().await;
+                guard.clone().context("WeCom Bot outbound handle not set; cannot upload attachments")?
+            };
+
+            for att in attachments {
+                let media_type = wecom_media_type(&att.content_type, &att.filename);
+
+                match upload_attachment(&handle, &att.path, &att.filename, &att.content_type).await {
+                    Ok(media_id) => {
+                        let body = build_media_message_body(media_type, &media_id);
+                        let json = serde_json::json!({
+                            "cmd": "aibot_respond_msg",
+                            "headers": {"req_id": req_id},
+                            "body": body,
+                        })
+                        .to_string();
+
+                        if let Err(e) = handle.sender.send(json) {
+                            tracing::warn!(
+                                filename = %att.filename,
+                                error = %e,
+                                "Failed to send WeCom Bot attachment message"
+                            );
+                        } else {
+                            tracing::info!(
+                                filename = %att.filename,
+                                media_type = %media_type,
+                                "WeCom Bot attachment message sent"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            filename = %att.filename,
+                            error = %e,
+                            "Failed to upload WeCom Bot attachment"
+                        );
+                    }
+                }
+            }
+        }
+
+        // 10. Store reply to chat log
         self.storage
             .store_reply(thread_path, &full_reply, message_dir)
             .await
@@ -438,10 +506,208 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
     }
 }
 
+// ─── Attachment Upload Helpers ────────────────────────────────────
+
+/// Maximum chunk size before base64 encoding (512 KiB).
+const UPLOAD_CHUNK_SIZE: usize = 512 * 1024;
+
+/// Maximum number of chunks allowed by WeCom.
+const MAX_UPLOAD_CHUNKS: usize = 100;
+
+/// Timeout for a single upload command ack.
+const UPLOAD_COMMAND_TIMEOUT_SECS: u64 = 60;
+
+/// WeCom media type limits (in bytes).
+const IMAGE_MAX_SIZE: usize = 10 * 1024 * 1024;
+const VOICE_MAX_SIZE: usize = 2 * 1024 * 1024;
+const VIDEO_MAX_SIZE: usize = 10 * 1024 * 1024;
+const FILE_MAX_SIZE: usize = 20 * 1024 * 1024;
+
+/// Map a filename/extension to WeCom media type.
+///
+/// WeCom supports:
+/// - image: png, jpg/jpeg, gif (max 10MB)
+/// - voice: amr (max 2MB)
+/// - video: mp4 (max 10MB)
+/// - file: everything else (max 20MB)
+fn wecom_media_type(_content_type: &str, filename: &str) -> &'static str {
+    let ext = std::path::Path::new(filename)
+        .extension()
+        .map(|e| e.to_string_lossy().to_lowercase())
+        .unwrap_or_default();
+
+    match ext.as_str() {
+        "png" | "jpg" | "jpeg" | "gif" => "image",
+        "amr" => "voice",
+        "mp4" => "video",
+        _ => "file",
+    }
+}
+
+/// Validate that a payload does not exceed WeCom media type limits.
+fn validate_wecom_media_size(bytes: &[u8], media_type: &str) -> Result<()> {
+    let max = match media_type {
+        "image" => IMAGE_MAX_SIZE,
+        "voice" => VOICE_MAX_SIZE,
+        "video" => VIDEO_MAX_SIZE,
+        _ => FILE_MAX_SIZE,
+    };
+
+    if bytes.len() > max {
+        anyhow::bail!(
+            "WeCom {media_type} attachment exceeds {max} bytes (got {} bytes)",
+            bytes.len()
+        );
+    }
+
+    Ok(())
+}
+
+/// Upload a file through the WeCom Bot WebSocket and return the `media_id`.
+async fn upload_attachment(
+    handle: &WecomBotConnectionHandle,
+    path: &Path,
+    filename: &str,
+    content_type: &str,
+) -> Result<String> {
+    let bytes = tokio::fs::read(path)
+        .await
+        .with_context(|| format!("Failed to read WeCom Bot attachment: {}", path.display()))?;
+
+    let media_type = wecom_media_type(content_type, filename);
+    validate_wecom_media_size(&bytes, media_type)
+        .with_context(|| format!("WeCom Bot attachment validation failed: {filename}"))?;
+
+    let total_chunks = bytes.chunks(UPLOAD_CHUNK_SIZE).count();
+    if total_chunks > MAX_UPLOAD_CHUNKS {
+        anyhow::bail!(
+            "WeCom Bot attachment requires {total_chunks} chunks, max is {MAX_UPLOAD_CHUNKS}"
+        );
+    }
+
+    let md5_digest = format!("{:x}", md5::compute(&bytes));
+    let timeout = std::time::Duration::from_secs(UPLOAD_COMMAND_TIMEOUT_SECS);
+
+    // 1. Initialize upload session.
+    let init_req_id = generate_req_id("aibot_upload_media_init");
+    let init_body = serde_json::to_value(UploadMediaInitBody {
+        media_type: media_type.to_string(),
+        filename: filename.to_string(),
+        total_size: bytes.len(),
+        total_chunks,
+        md5: md5_digest,
+    })
+    .context("Failed to serialize WeCom Bot upload init body")?;
+
+    let init_resp = handle
+        .send_and_wait(CMD_AIBOT_UPLOAD_MEDIA_INIT, &init_req_id, init_body, timeout)
+        .await
+        .context("Failed to initialize WeCom Bot media upload")?;
+
+    let errcode = init_resp["errcode"].as_i64().unwrap_or(-1);
+    if errcode != 0 {
+        let errmsg = init_resp["errmsg"].as_str().unwrap_or("unknown");
+        anyhow::bail!(
+            "WeCom Bot upload init failed: errcode={errcode}, errmsg={errmsg}"
+        );
+    }
+
+    let upload_id = init_resp["body"]["upload_id"]
+        .as_str()
+        .context("WeCom Bot upload init response missing upload_id")?;
+
+    // 2. Upload chunks.
+    for (index, chunk) in bytes.chunks(UPLOAD_CHUNK_SIZE).enumerate() {
+        let chunk_req_id = generate_req_id("aibot_upload_media_chunk");
+        let chunk_body = serde_json::to_value(UploadMediaChunkBody {
+            upload_id: upload_id.to_string(),
+            chunk_index: index,
+            base64_data: base64::Engine::encode(
+                &base64::engine::general_purpose::STANDARD,
+                chunk,
+            ),
+        })
+        .context("Failed to serialize WeCom Bot upload chunk body")?;
+
+        let chunk_resp = handle
+            .send_and_wait(CMD_AIBOT_UPLOAD_MEDIA_CHUNK, &chunk_req_id, chunk_body, timeout)
+            .await
+            .with_context(|| format!("Failed to upload WeCom Bot chunk {index}"))?;
+
+        let errcode = chunk_resp["errcode"].as_i64().unwrap_or(-1);
+        if errcode != 0 {
+            let errmsg = chunk_resp["errmsg"].as_str().unwrap_or("unknown");
+            anyhow::bail!(
+                "WeCom Bot upload chunk {index} failed: errcode={errcode}, errmsg={errmsg}"
+            );
+        }
+    }
+
+    // 3. Finish upload and obtain media_id.
+    let finish_req_id = generate_req_id("aibot_upload_media_finish");
+    let finish_body = serde_json::to_value(UploadMediaFinishBody {
+        upload_id: upload_id.to_string(),
+    })
+    .context("Failed to serialize WeCom Bot upload finish body")?;
+
+    let finish_resp = handle
+        .send_and_wait(CMD_AIBOT_UPLOAD_MEDIA_FINISH, &finish_req_id, finish_body, timeout)
+        .await
+        .context("Failed to finish WeCom Bot media upload")?;
+
+    let errcode = finish_resp["errcode"].as_i64().unwrap_or(-1);
+    if errcode != 0 {
+        let errmsg = finish_resp["errmsg"].as_str().unwrap_or("unknown");
+        anyhow::bail!(
+            "WeCom Bot upload finish failed: errcode={errcode}, errmsg={errmsg}"
+        );
+    }
+
+    let media_id = finish_resp["body"]["media_id"]
+        .as_str()
+        .context("WeCom Bot upload finish response missing media_id")?;
+
+    tracing::info!(
+        filename = %filename,
+        media_type = %media_type,
+        size = bytes.len(),
+        chunks = total_chunks,
+        "WeCom Bot attachment uploaded"
+    );
+
+    Ok(media_id.to_string())
+}
+
+/// Build an `aibot_respond_msg` body for a media attachment.
+fn build_media_message_body(media_type: &str, media_id: &str) -> serde_json::Value {
+    match media_type {
+        "image" => serde_json::json!({
+            "msgtype": "image",
+            "image": {"media_id": media_id}
+        }),
+        "voice" => serde_json::json!({
+            "msgtype": "voice",
+            "voice": {"media_id": media_id}
+        }),
+        "video" => serde_json::json!({
+            "msgtype": "video",
+            "video": {"media_id": media_id}
+        }),
+        _ => serde_json::json!({
+            "msgtype": "file",
+            "file": {"media_id": media_id}
+        }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::HashMap;
+    use std::io::Write;
+    use std::time::Duration;
+    use tokio::sync::{Mutex, mpsc, oneshot};
+    use tokio::time::timeout;
 
     #[test]
     fn test_clean_body() {
@@ -514,8 +780,9 @@ mod tests {
         let storage = Arc::new(MessageStorage::new(std::path::Path::new("/tmp")));
         let adapter = WecomBotOutboundAdapter::new_with_attachments(storage, None, false);
 
-        // Set the sender so messages can be captured
-        adapter.set_sender(tx).await;
+        // Set the handle so messages can be captured
+        let handle = WecomBotConnectionHandle::new(tx, Arc::new(Mutex::new(HashMap::new())));
+        adapter.set_handle(handle).await;
 
         // Build a message with req_id
         let message = InboundMessage {
@@ -599,7 +866,8 @@ mod tests {
         let storage = Arc::new(MessageStorage::new(std::path::Path::new("/tmp")));
         let adapter = WecomBotOutboundAdapter::new_with_attachments(storage, None, false);
 
-        adapter.set_sender(tx).await;
+        let handle = WecomBotConnectionHandle::new(tx, Arc::new(Mutex::new(HashMap::new())));
+        adapter.set_handle(handle).await;
 
         let message = InboundMessage {
             id: "test".to_string(),
@@ -654,7 +922,8 @@ mod tests {
         let storage = Arc::new(MessageStorage::new(std::path::Path::new("/tmp")));
         let adapter = WecomBotOutboundAdapter::new_with_attachments(storage, None, false);
 
-        adapter.set_sender(tx).await;
+        let handle = WecomBotConnectionHandle::new(tx, Arc::new(Mutex::new(HashMap::new())));
+        adapter.set_handle(handle).await;
 
         let message = InboundMessage {
             id: "test".to_string(),
@@ -717,5 +986,337 @@ mod tests {
         // Active stream should be cleared
         let guard = adapter.active_stream.lock().await;
         assert!(guard.is_none());
+    }
+
+    #[test]
+    fn test_wecom_media_type() {
+        assert_eq!(wecom_media_type("image/png", "photo.png"), "image");
+        assert_eq!(wecom_media_type("image/jpeg", "photo.jpg"), "image");
+        assert_eq!(wecom_media_type("image/jpeg", "photo.jpeg"), "image");
+        assert_eq!(wecom_media_type("image/gif", "photo.gif"), "image");
+        assert_eq!(wecom_media_type("audio/amr", "voice.amr"), "voice");
+        assert_eq!(wecom_media_type("video/mp4", "clip.mp4"), "video");
+        assert_eq!(wecom_media_type("application/pdf", "report.pdf"), "file");
+        assert_eq!(
+            wecom_media_type(
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                "data.xlsx"
+            ),
+            "file"
+        );
+        assert_eq!(wecom_media_type("text/csv", "data.csv"), "file");
+        assert_eq!(wecom_media_type("application/octet-stream", "data.bin"), "file");
+    }
+
+    #[test]
+    fn test_validate_wecom_media_size() {
+        assert!(validate_wecom_media_size(&[0u8; 1], "file").is_ok());
+        assert!(validate_wecom_media_size(&[0u8; FILE_MAX_SIZE], "file").is_ok());
+        assert!(validate_wecom_media_size(&[0u8; FILE_MAX_SIZE + 1], "file").is_err());
+        assert!(validate_wecom_media_size(&[0u8; IMAGE_MAX_SIZE + 1], "image").is_err());
+        assert!(validate_wecom_media_size(&[0u8; VOICE_MAX_SIZE + 1], "voice").is_err());
+        assert!(validate_wecom_media_size(&[0u8; VIDEO_MAX_SIZE + 1], "video").is_err());
+    }
+
+    /// Helper: run `upload_attachment` against a mock handle that injects the
+    /// given ack responses in order.
+    async fn run_upload_with_responses(
+        path: std::path::PathBuf,
+        filename: String,
+        content_type: String,
+        responses: Vec<serde_json::Value>,
+    ) -> Result<String> {
+        let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+        let pending = Arc::new(Mutex::new(HashMap::<String, oneshot::Sender<serde_json::Value>>::new()));
+        let handle = WecomBotConnectionHandle::new(tx, pending.clone());
+
+        let upload_task = tokio::spawn(async move {
+            upload_attachment(&handle, &path, &filename, &content_type).await
+        });
+
+        for resp in responses {
+            let cmd_json = timeout(Duration::from_secs(1), rx.recv())
+                .await
+                .expect("receive command")
+                .expect("channel open");
+            let cmd: serde_json::Value = serde_json::from_str(&cmd_json).unwrap();
+            let req_id = cmd["headers"]["req_id"]
+                .as_str()
+                .expect("req_id present")
+                .to_string();
+            let mut guard = pending.lock().await;
+            let sender = guard
+                .remove(&req_id)
+                .expect("pending response registered");
+            sender.send(resp).expect("receiver alive");
+        }
+
+        upload_task.await.expect("upload task completed")
+    }
+
+    #[tokio::test]
+    async fn test_upload_attachment_success() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("report.pdf");
+        let content = b"hello pdf";
+        let mut file = std::fs::File::create(&path).unwrap();
+        file.write_all(content).unwrap();
+
+        let md5_hex = format!("{:x}", md5::compute(content));
+
+        let responses = vec![
+            serde_json::json!({
+                "headers": {"req_id": "ignored"},
+                "errcode": 0,
+                "errmsg": "ok",
+                "body": {"upload_id": "upload_123"}
+            }),
+            serde_json::json!({
+                "headers": {"req_id": "ignored"},
+                "errcode": 0,
+                "errmsg": "ok"
+            }),
+            serde_json::json!({
+                "headers": {"req_id": "ignored"},
+                "errcode": 0,
+                "errmsg": "ok",
+                "body": {
+                    "type": "file",
+                    "media_id": "media_abc",
+                    "created_at": "1700000000"
+                }
+            }),
+        ];
+
+        let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+        let pending = Arc::new(Mutex::new(HashMap::<String, oneshot::Sender<serde_json::Value>>::new()));
+        let handle = WecomBotConnectionHandle::new(tx, pending.clone());
+
+        let upload_task = tokio::spawn(async move {
+            upload_attachment(&handle, &path, "report.pdf", "application/pdf").await
+        });
+
+        // Capture and verify init command.
+        let init_json = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("init recv")
+            .expect("init channel open");
+        let init: serde_json::Value = serde_json::from_str(&init_json).unwrap();
+        assert_eq!(init["cmd"], "aibot_upload_media_init");
+        assert_eq!(init["body"]["type"], "file");
+        assert_eq!(init["body"]["filename"], "report.pdf");
+        assert_eq!(init["body"]["total_size"], content.len());
+        assert_eq!(init["body"]["total_chunks"], 1);
+        assert_eq!(init["body"]["md5"], md5_hex);
+
+        let req_id = init["headers"]["req_id"].as_str().unwrap().to_string();
+        {
+            let mut guard = pending.lock().await;
+            let sender = guard.remove(&req_id).unwrap();
+            sender.send(responses[0].clone()).unwrap();
+        }
+
+        // Capture and verify chunk command.
+        let chunk_json = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("chunk recv")
+            .expect("chunk channel open");
+        let chunk: serde_json::Value = serde_json::from_str(&chunk_json).unwrap();
+        assert_eq!(chunk["cmd"], "aibot_upload_media_chunk");
+        assert_eq!(chunk["body"]["upload_id"], "upload_123");
+        assert_eq!(chunk["body"]["chunk_index"], 0);
+        assert_eq!(
+            chunk["body"]["base64_data"],
+            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, content)
+        );
+
+        let req_id = chunk["headers"]["req_id"].as_str().unwrap().to_string();
+        {
+            let mut guard = pending.lock().await;
+            let sender = guard.remove(&req_id).unwrap();
+            sender.send(responses[1].clone()).unwrap();
+        }
+
+        // Capture and verify finish command.
+        let finish_json = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("finish recv")
+            .expect("finish channel open");
+        let finish: serde_json::Value = serde_json::from_str(&finish_json).unwrap();
+        assert_eq!(finish["cmd"], "aibot_upload_media_finish");
+        assert_eq!(finish["body"]["upload_id"], "upload_123");
+
+        let req_id = finish["headers"]["req_id"].as_str().unwrap().to_string();
+        {
+            let mut guard = pending.lock().await;
+            let sender = guard.remove(&req_id).unwrap();
+            sender.send(responses[2].clone()).unwrap();
+        }
+
+        let media_id = upload_task.await.unwrap().expect("upload succeeded");
+        assert_eq!(media_id, "media_abc");
+    }
+
+    #[tokio::test]
+    async fn test_upload_attachment_init_failure() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("report.pdf");
+        std::fs::write(&path, b"x").unwrap();
+
+        let responses = vec![serde_json::json!({
+            "headers": {"req_id": "ignored"},
+            "errcode": 40001,
+            "errmsg": "invalid credential"
+        })];
+
+        let result = run_upload_with_responses(path, "report.pdf".to_string(), "application/pdf".to_string(), responses).await;
+        assert!(result.is_err());
+        let msg = format!("{:#}", result.unwrap_err());
+        assert!(msg.contains("init failed"), "error: {msg}");
+    }
+
+    #[tokio::test]
+    async fn test_send_reply_with_attachment() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let attachment_path = dir.path().join("report.pdf");
+        std::fs::write(&attachment_path, b"pdf content").unwrap();
+
+        let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+        let pending = Arc::new(Mutex::new(HashMap::<String, oneshot::Sender<serde_json::Value>>::new()));
+        let handle = WecomBotConnectionHandle::new(tx, pending.clone());
+
+        let storage = Arc::new(MessageStorage::new(dir.path()));
+        let adapter = WecomBotOutboundAdapter::new_with_attachments(storage, None, false);
+        adapter.set_handle(handle).await;
+
+        let message = InboundMessage {
+            id: "test".to_string(),
+            channel: "wecom_bot".to_string(),
+            channel_uid: "msg_1".to_string(),
+            sender: "user".to_string(),
+            sender_address: "user".to_string(),
+            recipients: vec![],
+            topic: String::new(),
+            content: jyc_types::MessageContent {
+                text: Some("hello".to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "req_id".to_string(),
+                    serde_json::Value::String("req_123".to_string()),
+                );
+                m
+            },
+            matched_pattern: None,
+        };
+
+        let attachments = vec![OutboundAttachment {
+            filename: "report.pdf".to_string(),
+            path: attachment_path,
+            content_type: "application/pdf".to_string(),
+        }];
+
+        let reply_task = tokio::spawn(async move {
+            let thread_path = dir.path().join("thread");
+            tokio::fs::create_dir_all(&thread_path).await.unwrap();
+            adapter
+                .send_reply(&message, "AI reply", &thread_path, "msg_001", Some(&attachments))
+                .await
+        });
+
+        // 1. Text reply frame.
+        let text_json = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("text recv")
+            .expect("text channel open");
+        let text: serde_json::Value = serde_json::from_str(&text_json).unwrap();
+        assert_eq!(text["cmd"], "aibot_respond_msg");
+        assert_eq!(text["headers"]["req_id"], "req_123");
+        assert_eq!(text["body"]["msgtype"], "stream");
+        assert_eq!(text["body"]["stream"]["finish"], true);
+        assert_eq!(text["body"]["stream"]["content"], "AI reply");
+
+        // 2. Upload init frame.
+        let init_json = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("init recv")
+            .expect("init channel open");
+        let init: serde_json::Value = serde_json::from_str(&init_json).unwrap();
+        assert_eq!(init["cmd"], "aibot_upload_media_init");
+        let init_req_id = init["headers"]["req_id"].as_str().unwrap().to_string();
+        {
+            let mut guard = pending.lock().await;
+            let sender = guard.remove(&init_req_id).unwrap();
+            sender
+                .send(serde_json::json!({
+                    "headers": {"req_id": init_req_id},
+                    "errcode": 0,
+                    "errmsg": "ok",
+                    "body": {"upload_id": "upload_123"}
+                }))
+                .unwrap();
+        }
+
+        // 3. Upload chunk frame.
+        let chunk_json = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("chunk recv")
+            .expect("chunk channel open");
+        let chunk: serde_json::Value = serde_json::from_str(&chunk_json).unwrap();
+        assert_eq!(chunk["cmd"], "aibot_upload_media_chunk");
+        let chunk_req_id = chunk["headers"]["req_id"].as_str().unwrap().to_string();
+        {
+            let mut guard = pending.lock().await;
+            let sender = guard.remove(&chunk_req_id).unwrap();
+            sender
+                .send(serde_json::json!({
+                    "headers": {"req_id": chunk_req_id},
+                    "errcode": 0,
+                    "errmsg": "ok"
+                }))
+                .unwrap();
+        }
+
+        // 4. Upload finish frame.
+        let finish_json = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("finish recv")
+            .expect("finish channel open");
+        let finish: serde_json::Value = serde_json::from_str(&finish_json).unwrap();
+        assert_eq!(finish["cmd"], "aibot_upload_media_finish");
+        let finish_req_id = finish["headers"]["req_id"].as_str().unwrap().to_string();
+        {
+            let mut guard = pending.lock().await;
+            let sender = guard.remove(&finish_req_id).unwrap();
+            sender
+                .send(serde_json::json!({
+                    "headers": {"req_id": finish_req_id},
+                    "errcode": 0,
+                    "errmsg": "ok",
+                    "body": {"type": "file", "media_id": "media_abc", "created_at": "1700000000"}
+                }))
+                .unwrap();
+        }
+
+        // 5. Attachment message frame.
+        let att_json = timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("attachment recv")
+            .expect("attachment channel open");
+        let att: serde_json::Value = serde_json::from_str(&att_json).unwrap();
+        assert_eq!(att["cmd"], "aibot_respond_msg");
+        assert_eq!(att["headers"]["req_id"], "req_123");
+        assert_eq!(att["body"]["msgtype"], "file");
+        assert_eq!(att["body"]["file"]["media_id"], "media_abc");
+
+        reply_task.await.unwrap().expect("send_reply succeeded");
     }
 }

--- a/crates/jyc-channels/src/wecom_bot/outbound.rs
+++ b/crates/jyc-channels/src/wecom_bot/outbound.rs
@@ -78,9 +78,7 @@ impl WecomBotOutboundAdapter {
 
     /// Get the shared connection handle Arc so the monitor can set it after
     /// WebSocket creation.
-    pub fn handle_arc(
-        &self,
-    ) -> Arc<Mutex<Option<WecomBotConnectionHandle>>> {
+    pub fn handle_arc(&self) -> Arc<Mutex<Option<WecomBotConnectionHandle>>> {
         self.handle.clone()
     }
 
@@ -267,13 +265,16 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
         if let Some(attachments) = attachments {
             let handle = {
                 let guard = self.handle.lock().await;
-                guard.clone().context("WeCom Bot outbound handle not set; cannot upload attachments")?
+                guard
+                    .clone()
+                    .context("WeCom Bot outbound handle not set; cannot upload attachments")?
             };
 
             for att in attachments {
                 let media_type = wecom_media_type(&att.content_type, &att.filename);
 
-                match upload_attachment(&handle, &att.path, &att.filename, &att.content_type).await {
+                match upload_attachment(&handle, &att.path, &att.filename, &att.content_type).await
+                {
                     Ok(media_id) => {
                         let body = build_media_message_body(media_type, &media_id);
                         let json = serde_json::json!({
@@ -600,16 +601,19 @@ async fn upload_attachment(
     .context("Failed to serialize WeCom Bot upload init body")?;
 
     let init_resp = handle
-        .send_and_wait(CMD_AIBOT_UPLOAD_MEDIA_INIT, &init_req_id, init_body, timeout)
+        .send_and_wait(
+            CMD_AIBOT_UPLOAD_MEDIA_INIT,
+            &init_req_id,
+            init_body,
+            timeout,
+        )
         .await
         .context("Failed to initialize WeCom Bot media upload")?;
 
     let errcode = init_resp["errcode"].as_i64().unwrap_or(-1);
     if errcode != 0 {
         let errmsg = init_resp["errmsg"].as_str().unwrap_or("unknown");
-        anyhow::bail!(
-            "WeCom Bot upload init failed: errcode={errcode}, errmsg={errmsg}"
-        );
+        anyhow::bail!("WeCom Bot upload init failed: errcode={errcode}, errmsg={errmsg}");
     }
 
     let upload_id = init_resp["body"]["upload_id"]
@@ -622,15 +626,17 @@ async fn upload_attachment(
         let chunk_body = serde_json::to_value(UploadMediaChunkBody {
             upload_id: upload_id.to_string(),
             chunk_index: index,
-            base64_data: base64::Engine::encode(
-                &base64::engine::general_purpose::STANDARD,
-                chunk,
-            ),
+            base64_data: base64::Engine::encode(&base64::engine::general_purpose::STANDARD, chunk),
         })
         .context("Failed to serialize WeCom Bot upload chunk body")?;
 
         let chunk_resp = handle
-            .send_and_wait(CMD_AIBOT_UPLOAD_MEDIA_CHUNK, &chunk_req_id, chunk_body, timeout)
+            .send_and_wait(
+                CMD_AIBOT_UPLOAD_MEDIA_CHUNK,
+                &chunk_req_id,
+                chunk_body,
+                timeout,
+            )
             .await
             .with_context(|| format!("Failed to upload WeCom Bot chunk {index}"))?;
 
@@ -651,16 +657,19 @@ async fn upload_attachment(
     .context("Failed to serialize WeCom Bot upload finish body")?;
 
     let finish_resp = handle
-        .send_and_wait(CMD_AIBOT_UPLOAD_MEDIA_FINISH, &finish_req_id, finish_body, timeout)
+        .send_and_wait(
+            CMD_AIBOT_UPLOAD_MEDIA_FINISH,
+            &finish_req_id,
+            finish_body,
+            timeout,
+        )
         .await
         .context("Failed to finish WeCom Bot media upload")?;
 
     let errcode = finish_resp["errcode"].as_i64().unwrap_or(-1);
     if errcode != 0 {
         let errmsg = finish_resp["errmsg"].as_str().unwrap_or("unknown");
-        anyhow::bail!(
-            "WeCom Bot upload finish failed: errcode={errcode}, errmsg={errmsg}"
-        );
+        anyhow::bail!("WeCom Bot upload finish failed: errcode={errcode}, errmsg={errmsg}");
     }
 
     let media_id = finish_resp["body"]["media_id"]
@@ -1005,7 +1014,10 @@ mod tests {
             "file"
         );
         assert_eq!(wecom_media_type("text/csv", "data.csv"), "file");
-        assert_eq!(wecom_media_type("application/octet-stream", "data.bin"), "file");
+        assert_eq!(
+            wecom_media_type("application/octet-stream", "data.bin"),
+            "file"
+        );
     }
 
     #[test]
@@ -1027,7 +1039,10 @@ mod tests {
         responses: Vec<serde_json::Value>,
     ) -> Result<String> {
         let (tx, mut rx) = mpsc::unbounded_channel::<String>();
-        let pending = Arc::new(Mutex::new(HashMap::<String, oneshot::Sender<serde_json::Value>>::new()));
+        let pending = Arc::new(Mutex::new(HashMap::<
+            String,
+            oneshot::Sender<serde_json::Value>,
+        >::new()));
         let handle = WecomBotConnectionHandle::new(tx, pending.clone());
 
         let upload_task = tokio::spawn(async move {
@@ -1045,9 +1060,7 @@ mod tests {
                 .expect("req_id present")
                 .to_string();
             let mut guard = pending.lock().await;
-            let sender = guard
-                .remove(&req_id)
-                .expect("pending response registered");
+            let sender = guard.remove(&req_id).expect("pending response registered");
             sender.send(resp).expect("receiver alive");
         }
 
@@ -1089,7 +1102,10 @@ mod tests {
         ];
 
         let (tx, mut rx) = mpsc::unbounded_channel::<String>();
-        let pending = Arc::new(Mutex::new(HashMap::<String, oneshot::Sender<serde_json::Value>>::new()));
+        let pending = Arc::new(Mutex::new(HashMap::<
+            String,
+            oneshot::Sender<serde_json::Value>,
+        >::new()));
         let handle = WecomBotConnectionHandle::new(tx, pending.clone());
 
         let upload_task = tokio::spawn(async move {
@@ -1169,7 +1185,13 @@ mod tests {
             "errmsg": "invalid credential"
         })];
 
-        let result = run_upload_with_responses(path, "report.pdf".to_string(), "application/pdf".to_string(), responses).await;
+        let result = run_upload_with_responses(
+            path,
+            "report.pdf".to_string(),
+            "application/pdf".to_string(),
+            responses,
+        )
+        .await;
         assert!(result.is_err());
         let msg = format!("{:#}", result.unwrap_err());
         assert!(msg.contains("init failed"), "error: {msg}");
@@ -1182,7 +1204,10 @@ mod tests {
         std::fs::write(&attachment_path, b"pdf content").unwrap();
 
         let (tx, mut rx) = mpsc::unbounded_channel::<String>();
-        let pending = Arc::new(Mutex::new(HashMap::<String, oneshot::Sender<serde_json::Value>>::new()));
+        let pending = Arc::new(Mutex::new(HashMap::<
+            String,
+            oneshot::Sender<serde_json::Value>,
+        >::new()));
         let handle = WecomBotConnectionHandle::new(tx, pending.clone());
 
         let storage = Arc::new(MessageStorage::new(dir.path()));
@@ -1228,7 +1253,13 @@ mod tests {
             let thread_path = dir.path().join("thread");
             tokio::fs::create_dir_all(&thread_path).await.unwrap();
             adapter
-                .send_reply(&message, "AI reply", &thread_path, "msg_001", Some(&attachments))
+                .send_reply(
+                    &message,
+                    "AI reply",
+                    &thread_path,
+                    "msg_001",
+                    Some(&attachments),
+                )
                 .await
         });
 

--- a/crates/jyc-channels/src/wecom_bot/outbound.rs
+++ b/crates/jyc-channels/src/wecom_bot/outbound.rs
@@ -1077,7 +1077,7 @@ mod tests {
 
         let md5_hex = format!("{:x}", md5::compute(content));
 
-        let responses = vec![
+        let responses = [
             serde_json::json!({
                 "headers": {"req_id": "ignored"},
                 "errcode": 0,

--- a/crates/jyc-channels/src/wecom_bot/types.rs
+++ b/crates/jyc-channels/src/wecom_bot/types.rs
@@ -14,6 +14,9 @@ pub const CMD_AIBOT_PING: &str = "ping";
 pub const CMD_AIBOT_RESPOND_MSG: &str = "aibot_respond_msg";
 pub const CMD_AIBOT_RESPOND_WELCOME_MSG: &str = "aibot_respond_welcome_msg";
 pub const CMD_AIBOT_SEND_MSG: &str = "aibot_send_msg";
+pub const CMD_AIBOT_UPLOAD_MEDIA_INIT: &str = "aibot_upload_media_init";
+pub const CMD_AIBOT_UPLOAD_MEDIA_CHUNK: &str = "aibot_upload_media_chunk";
+pub const CMD_AIBOT_UPLOAD_MEDIA_FINISH: &str = "aibot_upload_media_finish";
 
 /// Server-to-client commands.
 pub const CMD_AIBOT_MSG_CALLBACK: &str = "aibot_msg_callback";
@@ -258,6 +261,65 @@ pub struct StreamPayload {
     pub content: String,
     /// Whether this is the final chunk
     pub finish: bool,
+}
+
+// ─── Media Upload Types ───────────────────────────────────────────
+
+/// Request body for `aibot_upload_media_init`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UploadMediaInitBody {
+    /// Media type: `file`, `image`, `voice`, `video`.
+    #[serde(rename = "type")]
+    pub media_type: String,
+    /// File name.
+    pub filename: String,
+    /// Total file size in bytes.
+    #[serde(rename = "total_size")]
+    pub total_size: usize,
+    /// Number of chunks (max 100).
+    #[serde(rename = "total_chunks")]
+    pub total_chunks: usize,
+    /// MD5 digest of the full file (optional but recommended).
+    pub md5: String,
+}
+
+/// Response body for `aibot_upload_media_init`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UploadMediaInitResponse {
+    /// Upload session ID.
+    pub upload_id: String,
+}
+
+/// Request body for `aibot_upload_media_chunk`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UploadMediaChunkBody {
+    /// Upload session ID.
+    pub upload_id: String,
+    /// Chunk index, starting from 0.
+    #[serde(rename = "chunk_index")]
+    pub chunk_index: usize,
+    /// Base64-encoded chunk data.
+    #[serde(rename = "base64_data")]
+    pub base64_data: String,
+}
+
+/// Request body for `aibot_upload_media_finish`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UploadMediaFinishBody {
+    /// Upload session ID.
+    pub upload_id: String,
+}
+
+/// Response body for `aibot_upload_media_finish`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UploadMediaFinishResponse {
+    /// Media type.
+    #[serde(rename = "type")]
+    pub media_type: String,
+    /// Media ID valid for 3 days.
+    pub media_id: String,
+    /// Upload timestamp.
+    pub created_at: String,
 }
 
 #[cfg(test)]

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -30,6 +30,7 @@ use jyc_channels::wecom::kf_outbound::WecomKfOutboundAdapter;
 use jyc_channels::wecom::outbound::WecomOutboundAdapter;
 use jyc_channels::wecom::server::WecomWebhookServer;
 use jyc_channels::wecom::token_cache::AccessTokenCache;
+use jyc_channels::wecom_bot::client::WecomBotConnectionHandle;
 use jyc_channels::wecom_bot::inbound::{WecomBotInboundAdapter, WecomBotMatcher};
 use jyc_channels::wecom_bot::outbound::WecomBotOutboundAdapter;
 use jyc_core::message_router::MessageRouter;
@@ -191,9 +192,9 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
         let mut wechat_sender_arc: Option<
             std::sync::Arc<tokio::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<String>>>>,
         > = None;
-        // For wecom_bot, we share the WebSocket sender between inbound and outbound
-        let mut wecom_bot_sender_arc: Option<
-            std::sync::Arc<tokio::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<String>>>>,
+        // For wecom_bot, we share the WebSocket connection handle between inbound and outbound
+        let mut wecom_bot_handle_arc: Option<
+            std::sync::Arc<tokio::sync::Mutex<Option<WecomBotConnectionHandle>>>,
         > = None;
         // For wecomkf, we share the KfApiClient between inbound and outbound
         let mut wecomkf_kf_client: Option<Arc<KfApiClient>> = None;
@@ -270,7 +271,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     outbound_attachment_config,
                     footer_enabled,
                 );
-                wecom_bot_sender_arc = Some(adapter.sender_arc());
+                wecom_bot_handle_arc = Some(adapter.handle_arc());
                 Arc::new(adapter)
             }
             "wecom" => {
@@ -820,15 +821,15 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
 
                 let patterns_for_callback = patterns.clone();
                 let router_for_callback = router.clone();
-                let wecom_bot_sender_arc_clone = wecom_bot_sender_arc.clone().unwrap();
+                let wecom_bot_handle_arc_clone = wecom_bot_handle_arc.clone().unwrap();
 
                 let task = tokio::spawn(async move {
                     use jyc_types::InboundAdapter;
 
-                    let adapter = WecomBotInboundAdapter::with_shared_sender(
+                    let adapter = WecomBotInboundAdapter::with_shared_handle(
                         &wecom_bot_config,
                         channel_name_owned.clone(),
-                        wecom_bot_sender_arc_clone,
+                        wecom_bot_handle_arc_clone,
                     );
 
                     let thread_manager_clone = thread_manager.clone();

--- a/docs/channels/wecom_bot.md
+++ b/docs/channels/wecom_bot.md
@@ -130,6 +130,41 @@ After a user has messaged the bot, the bot can proactively send messages using
 }
 ```
 
+### Sending Attachments in Replies
+
+When the AI reply includes attachments, each attachment is uploaded over the
+same WebSocket and sent as a separate message after the text reply:
+
+1. Text reply is sent as a streaming message (`msgtype: "stream"`, `finish: true`).
+2. Each attachment is uploaded via:
+   - `aibot_upload_media_init` → returns `upload_id`
+   - `aibot_upload_media_chunk` → base64-encoded chunks (≤ 512 KiB each)
+   - `aibot_upload_media_finish` → returns `media_id`
+3. The attachment is sent with `aibot_respond_msg` using the original `req_id`:
+
+```json
+{
+  "cmd": "aibot_respond_msg",
+  "headers": {"req_id": "req_xxx"},
+  "body": {
+    "msgtype": "file",
+    "file": {"media_id": "MEDIA_ID"}
+  }
+}
+```
+
+Supported mappings:
+
+| File extension | WeCom msgtype | Size limit |
+|----------------|---------------|------------|
+| png, jpg, jpeg, gif | `image` | 10 MB |
+| amr | `voice` | 2 MB |
+| mp4 | `video` | 10 MB |
+| pdf, doc, xlsx, ppt, csv, etc. | `file` | 20 MB |
+
+Configuration uses the generic `[attachments.outbound]` settings (same as Feishu
+and email): `enabled`, `allowed_extensions`, `max_file_size`, `max_per_message`.
+
 ## Thread Naming
 
 - **Single chat**: `bot-{userid}`
@@ -140,8 +175,10 @@ After a user has messaged the bot, the bot can proactively send messages using
 - **24-hour reply window**: messages older than 24h cannot be replied to
 - **Rate limits**: 30 messages/minute, 1000 messages/hour
 - **Proactive push**: user must message the bot first before proactive `aibot_send_msg` works
-- **Media decryption**: image/file/video URLs returned in messages require AES-256-CBC
-decryption using the per-URL `aeskey`. This is not yet implemented.
+- **Media upload**: outbound attachments (files, images, etc.) are uploaded over the
+  WebSocket and sent as separate messages.
+- **Media download**: image/file/video URLs returned in messages are downloaded and
+  decrypted using AES-256-CBC with the per-URL `aeskey`.
 
 ## Comparison with Other WeCom Channels
 
@@ -151,6 +188,7 @@ decryption using the per-URL `aeskey`. This is not yet implemented.
 | Encryption | AES-CBC required | Token-based | None |
 | Real-time | Yes (webhook) | Polling | Yes (WebSocket) |
 | Streaming | No | No | Yes |
+| Outbound attachments | No | No | Yes |
 | Config | token + aes_key | corp_id + secret | bot_id + secret |
 
 ## TODO: Per-Group Pattern Routing


### PR DESCRIPTION
Closes #257

## Summary

Enable the `wecom_bot` channel to upload and send attachments in replies, using the WeCom Smart Robot WebSocket media upload protocol.

## Changes

- Added upload protocol types (`aibot_upload_media_init/chunk/finish`) in `wecom_bot/types.rs`.
- Introduced `WecomBotConnectionHandle` with a pending-response registry so the outbound adapter can await WebSocket ack frames.
- Upgraded the shared object between `WecomBotInboundAdapter` and `WecomBotOutboundAdapter` from a plain sender to the new handle.
- Implemented `upload_attachment()` helper: MD5, chunking (≤512 KiB), init/chunk/finish, and media-type classification (image/voice/video/file).
- Integrated attachment sending into `send_reply()`: text reply first, then one `aibot_respond_msg` per attachment using the original `req_id`.
- Reused generic `OutboundAttachmentConfig` validation (consistent with Feishu/email).
- Added unit tests for media-type mapping, size validation, upload wire format, and end-to-end `send_reply` with an attachment.
- Updated `CHANGELOG.md`, `docs/channels/wecom_bot.md`, and `config.example.toml`.

## Supported attachment mappings

| Extension | WeCom msgtype | Limit |
|-----------|---------------|-------|
| png/jpg/jpeg/gif | image | 10 MB |
| amr | voice | 2 MB |
| mp4 | video | 10 MB |
| pdf/doc/xlsx/ppt/csv/etc. | file | 20 MB |

## Notes

- Proactive `send_message` is not covered; the `OutboundAdapter` trait signature does not accept attachments for proactive messages.
- CI will run formatting, clippy, and tests.
