### PR TITLE
feat: add Docker build and push CI workflow for main branch

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,73 @@
+name: Docker Build & Push
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ccr.ccs.tencentyun.com
+  IMAGE_NAME: jiny/jyc
+
+jobs:
+  build-push:
+    name: Build and push ${{ matrix.target }} image
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: slim
+            mutable_tag: slim
+            sha_prefix: slim-main-
+          - target: production
+            mutable_tag: latest
+            sha_prefix: main-
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Tencent Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.TCR_USERNAME }}
+          password: ${{ secrets.TCR_PASSWORD }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ matrix.mutable_tag }}
+            type=sha,prefix=${{ matrix.sha_prefix }},format=short
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: ${{ matrix.target }}
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=jyc-build
+          cache-to: type=gha,mode=max,scope=jyc-build


### PR DESCRIPTION
Adds a GitHub Actions workflow that builds and pushes Docker images to the Tencent Cloud Container Registry whenever a commit lands on main.

## What changed
- New workflow: .github/workflows/docker-publish.yml
- Trigger: push to main (skips docs-only changes)
- Builds both slim and production targets from docker/Dockerfile
- Publishes to ccr.ccs.tencentyun.com/jiny/jyc with:
  - slim and slim-main-<short-sha>
  - latest and main-<short-sha>
- Uses linux/amd64 only and GitHub Actions cache for layer caching
- Existing PR CI workflow is left untouched

## Prerequisites before merge
Repository secrets must be added in GitHub settings:
- TCR_USERNAME
- TCR_PASSWORD

Closes #259
