### PR TITLE
fix(wecom_bot): scheduled task proactive message and enter_chat parse error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to JYC will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **WeCom Bot `enter_chat` event parse error.** Added custom serde deserializer
+  for `BotEvent.event` that accepts both plain string form (`"enter_chat"`) and
+  object form (`{"eventtype": "enter_chat"}`), fixing a parse failure caused by
+  WeCom API inconsistency. (#264, #266)
+
+- **WeCom Bot scheduled task proactive message `req_id` error.** When `req_id`
+  is missing (scheduled tasks), `send_reply` now derives `chatid` from
+  `thread_path`, generates a fresh `req_id`, and uses `aibot_send_msg`
+  (proactive) instead of `aibot_respond_msg` (passive reply). (#264, #266)
+
 ### Added
 
 - **Channel-agnostic scheduled job system.** Background JobScheduler runs

--- a/crates/jyc-channels/src/wecom_bot/outbound.rs
+++ b/crates/jyc-channels/src/wecom_bot/outbound.rs
@@ -278,9 +278,15 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
         };
 
         // 8. Send reply via WebSocket with finish=true
-        self.send_text_reply(&req_id, &full_reply, &stream_id, true, proactive_chatid.as_deref())
-            .await
-            .context("Failed to send WeCom Bot reply")?;
+        self.send_text_reply(
+            &req_id,
+            &full_reply,
+            &stream_id,
+            true,
+            proactive_chatid.as_deref(),
+        )
+        .await
+        .context("Failed to send WeCom Bot reply")?;
 
         let message_id = uuid::Uuid::new_v4().to_string();
 

--- a/crates/jyc-channels/src/wecom_bot/outbound.rs
+++ b/crates/jyc-channels/src/wecom_bot/outbound.rs
@@ -313,13 +313,12 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
                 match upload_attachment(&handle, &att.path, &att.filename, &att.content_type).await
                 {
                     Ok(media_id) => {
-                        let body = build_media_message_body(media_type, &media_id);
                         let att_cmd = if proactive_chatid.is_some() {
                             "aibot_send_msg"
                         } else {
                             "aibot_respond_msg"
                         };
-                        let mut body = body;
+                        let mut body = build_media_message_body(media_type, &media_id);
                         if let Some(ref chatid) = proactive_chatid {
                             body["chatid"] = serde_json::Value::String(chatid.clone());
                         }

--- a/crates/jyc-channels/src/wecom_bot/outbound.rs
+++ b/crates/jyc-channels/src/wecom_bot/outbound.rs
@@ -105,6 +105,8 @@ impl WecomBotOutboundAdapter {
 
     /// Send a text/markdown reply through the WebSocket.
     ///
+    /// When `chatid` is `Some`, uses `aibot_send_msg` (proactive mode).
+    /// When `chatid` is `None`, uses `aibot_respond_msg` (passive reply mode).
     /// NOTE: aibot_respond_msg only supports msgtype="stream" (and "template_card").
     /// Text/markdown must be sent as a stream with finish=true.
     async fn send_text_reply(
@@ -113,18 +115,31 @@ impl WecomBotOutboundAdapter {
         content: &str,
         stream_id: &str,
         finish: bool,
+        chatid: Option<&str>,
     ) -> Result<()> {
-        let json = serde_json::json!({
-            "cmd": "aibot_respond_msg",
-            "headers": {"req_id": req_id},
-            "body": {
-                "msgtype": "stream",
-                "stream": {
-                    "id": stream_id,
-                    "content": content,
-                    "finish": finish
-                }
+        let cmd = if chatid.is_some() {
+            "aibot_send_msg"
+        } else {
+            "aibot_respond_msg"
+        };
+
+        let mut body = serde_json::json!({
+            "msgtype": "stream",
+            "stream": {
+                "id": stream_id,
+                "content": content,
+                "finish": finish
             }
+        });
+
+        if let Some(chatid) = chatid {
+            body["chatid"] = serde_json::Value::String(chatid.to_string());
+        }
+
+        let json = serde_json::json!({
+            "cmd": cmd,
+            "headers": {"req_id": req_id},
+            "body": body,
         })
         .to_string();
 
@@ -141,7 +156,7 @@ impl WecomBotOutboundAdapter {
         stream_id: &str,
         content: &str,
     ) -> Result<()> {
-        self.send_text_reply(req_id, content, stream_id, false)
+        self.send_text_reply(req_id, content, stream_id, false, None)
             .await
             .context("Failed to update WeCom Bot processing indicator")
     }
@@ -205,16 +220,32 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
             format!("{}\n\n{}", clean_reply, footer)
         };
 
-        // 5. Get req_id from original message metadata
-        let req_id = original
+        // 5. Get req_id from original message metadata.
+        //    Proactive messages (scheduled tasks) have no req_id — derive chatid
+        //    from thread_path and use aibot_send_msg instead.
+        let original_req_id = original
             .metadata
             .get("req_id")
             .and_then(|v| v.as_str())
             .unwrap_or("");
 
-        if req_id.is_empty() {
-            tracing::warn!("Original message missing req_id, reply may not be correlated by WeCom");
-        }
+        let (req_id, proactive_chatid) = if original_req_id.is_empty() {
+            // Derive chatid from thread_path: strip "bot-" prefix from last component
+            let thread_name = thread_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("");
+            let chatid = thread_name.strip_prefix("bot-").unwrap_or(thread_name);
+            let new_req_id = generate_req_id("aibot_send_msg");
+            tracing::warn!(
+                thread_name = %thread_name,
+                chatid = %chatid,
+                "Original message missing req_id, using proactive send"
+            );
+            (new_req_id, Some(chatid.to_string()))
+        } else {
+            (original_req_id.to_string(), None)
+        };
 
         // 6. Validate attachments if configuration is present
         if let Some(attachments) = attachments
@@ -247,7 +278,7 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
         };
 
         // 8. Send reply via WebSocket with finish=true
-        self.send_text_reply(req_id, &full_reply, &stream_id, true)
+        self.send_text_reply(&req_id, &full_reply, &stream_id, true, proactive_chatid.as_deref())
             .await
             .context("Failed to send WeCom Bot reply")?;
 
@@ -277,8 +308,17 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
                 {
                     Ok(media_id) => {
                         let body = build_media_message_body(media_type, &media_id);
+                        let att_cmd = if proactive_chatid.is_some() {
+                            "aibot_send_msg"
+                        } else {
+                            "aibot_respond_msg"
+                        };
+                        let mut body = body;
+                        if let Some(ref chatid) = proactive_chatid {
+                            body["chatid"] = serde_json::Value::String(chatid.clone());
+                        }
                         let json = serde_json::json!({
-                            "cmd": "aibot_respond_msg",
+                            "cmd": att_cmd,
                             "headers": {"req_id": req_id},
                             "body": body,
                         })
@@ -492,7 +532,7 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
             return Ok(());
         }
 
-        self.send_text_reply(req_id, content, handle, false)
+        self.send_text_reply(req_id, content, handle, false, None)
             .await
             .context("Failed to update WeCom Bot processing indicator")?;
 

--- a/crates/jyc-channels/src/wecom_bot/types.rs
+++ b/crates/jyc-channels/src/wecom_bot/types.rs
@@ -205,6 +205,7 @@ pub struct BotEvent {
     /// Chat ID
     pub chatid: String,
     /// Event type: enter_chat, template_card_event, feedback_event, disconnected_event
+    #[serde(deserialize_with = "deserialize_event_field")]
     pub event: String,
     /// Event data (type-specific)
     #[serde(default)]
@@ -212,6 +213,45 @@ pub struct BotEvent {
     /// Request ID (from headers, not body)
     #[serde(default)]
     pub req_id: String,
+}
+
+/// Custom deserializer for `BotEvent.event` that accepts both a plain string
+/// (`"enter_chat"`) and an object (`{"eventtype": "enter_chat"}`).
+///
+/// WeCom API sometimes sends events as nested objects instead of plain strings.
+fn deserialize_event_field<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+
+    struct EventVisitor;
+
+    impl<'de> de::Visitor<'de> for EventVisitor {
+        type Value = String;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a string or an object with an \"eventtype\" field")
+        }
+
+        fn visit_str<E: de::Error>(self, value: &str) -> Result<String, E> {
+            Ok(value.to_string())
+        }
+
+        fn visit_map<M: de::MapAccess<'de>>(self, mut map: M) -> Result<String, M::Error> {
+            let mut eventtype = None;
+            while let Some(key) = map.next_key::<String>()? {
+                if key.to_lowercase() == "eventtype" {
+                    eventtype = Some(map.next_value::<String>()?);
+                } else {
+                    let _: serde::de::IgnoredAny = map.next_value()?;
+                }
+            }
+            eventtype.ok_or_else(|| de::Error::missing_field("eventtype"))
+        }
+    }
+
+    deserializer.deserialize_any(EventVisitor)
 }
 
 /// Payload for responding/sending messages.
@@ -363,6 +403,25 @@ mod tests {
                 "aibotid": "bot_xxx",
                 "chatid": "chat_456",
                 "event": "enter_chat"
+            }
+        }"#;
+        let raw: serde_json::Value = serde_json::from_str(json).unwrap();
+        let body = raw.get("body").cloned().unwrap();
+        let event: BotEvent = serde_json::from_value(body).unwrap();
+        assert_eq!(event.event, "enter_chat");
+        assert_eq!(event.chatid, "chat_456");
+    }
+
+    #[test]
+    fn test_parse_event_object_form() {
+        // WeCom may send event as an object: {"eventtype": "enter_chat"}
+        let json = r#"{
+            "cmd": "aibot_event_callback",
+            "headers": {"req_id": "req_def"},
+            "body": {
+                "aibotid": "bot_xxx",
+                "chatid": "chat_456",
+                "event": {"eventtype": "enter_chat"}
             }
         }"#;
         let raw: serde_json::Value = serde_json::from_str(json).unwrap();


### PR DESCRIPTION
## Spec

Fix two WeCom Bot bugs: (1) scheduled task proactive messages fail with `invalid req_id` because `send_reply` uses `aibot_respond_msg` without a valid `req_id`, and (2) `enter_chat` events fail to parse because WeCom sends `"event": {"eventtype": "enter_chat"}` (object) instead of `"event": "enter_chat"` (string).

Fixes #264

## Implementation Plan

### Step 1: Fix `BotEvent.event` deserialization in `types.rs`
**What:** Add a custom deserialization helper `deserialize_event_field` that accepts both `"enter_chat"` (plain string) and `{"eventtype": "enter_chat"}` (object). Use it via `#[serde(deserialize_with = "deserialize_event_field")]` on `BotEvent.event`. Extract the event type string from either form.
**Why:** WeCom API sometimes sends events as nested objects `{"eventtype": "..."}` instead of plain strings, causing serde to fail parsing the entire `BotEvent` body.
**Verify:** `cargo test --package jyc-channels --lib wecom_bot::types::tests` — add a new test case with the object-form JSON (e.g., `"event": {"eventtype": "enter_chat"}`) and assert `event.event == "enter_chat"`. Existing `test_parse_event` must still pass with the string form.

### Step 2: Handle missing `req_id` in `send_reply()` by switching to proactive send
**What:** In `WecomBotOutboundAdapter::send_reply()` (`outbound.rs:209-213`), after extracting `req_id`, check if it's empty. If empty:
- Derive `chatid` from `thread_path` by stripping the `"bot-"` prefix from the last path component (matching the convention in `WecomBotMatcher::derive_thread_name`, inbound.rs:48-56)
- Use `aibot_send_msg` (same wire format as `send_message()`, outbound.rs:349-376) instead of `aibot_respond_msg` for both the text reply and any attachment messages
- Generate a fresh `req_id` using `generate_req_id("aibot_send_msg")` (import from `super::client`)
**Why:** Scheduled jobs produce `InboundMessage` without `req_id`, making `aibot_respond_msg` fail with errcode 846605. Proactive messages must use `aibot_send_msg`.
**Verify:** `cargo test --package jyc-channels --lib wecom_bot::outbound::tests` — add a test constructing an `InboundMessage` without `req_id` in metadata, calling `send_reply`, and asserting the outbound frame uses `"cmd": "aibot_send_msg"` with the correct `chatid` derived from thread path. All existing tests must continue to pass.

### Step 3: (Optional) Add test for `BotEvent` object-form parse in `types.rs`
**What:** Add a `test_parse_event_object_form` test that validates deserialization of `"event": {"eventtype": "enter_chat"}`.
**Why:** Regression protection for the custom deserializer.
**Verify:** `cargo test test_parse_event_object_form`

## Design Decisions
- Thread name convention `bot-{chatid}` is already established in `WecomBotMatcher::derive_thread_name` — we reuse the same convention for reverse lookup
- Attachment upload (`upload_attachment`) is unchanged; only the final `aibot_respond_msg`/`aibot_send_msg` frame differs based on `req_id` presence
- Custom deserializer for `BotEvent.event` uses a visitor pattern to handle both string and object forms transparently