### PR TITLE
fix: increase Docker publish timeout and reuse slim cache for production

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,23 +16,12 @@ env:
   IMAGE_NAME: jiny/jyc
 
 jobs:
-  build-push:
-    name: Build and push ${{ matrix.target }} image
+  build-slim:
+    name: Build and push slim image
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     permissions:
       contents: read
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: slim
-            mutable_tag: slim
-            sha_prefix: slim-main-
-          - target: production
-            mutable_tag: latest
-            sha_prefix: main-
 
     steps:
       - name: Checkout repository
@@ -56,18 +45,66 @@ jobs:
           flavor: |
             latest=false
           tags: |
-            type=raw,value=${{ matrix.mutable_tag }}
-            type=sha,prefix=${{ matrix.sha_prefix }},format=short
+            type=raw,value=slim
+            type=sha,prefix=slim-main-,format=short
 
-      - name: Build and push Docker image
+      - name: Build and push slim image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile
-          target: ${{ matrix.target }}
+          target: slim
           platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=jyc-build
-          cache-to: type=gha,mode=max,scope=jyc-build
+          cache-from: type=gha,scope=jyc-slim
+          cache-to: type=gha,mode=max,scope=jyc-slim
+
+  build-production:
+    name: Build and push production image
+    needs: build-slim
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Tencent Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.TCR_USERNAME }}
+          password: ${{ secrets.TCR_PASSWORD }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=main-,format=short
+
+      - name: Build and push production image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          target: production
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: |
+            type=gha,scope=jyc-slim
+            type=gha,scope=jyc-production
+          cache-to: type=gha,mode=max,scope=jyc-production


### PR DESCRIPTION
The production image build was canceled because it hit the 60-minute timeout while exporting the image.

## Changes
- Split the single matrix job into two sequential jobs:
  - build-slim: builds and pushes the slim image, exporting cache to scope jyc-slim.
  - build-production: depends on build-slim so it can reuse the already-cached slim layers, then exports its own cache to scope jyc-production.
- Increased timeouts:
  - build-slim: 90 minutes
  - build-production: 120 minutes
- Changed cache scopes from a shared jyc-build to per-job scopes (jyc-slim, jyc-production) so the production job can safely read the slim cache without overwriting it.

This should prevent the production build from being canceled and avoid duplicate work between the two targets.

Closes #259
