### PR TITLE
feat: builtin tool jyc_send_to_thread for cross-thread/channel communication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All notable changes to JYC will be documented in this file.
 
 ### Added
 
+- **Cross-thread/channel communication tool (`jyc_send_to_thread`).** New
+  builtin tool that enables AI agents to inject messages into threads in other
+  channels. The tool is backed by `ThreadManager::enqueue()` (same mechanism as
+  the JobScheduler). ToolContext carries a cross-channel `thread_managers` map
+  (keyed by channel name) wired from Monitor → JycAgentService → AgentLoopConfig
+  → ToolContext. System prompt lists available channels. Attachment validation
+  mirrors `ReplyMessageTool`. (#268)
+
 - **Channel-agnostic scheduled job system.** Background JobScheduler runs
   alongside the monitor, scans all threads for due jobs (per-thread
   `.jyc/jobs/<id>.json` storage), fires recurring (cron) or one-time jobs by

--- a/crates/jyc-agent/src/agent_loop.rs
+++ b/crates/jyc-agent/src/agent_loop.rs
@@ -6,6 +6,7 @@
 use anyhow::Result;
 use chrono::Utc;
 use futures::StreamExt;
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
@@ -14,6 +15,7 @@ use tracing;
 
 use jyc_core::thread_event::ThreadEvent;
 use jyc_core::thread_event_bus::ThreadEventBusRef;
+use jyc_core::thread_manager::ThreadManager;
 
 use crate::provider::{Provider, is_transient_sse_error};
 use crate::tools::{ToolContext, ToolOutput, registry::ToolRegistry};
@@ -62,6 +64,11 @@ pub struct AgentLoopConfig<'a> {
     /// `jyc_send_message`). Passed through to `ToolContext` so tools
     /// can send messages directly without signal-file indirection.
     pub outbound: Option<Arc<dyn jyc_types::channel::OutboundAdapter>>,
+    /// Cross-channel thread managers keyed by channel name.
+    /// Passed through to `ToolContext` so the `jyc_send_to_thread` tool
+    /// can inject messages into threads in other channels.
+    pub thread_managers:
+        Option<Arc<tokio::sync::Mutex<HashMap<String, Arc<ThreadManager>>>>>,
 }
 
 /// Run the agent loop to completion.
@@ -84,6 +91,7 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
         additional_read_roots,
         pattern_inject_images,
         outbound,
+        thread_managers,
     } = config;
 
     // Provider used for the cycle-boundary progress summary. Falls back to
@@ -190,6 +198,7 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
             let mut ctx = ToolContext::with_roots(working_dir, additional_read_roots.clone());
             ctx.pattern_inject_images = pattern_inject_images;
             ctx.outbound = outbound.clone();
+            ctx.thread_managers = thread_managers.clone();
             let synthetic_input: serde_json::Value = serde_json::from_str(&synthetic_args)
                 .unwrap_or(serde_json::Value::Object(Default::default()));
             let synthetic_output = match tools
@@ -340,6 +349,7 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
         let mut ctx = ToolContext::with_roots(working_dir, additional_read_roots.clone());
         ctx.pattern_inject_images = pattern_inject_images;
         ctx.outbound = outbound.clone();
+        ctx.thread_managers = thread_managers.clone();
 
         for tool_call in &response.tool_calls {
             if cancel.is_cancelled() {

--- a/crates/jyc-agent/src/agent_loop.rs
+++ b/crates/jyc-agent/src/agent_loop.rs
@@ -16,7 +16,7 @@ use jyc_core::thread_event::ThreadEvent;
 use jyc_core::thread_event_bus::ThreadEventBusRef;
 
 use crate::provider::{Provider, is_transient_sse_error};
-use crate::tools::{ToolContext, ToolOutput, ThreadManagersMap, registry::ToolRegistry};
+use crate::tools::{ThreadManagersMap, ToolContext, ToolOutput, registry::ToolRegistry};
 use crate::types::{AgentLoopResult, ContentBlock, Message, Role, StreamEvent, ToolDefinition};
 
 /// Default maximum number of tool-call iterations before giving up.

--- a/crates/jyc-agent/src/agent_loop.rs
+++ b/crates/jyc-agent/src/agent_loop.rs
@@ -66,6 +66,9 @@ pub struct AgentLoopConfig<'a> {
     /// Passed through to `ToolContext` so the `jyc_send_to_thread` tool
     /// can inject messages into threads in other channels.
     pub thread_managers: Option<ThreadManagersMap>,
+    /// Current channel name, for tools that need source context
+    /// (e.g. `jyc_send_to_thread` sets `source_channel` metadata from this).
+    pub current_channel: Option<String>,
 }
 
 /// Run the agent loop to completion.
@@ -89,6 +92,7 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
         pattern_inject_images,
         outbound,
         thread_managers,
+        current_channel,
     } = config;
 
     // Provider used for the cycle-boundary progress summary. Falls back to
@@ -196,6 +200,8 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
             ctx.pattern_inject_images = pattern_inject_images;
             ctx.outbound = outbound.clone();
             ctx.thread_managers = thread_managers.clone();
+            ctx.current_channel = current_channel.clone();
+            ctx.current_thread = Some(thread_name.to_string());
             let synthetic_input: serde_json::Value = serde_json::from_str(&synthetic_args)
                 .unwrap_or(serde_json::Value::Object(Default::default()));
             let synthetic_output = match tools
@@ -347,6 +353,8 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
         ctx.pattern_inject_images = pattern_inject_images;
         ctx.outbound = outbound.clone();
         ctx.thread_managers = thread_managers.clone();
+        ctx.current_channel = current_channel.clone();
+        ctx.current_thread = Some(thread_name.to_string());
 
         for tool_call in &response.tool_calls {
             if cancel.is_cancelled() {

--- a/crates/jyc-agent/src/agent_loop.rs
+++ b/crates/jyc-agent/src/agent_loop.rs
@@ -6,7 +6,6 @@
 use anyhow::Result;
 use chrono::Utc;
 use futures::StreamExt;
-use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
@@ -15,10 +14,9 @@ use tracing;
 
 use jyc_core::thread_event::ThreadEvent;
 use jyc_core::thread_event_bus::ThreadEventBusRef;
-use jyc_core::thread_manager::ThreadManager;
 
 use crate::provider::{Provider, is_transient_sse_error};
-use crate::tools::{ToolContext, ToolOutput, registry::ToolRegistry};
+use crate::tools::{ToolContext, ToolOutput, ThreadManagersMap, registry::ToolRegistry};
 use crate::types::{AgentLoopResult, ContentBlock, Message, Role, StreamEvent, ToolDefinition};
 
 /// Default maximum number of tool-call iterations before giving up.
@@ -67,8 +65,7 @@ pub struct AgentLoopConfig<'a> {
     /// Cross-channel thread managers keyed by channel name.
     /// Passed through to `ToolContext` so the `jyc_send_to_thread` tool
     /// can inject messages into threads in other channels.
-    pub thread_managers:
-        Option<Arc<tokio::sync::Mutex<HashMap<String, Arc<ThreadManager>>>>>,
+    pub thread_managers: Option<ThreadManagersMap>,
 }
 
 /// Run the agent loop to completion.

--- a/crates/jyc-agent/src/lib.rs
+++ b/crates/jyc-agent/src/lib.rs
@@ -108,6 +108,7 @@ mod integration_tests {
             pattern_inject_images: false,
             outbound: None,
             thread_managers: None,
+            current_channel: None,
         })
         .await
         .unwrap();

--- a/crates/jyc-agent/src/lib.rs
+++ b/crates/jyc-agent/src/lib.rs
@@ -107,6 +107,7 @@ mod integration_tests {
             additional_read_roots: Vec::new(),
             pattern_inject_images: false,
             outbound: None,
+            thread_managers: None,
         })
         .await
         .unwrap();

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -12,6 +12,7 @@ use tracing;
 
 use jyc_core::agent::{AgentResult, AgentService};
 use jyc_core::thread_event_bus::ThreadEventBusRef;
+use jyc_core::thread_manager::ThreadManager;
 use jyc_types::{ChannelPattern, InboundMessage, McpServerConfig, QueueItem};
 
 use crate::agent_loop::{self, AgentLoopConfig};
@@ -129,6 +130,10 @@ pub struct JycAgentService {
     channel_skills: Option<Vec<String>>,
     /// Channel-level skills to disable (merged with pattern-level).
     channel_disabled_skills: Option<Vec<String>>,
+    /// Cross-channel thread managers keyed by channel name.
+    /// Passed through to `AgentLoopConfig` so the `jyc_send_to_thread` tool
+    /// can inject messages into threads in other channels.
+    thread_managers: Option<Arc<tokio::sync::Mutex<HashMap<String, Arc<ThreadManager>>>>>,
 }
 
 impl JycAgentService {
@@ -164,7 +169,19 @@ impl JycAgentService {
             channel_disabled_mcp_servers,
             channel_skills,
             channel_disabled_skills,
+            thread_managers: None,
         }
+    }
+
+    /// Set the cross-channel thread managers map.
+    ///
+    /// Called by the monitor during startup to inject the thread manager map
+    /// into each agent service after all channels have been initialized.
+    pub fn set_thread_managers(
+        &mut self,
+        tm: Arc<tokio::sync::Mutex<HashMap<String, Arc<ThreadManager>>>>,
+    ) {
+        self.thread_managers = Some(tm);
     }
 
     /// Discover skills from multiple paths, with priority-based deduplication.
@@ -959,7 +976,7 @@ impl AgentService for JycAgentService {
             additional_read_roots,
             pattern_inject_images: pattern_inject,
             outbound: self.outbound.clone(),
-            thread_managers: None,
+            thread_managers: self.thread_managers.clone(),
         })
         .await?;
 

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -959,6 +959,7 @@ impl AgentService for JycAgentService {
             additional_read_roots,
             pattern_inject_images: pattern_inject,
             outbound: self.outbound.clone(),
+            thread_managers: None,
         })
         .await?;
 

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -133,7 +133,9 @@ pub struct JycAgentService {
     /// Cross-channel thread managers keyed by channel name.
     /// Passed through to `AgentLoopConfig` so the `jyc_send_to_thread` tool
     /// can inject messages into threads in other channels.
-    thread_managers: Option<ThreadManagersMap>,
+    /// Uses `std::sync::Mutex` for interior mutability (set after construction
+    /// via `set_thread_managers()` on an `Arc<Self>`).
+    thread_managers: std::sync::Mutex<Option<ThreadManagersMap>>,
 }
 
 impl JycAgentService {
@@ -169,7 +171,7 @@ impl JycAgentService {
             channel_disabled_mcp_servers,
             channel_skills,
             channel_disabled_skills,
-            thread_managers: None,
+            thread_managers: std::sync::Mutex::new(None),
         }
     }
 
@@ -177,8 +179,8 @@ impl JycAgentService {
     ///
     /// Called by the monitor during startup to inject the thread manager map
     /// into each agent service after all channels have been initialized.
-    pub fn set_thread_managers(&mut self, tm: ThreadManagersMap) {
-        self.thread_managers = Some(tm);
+    pub fn set_thread_managers(&self, tm: ThreadManagersMap) {
+        *self.thread_managers.lock().expect("thread_managers poisoned") = Some(tm);
     }
 
     /// Discover skills from multiple paths, with priority-based deduplication.
@@ -377,7 +379,12 @@ impl JycAgentService {
         );
 
         // Cross-Thread Communication section (when thread managers are available)
-        if let Some(ref tm_map) = self.thread_managers {
+        let tm_map_opt = self
+            .thread_managers
+            .lock()
+            .expect("thread_managers poisoned")
+            .clone();
+        if let Some(ref tm_map) = tm_map_opt {
             prompt.push_str(
                 "\n## Cross-Thread Communication\n\n\
                  You can send messages to threads in other channels using the `jyc_send_to_thread` tool.\n\n\
@@ -970,6 +977,11 @@ impl AgentService for JycAgentService {
 
         // 7. Run agent loop
         let additional_read_roots = self.resolve_additional_read_roots(message, thread_path);
+        let thread_managers = self
+            .thread_managers
+            .lock()
+            .expect("thread_managers poisoned")
+            .clone();
         let result = agent_loop::run(AgentLoopConfig {
             provider: provider.as_ref(),
             small_provider: small_provider
@@ -988,7 +1000,7 @@ impl AgentService for JycAgentService {
             additional_read_roots,
             pattern_inject_images: pattern_inject,
             outbound: self.outbound.clone(),
-            thread_managers: self.thread_managers.clone(),
+            thread_managers: thread_managers.clone(),
         })
         .await?;
 

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -12,13 +12,13 @@ use tracing;
 
 use jyc_core::agent::{AgentResult, AgentService};
 use jyc_core::thread_event_bus::ThreadEventBusRef;
-use jyc_core::thread_manager::ThreadManager;
 use jyc_types::{ChannelPattern, InboundMessage, McpServerConfig, QueueItem};
 
 use crate::agent_loop::{self, AgentLoopConfig};
 use crate::provider;
 use crate::session;
 use crate::tools::registry::ToolRegistry;
+use crate::tools::ThreadManagersMap;
 use crate::types::AgentConfig;
 use crate::vision::VisionClient;
 use std::sync::Arc;
@@ -133,7 +133,7 @@ pub struct JycAgentService {
     /// Cross-channel thread managers keyed by channel name.
     /// Passed through to `AgentLoopConfig` so the `jyc_send_to_thread` tool
     /// can inject messages into threads in other channels.
-    thread_managers: Option<Arc<tokio::sync::Mutex<HashMap<String, Arc<ThreadManager>>>>>,
+    thread_managers: Option<ThreadManagersMap>,
 }
 
 impl JycAgentService {
@@ -177,10 +177,7 @@ impl JycAgentService {
     ///
     /// Called by the monitor during startup to inject the thread manager map
     /// into each agent service after all channels have been initialized.
-    pub fn set_thread_managers(
-        &mut self,
-        tm: Arc<tokio::sync::Mutex<HashMap<String, Arc<ThreadManager>>>>,
-    ) {
+    pub fn set_thread_managers(&mut self, tm: ThreadManagersMap) {
         self.thread_managers = Some(tm);
     }
 

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -136,6 +136,8 @@ pub struct JycAgentService {
     /// Uses `std::sync::Mutex` for interior mutability (set after construction
     /// via `set_thread_managers()` on an `Arc<Self>`).
     thread_managers: std::sync::Mutex<Option<ThreadManagersMap>>,
+    /// Current channel name for source context in cross-thread tools.
+    channel_name: String,
 }
 
 impl JycAgentService {
@@ -156,6 +158,7 @@ impl JycAgentService {
         channel_disabled_mcp_servers: Option<Vec<String>>,
         channel_skills: Option<Vec<String>>,
         channel_disabled_skills: Option<Vec<String>>,
+        channel_name: String,
     ) -> Self {
         Self {
             config,
@@ -172,6 +175,7 @@ impl JycAgentService {
             channel_skills,
             channel_disabled_skills,
             thread_managers: std::sync::Mutex::new(None),
+            channel_name,
         }
     }
 
@@ -388,11 +392,24 @@ impl JycAgentService {
             prompt.push_str(
                 "\n## Cross-Thread Communication\n\n\
                  You can send messages to threads in other channels using the `jyc_send_to_thread` tool.\n\n\
-                 Available channels:\n",
+                 Available channels and their active threads:\n",
             );
             let map = tm_map.lock().await;
-            for channel_name in map.keys() {
-                prompt.push_str(&format!("- Channel \"{}\"\n", channel_name));
+            for (channel_name, tm) in map.iter() {
+                let channel_type = tm.channel_type();
+                prompt.push_str(&format!("- Channel \"{}\" ({})\n", channel_name, channel_type));
+                // List active threads for this channel
+                let threads = tm.list_threads().await;
+                if threads.is_empty() {
+                    prompt.push_str("    (no active threads)\n");
+                } else {
+                    for thread_info in &threads {
+                        prompt.push_str(&format!(
+                            "  - {}\n",
+                            thread_info.name
+                        ));
+                    }
+                }
             }
             prompt.push('\n');
         }
@@ -1001,6 +1018,7 @@ impl AgentService for JycAgentService {
             pattern_inject_images: pattern_inject,
             outbound: self.outbound.clone(),
             thread_managers: thread_managers.clone(),
+            current_channel: Some(self.channel_name.clone()),
         })
         .await?;
 
@@ -1104,6 +1122,7 @@ mod tests {
             None,
             None,
             None,
+            "test".to_string(),
         )
     }
 
@@ -1141,6 +1160,7 @@ mod tests {
             channel_disabled_mcp_servers,
             None,
             None,
+            "test".to_string(),
         )
     }
 
@@ -1163,6 +1183,7 @@ mod tests {
             None,
             channel_skills,
             channel_disabled_skills,
+            "test".to_string(),
         )
     }
 

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -290,7 +290,7 @@ impl JycAgentService {
     }
 
     /// Build the system prompt for a thread.
-    fn build_system_prompt(&self, thread_path: &Path, matched_pattern: Option<&str>) -> String {
+    async fn build_system_prompt(&self, thread_path: &Path, matched_pattern: Option<&str>) -> String {
         let mut prompt = String::new();
 
         // Security: directory boundaries
@@ -375,6 +375,20 @@ impl JycAgentService {
              This thread maintains a chronological chat history in `chat_history_YYYY-MM-DD.md`.\n\
              You can read it with the `read` tool if you need context from prior conversations.\n",
         );
+
+        // Cross-Thread Communication section (when thread managers are available)
+        if let Some(ref tm_map) = self.thread_managers {
+            prompt.push_str(
+                "\n## Cross-Thread Communication\n\n\
+                 You can send messages to threads in other channels using the `jyc_send_to_thread` tool.\n\n\
+                 Available channels:\n",
+            );
+            let map = tm_map.lock().await;
+            for channel_name in map.keys() {
+                prompt.push_str(&format!("- Channel \"{}\"\n", channel_name));
+            }
+            prompt.push('\n');
+        }
 
         prompt
     }
@@ -927,8 +941,9 @@ impl AgentService for JycAgentService {
 
         // 4. Build prompts (image-injection gated by per-pattern flag and
         //    per-model `supports_images`)
+        // 3a. Build system prompt (available channels, skills, AGENTS.md, etc.)
         let system_prompt =
-            self.build_system_prompt(thread_path, message.matched_pattern.as_deref());
+            self.build_system_prompt(thread_path, message.matched_pattern.as_deref()).await;
         let user_blocks = self.build_user_blocks(message, provider.supports_images());
 
         // 5. Build tool registry

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -17,8 +17,8 @@ use jyc_types::{ChannelPattern, InboundMessage, McpServerConfig, QueueItem};
 use crate::agent_loop::{self, AgentLoopConfig};
 use crate::provider;
 use crate::session;
-use crate::tools::registry::ToolRegistry;
 use crate::tools::ThreadManagersMap;
+use crate::tools::registry::ToolRegistry;
 use crate::types::AgentConfig;
 use crate::vision::VisionClient;
 use std::sync::Arc;
@@ -184,7 +184,10 @@ impl JycAgentService {
     /// Called by the monitor during startup to inject the thread manager map
     /// into each agent service after all channels have been initialized.
     pub fn set_thread_managers(&self, tm: ThreadManagersMap) {
-        *self.thread_managers.lock().expect("thread_managers poisoned") = Some(tm);
+        *self
+            .thread_managers
+            .lock()
+            .expect("thread_managers poisoned") = Some(tm);
     }
 
     /// Discover skills from multiple paths, with priority-based deduplication.
@@ -296,7 +299,11 @@ impl JycAgentService {
     }
 
     /// Build the system prompt for a thread.
-    async fn build_system_prompt(&self, thread_path: &Path, matched_pattern: Option<&str>) -> String {
+    async fn build_system_prompt(
+        &self,
+        thread_path: &Path,
+        matched_pattern: Option<&str>,
+    ) -> String {
         let mut prompt = String::new();
 
         // Security: directory boundaries
@@ -397,17 +404,17 @@ impl JycAgentService {
             let map = tm_map.lock().await;
             for (channel_name, tm) in map.iter() {
                 let channel_type = tm.channel_type();
-                prompt.push_str(&format!("- Channel \"{}\" ({})\n", channel_name, channel_type));
+                prompt.push_str(&format!(
+                    "- Channel \"{}\" ({})\n",
+                    channel_name, channel_type
+                ));
                 // List active threads for this channel
                 let threads = tm.list_threads().await;
                 if threads.is_empty() {
                     prompt.push_str("    (no active threads)\n");
                 } else {
                     for thread_info in &threads {
-                        prompt.push_str(&format!(
-                            "  - {}\n",
-                            thread_info.name
-                        ));
+                        prompt.push_str(&format!("  - {}\n", thread_info.name));
                     }
                 }
             }
@@ -966,8 +973,9 @@ impl AgentService for JycAgentService {
         // 4. Build prompts (image-injection gated by per-pattern flag and
         //    per-model `supports_images`)
         // 3a. Build system prompt (available channels, skills, AGENTS.md, etc.)
-        let system_prompt =
-            self.build_system_prompt(thread_path, message.matched_pattern.as_deref()).await;
+        let system_prompt = self
+            .build_system_prompt(thread_path, message.matched_pattern.as_deref())
+            .await;
         let user_blocks = self.build_user_blocks(message, provider.supports_images());
 
         // 5. Build tool registry

--- a/crates/jyc-agent/src/tools/builtin/mod.rs
+++ b/crates/jyc-agent/src/tools/builtin/mod.rs
@@ -7,6 +7,7 @@ pub mod grep;
 pub mod job_tools;
 pub mod read;
 pub mod read_image;
+pub mod send_to_thread;
 pub mod webfetch;
 pub mod write;
 
@@ -30,6 +31,7 @@ pub fn create_builtin_registry() -> ToolRegistry {
     registry.register(Box::new(job_tools::JobCreateTool));
     registry.register(Box::new(job_tools::JobDeleteTool));
     registry.register(Box::new(job_tools::JobToggleTool));
+    registry.register(Box::new(send_to_thread::SendToThreadTool));
 
     registry
 }

--- a/crates/jyc-agent/src/tools/builtin/send_to_thread.rs
+++ b/crates/jyc-agent/src/tools/builtin/send_to_thread.rs
@@ -180,14 +180,18 @@ impl Tool for SendToThreadTool {
                 .collect(),
             metadata: {
                 let mut m = HashMap::new();
-                m.insert(
-                    "source_channel".to_string(),
-                    serde_json::Value::String(String::new()),
-                );
-                m.insert(
-                    "source_thread".to_string(),
-                    serde_json::Value::String(String::new()),
-                );
+                if let Some(ref src_ch) = ctx.current_channel {
+                    m.insert(
+                        "source_channel".to_string(),
+                        serde_json::Value::String(src_ch.clone()),
+                    );
+                }
+                if let Some(ref src_th) = ctx.current_thread {
+                    m.insert(
+                        "source_thread".to_string(),
+                        serde_json::Value::String(src_th.clone()),
+                    );
+                }
                 m
             },
             matched_pattern: None,

--- a/crates/jyc-agent/src/tools/builtin/send_to_thread.rs
+++ b/crates/jyc-agent/src/tools/builtin/send_to_thread.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use tracing;
 
 use crate::tools::{Tool, ToolContext, ToolOutput};
-use jyc_types::{InboundMessage, MessageContent, MessageAttachment, PatternMatch};
+use jyc_types::{InboundMessage, MessageAttachment, MessageContent, PatternMatch};
 
 /// Tool for sending messages to threads in other channels.
 pub struct SendToThreadTool;
@@ -140,7 +140,11 @@ impl Tool for SendToThreadTool {
                 return Ok(ToolOutput::error(format!(
                     "Channel '{}' not found. Available channels: {}",
                     channel,
-                    tm_map.keys().map(|k| format!("\"{}\"", k)).collect::<Vec<_>>().join(", "),
+                    tm_map
+                        .keys()
+                        .map(|k| format!("\"{}\"", k))
+                        .collect::<Vec<_>>()
+                        .join(", "),
                 )));
             }
         };
@@ -168,7 +172,9 @@ impl Tool for SendToThreadTool {
                 .iter()
                 .map(|filename| {
                     let file_path = ctx.working_dir.join(filename);
-                    let size = std::fs::metadata(&file_path).map(|m| m.len() as usize).unwrap_or(0);
+                    let size = std::fs::metadata(&file_path)
+                        .map(|m| m.len() as usize)
+                        .unwrap_or(0);
                     MessageAttachment {
                         filename: filename.clone(),
                         content_type: "application/octet-stream".to_string(),

--- a/crates/jyc-agent/src/tools/builtin/send_to_thread.rs
+++ b/crates/jyc-agent/src/tools/builtin/send_to_thread.rs
@@ -1,0 +1,225 @@
+//! Builtin tool: `jyc_send_to_thread` — cross-thread/channel communication.
+//!
+//! Allows AI agents to inject messages into threads in other channels.
+//! For example, an agent in a Feishu thread can generate a PDF and inject it
+//! into an email channel's invoice_processing thread.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use tracing;
+
+use crate::tools::{Tool, ToolContext, ToolOutput};
+use jyc_types::{InboundMessage, MessageContent, MessageAttachment, PatternMatch};
+
+/// Tool for sending messages to threads in other channels.
+pub struct SendToThreadTool;
+
+#[async_trait]
+impl Tool for SendToThreadTool {
+    fn name(&self) -> &str {
+        "jyc_send_to_thread"
+    }
+
+    fn description(&self) -> &str {
+        "Send a message to a thread in another channel. \
+         Use this for cross-thread/channel communication, e.g. sending a \
+         generated PDF to an invoice processing thread in another channel. \
+         The target thread will be auto-created if it doesn't exist yet."
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "channel": {
+                    "type": "string",
+                    "description": "Target channel name, e.g. \"jin283\" or \"feishu_work\""
+                },
+                "thread": {
+                    "type": "string",
+                    "description": "Target thread name, e.g. \"invoice_processing\" or \"support\""
+                },
+                "message": {
+                    "type": "string",
+                    "description": "Message body to inject into the target thread"
+                },
+                "attachments": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Optional list of filenames within the current thread directory to attach"
+                },
+                "recipient": {
+                    "type": "string",
+                    "description": "Optional recipient address/ID. Sets the sender_address on the injected message, enabling channel-appropriate reply routing"
+                }
+            },
+            "required": ["channel", "thread", "message"]
+        })
+    }
+
+    async fn execute(&self, input: Value, ctx: &ToolContext<'_>) -> Result<ToolOutput> {
+        let channel = input
+            .get("channel")
+            .and_then(|c| c.as_str())
+            .ok_or_else(|| anyhow::anyhow!("Missing 'channel' parameter"))?;
+
+        let thread_name = input
+            .get("thread")
+            .and_then(|t| t.as_str())
+            .ok_or_else(|| anyhow::anyhow!("Missing 'thread' parameter"))?;
+
+        let message = input
+            .get("message")
+            .and_then(|m| m.as_str())
+            .ok_or_else(|| anyhow::anyhow!("Missing 'message' parameter"))?;
+
+        let attachments: Option<Vec<String>> = input
+            .get("attachments")
+            .and_then(|a| serde_json::from_value(a.clone()).ok());
+
+        let recipient = input.get("recipient").and_then(|r| r.as_str());
+
+        // Validate required fields are non-empty
+        if channel.trim().is_empty() {
+            return Ok(ToolOutput::error("Channel cannot be empty"));
+        }
+        if thread_name.trim().is_empty() {
+            return Ok(ToolOutput::error("Thread cannot be empty"));
+        }
+        if message.trim().is_empty() {
+            return Ok(ToolOutput::error("Message cannot be empty"));
+        }
+
+        // Validate attachments (same logic as ReplyMessageTool)
+        let validated_attachments = if let Some(ref filenames) = attachments {
+            let mut valid = Vec::new();
+            for filename in filenames {
+                let file_path = ctx.working_dir.join(filename);
+                if !file_path.exists() {
+                    return Ok(ToolOutput::error(format!(
+                        "Attachment not found: '{}'",
+                        filename
+                    )));
+                }
+                // Security: ensure within working directory
+                if let Ok(canonical) = file_path.canonicalize() {
+                    let working_canonical = ctx
+                        .working_dir
+                        .canonicalize()
+                        .unwrap_or_else(|_| ctx.working_dir.to_path_buf());
+                    if !canonical.starts_with(&working_canonical) {
+                        return Ok(ToolOutput::error(format!(
+                            "Attachment '{}' is outside the working directory",
+                            filename
+                        )));
+                    }
+                }
+                valid.push(filename.clone());
+            }
+            valid
+        } else {
+            vec![]
+        };
+
+        // Look up the target channel's ThreadManager
+        let thread_managers = match ctx.thread_managers.as_ref() {
+            Some(tm) => tm,
+            None => {
+                return Ok(ToolOutput::error(
+                    "No thread managers available for cross-channel communication",
+                ));
+            }
+        };
+
+        let tm_map = thread_managers.lock().await;
+        let target_tm = match tm_map.get(channel) {
+            Some(tm) => tm.clone(),
+            None => {
+                return Ok(ToolOutput::error(format!(
+                    "Channel '{}' not found. Available channels: {}",
+                    channel,
+                    tm_map.keys().map(|k| format!("\"{}\"", k)).collect::<Vec<_>>().join(", "),
+                )));
+            }
+        };
+        drop(tm_map);
+
+        // Build InboundMessage with source metadata
+        let inbound = InboundMessage {
+            id: uuid::Uuid::new_v4().to_string(),
+            channel: channel.to_string(),
+            channel_uid: format!("jyc-send-to-thread-{}", uuid::Uuid::new_v4()),
+            sender: "Agent".to_string(),
+            sender_address: recipient.unwrap_or("agent@jyc").to_string(),
+            recipients: vec![],
+            topic: "Message from cross-thread tool".to_string(),
+            content: MessageContent {
+                text: Some(message.to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: validated_attachments
+                .iter()
+                .map(|filename| {
+                    let file_path = ctx.working_dir.join(filename);
+                    let size = std::fs::metadata(&file_path).map(|m| m.len() as usize).unwrap_or(0);
+                    MessageAttachment {
+                        filename: filename.clone(),
+                        content_type: "application/octet-stream".to_string(),
+                        size,
+                        content: None,
+                        saved_path: Some(file_path),
+                    }
+                })
+                .collect(),
+            metadata: {
+                let mut m = HashMap::new();
+                m.insert(
+                    "source_channel".to_string(),
+                    serde_json::Value::String(String::new()),
+                );
+                m.insert(
+                    "source_thread".to_string(),
+                    serde_json::Value::String(String::new()),
+                );
+                m
+            },
+            matched_pattern: None,
+        };
+
+        // Enqueue the message into the target thread
+        let pattern_match = PatternMatch {
+            pattern_name: String::new(),
+            channel: channel.to_string(),
+            matches: HashMap::new(),
+        };
+
+        target_tm
+            .enqueue(inbound, thread_name.to_string(), pattern_match, None, true)
+            .await;
+
+        let attachment_info = if validated_attachments.is_empty() {
+            String::new()
+        } else {
+            format!(" with {} attachment(s)", validated_attachments.len())
+        };
+
+        tracing::info!(
+            target_channel = %channel,
+            target_thread = %thread_name,
+            attachment_count = validated_attachments.len(),
+            "Cross-thread message sent"
+        );
+
+        Ok(ToolOutput::success(format!(
+            "Message sent to channel '{}', thread '{}'{}. The target thread will process it.",
+            channel, thread_name, attachment_info
+        )))
+    }
+}

--- a/crates/jyc-agent/src/tools/mod.rs
+++ b/crates/jyc-agent/src/tools/mod.rs
@@ -19,8 +19,7 @@ use jyc_core::thread_manager::ThreadManager;
 use jyc_types::channel::OutboundAdapter;
 
 /// Shared thread managers map keyed by channel name.
-pub type ThreadManagersMap =
-    Arc<tokio::sync::Mutex<HashMap<String, Arc<ThreadManager>>>>;
+pub type ThreadManagersMap = Arc<tokio::sync::Mutex<HashMap<String, Arc<ThreadManager>>>>;
 
 /// Context provided to tools during execution.
 pub struct ToolContext<'a> {

--- a/crates/jyc-agent/src/tools/mod.rs
+++ b/crates/jyc-agent/src/tools/mod.rs
@@ -18,6 +18,10 @@ use crate::types::{ImageSource, ToolDefinition};
 use jyc_core::thread_manager::ThreadManager;
 use jyc_types::channel::OutboundAdapter;
 
+/// Shared thread managers map keyed by channel name.
+pub type ThreadManagersMap =
+    Arc<tokio::sync::Mutex<HashMap<String, Arc<ThreadManager>>>>;
+
 /// Context provided to tools during execution.
 pub struct ToolContext<'a> {
     /// Working directory for the tool.
@@ -51,8 +55,7 @@ pub struct ToolContext<'a> {
     /// Used by `jyc_send_to_thread` tool to inject messages into threads
     /// in other channels. `None` when running in contexts without
     /// cross-channel communication (e.g. unit tests).
-    pub thread_managers:
-        Option<Arc<tokio::sync::Mutex<HashMap<String, Arc<ThreadManager>>>>>,
+    pub thread_managers: Option<ThreadManagersMap>,
 }
 
 impl<'a> ToolContext<'a> {

--- a/crates/jyc-agent/src/tools/mod.rs
+++ b/crates/jyc-agent/src/tools/mod.rs
@@ -10,10 +10,12 @@ pub mod registry;
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use crate::types::{ImageSource, ToolDefinition};
+use jyc_core::thread_manager::ThreadManager;
 use jyc_types::channel::OutboundAdapter;
 
 /// Context provided to tools during execution.
@@ -45,6 +47,12 @@ pub struct ToolContext<'a> {
     /// the tool registry. `None` when the agent runs in contexts without
     /// a pre-warmed outbound adapter.
     pub outbound: Option<Arc<dyn OutboundAdapter>>,
+    /// Cross-channel thread managers keyed by channel name.
+    /// Used by `jyc_send_to_thread` tool to inject messages into threads
+    /// in other channels. `None` when running in contexts without
+    /// cross-channel communication (e.g. unit tests).
+    pub thread_managers:
+        Option<Arc<tokio::sync::Mutex<HashMap<String, Arc<ThreadManager>>>>>,
 }
 
 impl<'a> ToolContext<'a> {
@@ -56,6 +64,7 @@ impl<'a> ToolContext<'a> {
             pending_images: Mutex::new(Vec::new()),
             pattern_inject_images: false,
             outbound: None,
+            thread_managers: None,
         }
     }
 
@@ -67,6 +76,7 @@ impl<'a> ToolContext<'a> {
             pending_images: Mutex::new(Vec::new()),
             pattern_inject_images: false,
             outbound: None,
+            thread_managers: None,
         }
     }
     /// Drain and return any pending image sources accumulated during the

--- a/crates/jyc-agent/src/tools/mod.rs
+++ b/crates/jyc-agent/src/tools/mod.rs
@@ -56,6 +56,12 @@ pub struct ToolContext<'a> {
     /// in other channels. `None` when running in contexts without
     /// cross-channel communication (e.g. unit tests).
     pub thread_managers: Option<ThreadManagersMap>,
+    /// Current channel name, for tools that need source context (e.g.
+    /// `jyc_send_to_thread` sets `source_channel` metadata from this).
+    pub current_channel: Option<String>,
+    /// Current thread name, for tools that need source context (e.g.
+    /// `jyc_send_to_thread` sets `source_thread` metadata from this).
+    pub current_thread: Option<String>,
 }
 
 impl<'a> ToolContext<'a> {
@@ -68,6 +74,8 @@ impl<'a> ToolContext<'a> {
             pattern_inject_images: false,
             outbound: None,
             thread_managers: None,
+            current_channel: None,
+            current_thread: None,
         }
     }
 
@@ -80,6 +88,8 @@ impl<'a> ToolContext<'a> {
             pattern_inject_images: false,
             outbound: None,
             thread_managers: None,
+            current_channel: None,
+            current_thread: None,
         }
     }
     /// Drain and return any pending image sources accumulated during the

--- a/crates/jyc-agent/tests/unit_tests.rs
+++ b/crates/jyc-agent/tests/unit_tests.rs
@@ -855,6 +855,7 @@ mod skills {
             None,
             None,
             None,
+            "test".to_string(),
         )
     }
 

--- a/crates/jyc-agent/tests/unit_tests.rs
+++ b/crates/jyc-agent/tests/unit_tests.rs
@@ -433,14 +433,15 @@ mod tool_registry {
         assert!(registry.has_tool("job_create"));
         assert!(registry.has_tool("job_delete"));
         assert!(registry.has_tool("job_toggle"));
-        assert_eq!(registry.len(), 11);
+        assert!(registry.has_tool("jyc_send_to_thread"));
+        assert_eq!(registry.len(), 12);
     }
 
     #[test]
     fn registry_produces_definitions() {
         let registry = create_builtin_registry();
         let definitions = registry.definitions();
-        assert_eq!(definitions.len(), 11);
+        assert_eq!(definitions.len(), 12);
 
         // Each definition should have name, description, and input_schema
         for def in &definitions {

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -118,6 +118,8 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
     let mut all_thread_managers: Vec<Arc<ThreadManager>> = Vec::new();
     let mut all_channels: Vec<jyc_types::ChannelInfo> = Vec::new();
     let mut all_workspace_dirs: Vec<std::path::PathBuf> = Vec::new();
+    // Collect JycAgentService instances for wiring cross-channel thread managers
+    let mut all_agent_services: Vec<Arc<JycAgentService>> = Vec::new();
     let config_snapshot = config.load();
     let agent_config = Arc::new(config_snapshot.agent.clone());
 
@@ -437,7 +439,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                             )))
                         })
                 };
-                Arc::new(JycAgentService::new(
+                let jyc_agent_svc = Arc::new(JycAgentService::new(
                     agent_cfg,
                     workdir.to_path_buf(),
                     config_snapshot.mcps.clone(),
@@ -450,7 +452,9 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     channel_config.disabled_mcp_servers.clone(),
                     channel_config.skills.clone(),
                     channel_config.disabled_skills.clone(),
-                ))
+                ));
+                all_agent_services.push(jyc_agent_svc.clone());
+                jyc_agent_svc as Arc<dyn AgentService>
             }
             "static" => {
                 let text = agent_config
@@ -1028,30 +1032,39 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
         anyhow::bail!("No channels configured");
     }
 
-    // 4.5. Start JobScheduler (if scheduler is enabled in config)
-    let scheduler_config = config_snapshot.scheduler.clone();
-    if scheduler_config.enabled {
-        // Build thread manager map keyed by channel name
+    // 4.5. Wire cross-channel thread managers into agent services
+    {
         let tm_map: HashMap<String, Arc<ThreadManager>> = all_thread_managers
             .iter()
             .map(|tm| (tm.channel_name().to_string(), tm.clone()))
             .collect();
         let tm_map = Arc::new(tokio::sync::Mutex::new(tm_map));
-
-        let scheduler = JobScheduler::new(
-            tm_map,
-            all_workspace_dirs.clone(),
-            scheduler_config.scan_interval_secs,
-            scheduler_config.max_jobs_per_thread,
-            true,
+        for svc in &all_agent_services {
+            svc.set_thread_managers(tm_map.clone());
+        }
+        tracing::info!(
+            "Wired thread managers into {} agent service(s)",
+            all_agent_services.len()
         );
 
-        let scheduler_cancel = cancel.clone();
-        tasks.push(tokio::spawn(async move {
-            scheduler.run(scheduler_cancel).await;
-        }));
+        // Start JobScheduler (if scheduler is enabled in config)
+        let scheduler_config = config_snapshot.scheduler.clone();
+        if scheduler_config.enabled {
+            let scheduler = JobScheduler::new(
+                tm_map,
+                all_workspace_dirs.clone(),
+                scheduler_config.scan_interval_secs,
+                scheduler_config.max_jobs_per_thread,
+                true,
+            );
 
-        tracing::info!("Job scheduler started");
+            let scheduler_cancel = cancel.clone();
+            tasks.push(tokio::spawn(async move {
+                scheduler.run(scheduler_cancel).await;
+            }));
+
+            tracing::info!("Job scheduler started");
+        }
     }
 
     // 5. Start inspect server (if configured)

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -452,6 +452,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     channel_config.disabled_mcp_servers.clone(),
                     channel_config.skills.clone(),
                     channel_config.disabled_skills.clone(),
+                    channel_name.clone(),
                 ));
                 all_agent_services.push(jyc_agent_svc.clone());
                 jyc_agent_svc as Arc<dyn AgentService>


### PR DESCRIPTION
## Spec

Add a new builtin tool `jyc_send_to_thread` that enables AI agents to inject messages into threads in other channels. For example, an agent in a Feishu thread can generate a PDF and inject it into an email channel's invoice_processing thread, optionally targeting a specific recipient email address.

The tool uses `ThreadManager::enqueue()` — the same mechanism the `JobScheduler` already uses for cross-channel message injection. A shared `thread_managers` map (keyed by channel name) is threaded through the system: Monitor → JycAgentService → AgentLoopConfig → ToolContext → tool.

Additionally, `build_system_prompt()` is enhanced to list available channels and their active threads, so the agent can map natural language instructions ("send to jin283's invoice processing") to actual `channel`/`thread` parameter values.

Fixes #267

## Implementation Plan

### Step 1: Add `thread_managers` field to `ToolContext`
**What:** In `crates/jyc-agent/src/tools/mod.rs`, add a new optional field:
```rust
pub thread_managers: Option<Arc<tokio::sync::Mutex<HashMap<String, Arc<jyc_core::thread_manager::ThreadManager>>>>>,
```
Add required imports (`Arc`, `Mutex`, `HashMap`, `ThreadManager`).

**Why:** `ToolContext` is the per-invocation context that tools receive. This field carries the cross-channel thread manager map from the monitor layer down to the tool.

**Verify:** `cargo check -p jyc-agent` and `cargo clippy -p jyc-agent -- -D warnings`

### Step 2: Add `thread_managers` to `AgentLoopConfig`
**What:** In `crates/jyc-agent/src/agent_loop.rs`:
- Add `thread_managers: Option<Arc<Mutex<HashMap<String, Arc<jyc_core::thread_manager::ThreadManager>>>>>,` to the `AgentLoopConfig` struct
- In the `run()` function (around line 340–342), after constructing `ctx`, set `ctx.thread_managers = thread_managers.clone();`

**Why:** `AgentLoopConfig` bridges the service layer to the agent loop. This passes the thread manager map through to `ToolContext`.

**Verify:** `cargo check -p jyc-agent` and `cargo test -p jyc-agent`

### Step 3: Add `thread_managers` setter to `JycAgentService`
**What:** In `crates/jyc-agent/src/service.rs`:
- Add field `thread_managers: Option<Arc<tokio::sync::Mutex<HashMap<String, Arc<jyc_core::thread_manager::ThreadManager>>>>>>` to `JycAgentService` struct
- Add setter method: `pub fn set_thread_managers(&mut self, tm: Arc<tokio::sync::Mutex<HashMap<String, Arc<jyc_core::thread_manager::ThreadManager>>>>)`
- In `process_message()` (around line 944–962), pass `self.thread_managers.clone()` to `AgentLoopConfig`

**Why:** `JycAgentService` is the central service that owns the agent loop configuration. Adding the thread managers here makes them available for every thread's agent loop invocation.

**Verify:** `cargo check -p jyc-agent` and `cargo test -p jyc-agent`

### Step 4: Create new builtin tool `SendToThreadTool`
**What:** Create new file `crates/jyc-agent/src/tools/builtin/send_to_thread.rs`:
- Implement `Tool` trait with name `"jyc_send_to_thread"`
- Input schema parameters:
  - `channel` (string, required): target channel name, e.g. `"jin283"`
  - `thread` (string, required): target thread name, e.g. `"invoice_processing"`
  - `message` (string, required): message body to inject
  - `attachments` (string[], optional): file paths within current thread directory
  - `recipient` (string, optional): sets `sender_address` in the injected `InboundMessage`, enabling channel-appropriate reply routing
- `execute()` logic:
  1. Validate inputs (non-empty channel, thread, message)
  2. Validate attachments exist and are within working directory (same logic as `ReplyMessageTool`)
  3. Look up target channel's `ThreadManager` from `ctx.thread_managers`. Return an error if `None` or channel not found
  4. Construct `InboundMessage` with `sender_address` from `recipient`, `channel` from `channel` param, attachments from file reads, and metadata carrying source thread/channel info
  5. Call `tm.enqueue(message, thread_name, PatternMatch::default(), None, true)`
  6. Return success with thread + channel info

**Why:** This is the core tool that agents invoke to communicate across threads and channels. Security boundaries (path validation) match `ReplyMessageTool`.

**Verify:** `cargo check -p jyc-agent` and `cargo test -p jyc-agent`

### Step 5: Register the new tool in the builtin registry
**What:** In `crates/jyc-agent/src/tools/builtin/mod.rs`:
- Add `pub mod send_to_thread;`
- Register `Box::new(send_to_thread::SendToThreadTool)` in `create_builtin_registry()`

**Why:** All builtin tools are registered centrally. This makes `jyc_send_to_thread` available to all threads by default (can be disabled per-pattern via `disabled_tools`).

**Verify:** `cargo check -p jyc-agent` and `cargo test -p jyc-agent`

### Step 6: Enhance system prompt with available channels and threads
**What:** In `crates/jyc-agent/src/service.rs`, in `build_system_prompt()`:
- After the AGENTS.md sections, add a "Cross-Thread Communication" section if `self.thread_managers.is_some()`
- Iterate over thread managers map, call `list_threads()` on each, and format output as:
  ```
  ## Cross-Thread Communication

  You can send messages to threads in other channels using the `jyc_send_to_thread` tool.

  Available channels and their active threads:
  - Channel "jin283" (email): invoice_processing, support, alerts
  - Channel "feishu_work" (feishu): general, team-updates
  ```
- Handle the case where `thread_managers` is `None` gracefully (skip the section)

**Why:** Without channel/thread context, the agent cannot map natural language instructions like "send to jin283's invoice processing" to exact `channel`/`thread` parameter values.

**Verify:** `cargo test -p jyc-agent` (existing tests for `build_system_prompt` must still pass)

### Step 7: Wire thread_managers in monitor startup
**What:** In `crates/jyc-cli/src/cli/monitor.rs`:
- After the channel loop that builds `all_thread_managers: Vec<Arc<ThreadManager>>`, build the map:
  ```rust
  let tm_map: HashMap<String, Arc<ThreadManager>> = all_thread_managers
      .iter()
      .map(|tm| (tm.channel_name().to_string(), tm.clone()))
      .collect();
  let tm_map = Arc::new(tokio::sync::Mutex::new(tm_map));
  ```
- Iterate over `all_agent_services` (or store them during the channel loop) and call `set_thread_managers(tm_map.clone())` on each

Note: Currently `JycAgentService` is created inline and not collected. We may need to collect them into a `Vec<Arc<JycAgentService>>` (or use `Arc::get_mut` if wrapped in `Arc<std::sync::Mutex<...>>`). The simplest approach: store agent services alongside thread managers during the channel setup loop.

**Why:** The monitor owns the global view of all channels. This step builds the shared map and injects it into each agent service, completing the data flow from monitor → agent service → agent loop → tool context → tool.

**Verify:** `cargo check --workspace` and `cargo test --workspace`

## Design Decisions

- **`recipient` → `sender_address`**: The `recipient` parameter sets `sender_address` in the injected `InboundMessage`. This is intentional — every channel's `OutboundAdapter::send_reply()` already uses `sender_address` to determine the reply target. No channel-specific logic in the tool.
- **Security boundary**: Attachment validation mirrors `ReplyMessageTool` — only files within the current thread's working directory are allowed, enforced via canonical path prefix check.
- **Source tracking**: Injected messages carry metadata (`source_channel`, `source_thread`) so the target thread's agent can identify cross-thread messages.
- **Thread creation**: `ThreadManager::enqueue()` auto-creates thread queues that don't exist yet. This allows sending to new threads, though without template initialization they'll lack AGENTS.md context.
- **Tool disabling**: Like all builtin tools, `jyc_send_to_thread` can be disabled per-pattern via `disabled_tools = ["jyc_send_to_thread"]`.