### PR TITLE
feat: enhance jyc_send_message with cross-channel and attachment support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ All notable changes to JYC will be documented in this file.
 
 ### Added
 
+- **`jyc_send_message` enhanced with cross-channel and attachment support.** The
+  builtin tool now accepts an optional `channel` parameter for sending proactive
+  messages through any configured channel's outbound adapter (bypassing agent
+  processing), and an optional `attachments` parameter for including file
+  attachments (supported by email, Feishu, and WeCom Bot channels). Existing
+  usage without these parameters is fully backward compatible. (#267, #270)
+
 - **Cross-thread/channel communication tool (`jyc_send_to_thread`).** New
   builtin tool that enables AI agents to inject messages into threads in other
   channels. The tool is backed by `ThreadManager::enqueue()` (same mechanism as

--- a/crates/jyc-agent/src/agent_loop.rs
+++ b/crates/jyc-agent/src/agent_loop.rs
@@ -16,7 +16,7 @@ use jyc_core::thread_event::ThreadEvent;
 use jyc_core::thread_event_bus::ThreadEventBusRef;
 
 use crate::provider::{Provider, is_transient_sse_error};
-use crate::tools::{ThreadManagersMap, ToolContext, ToolOutput, registry::ToolRegistry};
+use crate::tools::{OutboundsMap, ThreadManagersMap, ToolContext, ToolOutput, registry::ToolRegistry};
 use crate::types::{AgentLoopResult, ContentBlock, Message, Role, StreamEvent, ToolDefinition};
 
 /// Default maximum number of tool-call iterations before giving up.
@@ -69,6 +69,10 @@ pub struct AgentLoopConfig<'a> {
     /// Current channel name, for tools that need source context
     /// (e.g. `jyc_send_to_thread` sets `source_channel` metadata from this).
     pub current_channel: Option<String>,
+    /// Cross-channel outbound adapters keyed by channel name.
+    /// Passed through to `ToolContext` so the `jyc_send_message` tool can
+    /// send proactive messages through any channel's outbound adapter.
+    pub outbounds: Option<OutboundsMap>,
 }
 
 /// Run the agent loop to completion.
@@ -93,6 +97,7 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
         outbound,
         thread_managers,
         current_channel,
+        outbounds,
     } = config;
 
     // Provider used for the cycle-boundary progress summary. Falls back to
@@ -202,6 +207,7 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
             ctx.thread_managers = thread_managers.clone();
             ctx.current_channel = current_channel.clone();
             ctx.current_thread = Some(thread_name.to_string());
+            ctx.outbounds = outbounds.clone();
             let synthetic_input: serde_json::Value = serde_json::from_str(&synthetic_args)
                 .unwrap_or(serde_json::Value::Object(Default::default()));
             let synthetic_output = match tools
@@ -355,6 +361,7 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
         ctx.thread_managers = thread_managers.clone();
         ctx.current_channel = current_channel.clone();
         ctx.current_thread = Some(thread_name.to_string());
+        ctx.outbounds = outbounds.clone();
 
         for tool_call in &response.tool_calls {
             if cancel.is_cancelled() {

--- a/crates/jyc-agent/src/agent_loop.rs
+++ b/crates/jyc-agent/src/agent_loop.rs
@@ -16,7 +16,9 @@ use jyc_core::thread_event::ThreadEvent;
 use jyc_core::thread_event_bus::ThreadEventBusRef;
 
 use crate::provider::{Provider, is_transient_sse_error};
-use crate::tools::{OutboundsMap, ThreadManagersMap, ToolContext, ToolOutput, registry::ToolRegistry};
+use crate::tools::{
+    OutboundsMap, ThreadManagersMap, ToolContext, ToolOutput, registry::ToolRegistry,
+};
 use crate::types::{AgentLoopResult, ContentBlock, Message, Role, StreamEvent, ToolDefinition};
 
 /// Default maximum number of tool-call iterations before giving up.

--- a/crates/jyc-agent/src/lib.rs
+++ b/crates/jyc-agent/src/lib.rs
@@ -109,6 +109,7 @@ mod integration_tests {
             outbound: None,
             thread_managers: None,
             current_channel: None,
+            outbounds: None,
         })
         .await
         .unwrap();

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -414,11 +414,31 @@ impl JycAgentService {
             .lock()
             .expect("thread_managers poisoned")
             .clone();
+        let outbounds_configured = self
+            .outbounds
+            .lock()
+            .expect("outbounds poisoned")
+            .is_some();
         if let Some(ref tm_map) = tm_map_opt {
             prompt.push_str(
                 "\n## Cross-Thread Communication\n\n\
-                 You can send messages to threads in other channels using the `jyc_send_to_thread` tool.\n\n\
-                 Available channels and their active threads:\n",
+                 You can send messages to threads in other channels using the `jyc_send_to_thread` tool.\n",
+            );
+
+            // Note about direct outbound messaging via jyc_send_message
+            if outbounds_configured {
+                prompt.push_str(
+                    "For direct outbound messaging (bypassing agent processing), \
+                     use `jyc_send_message` with the optional `channel` parameter set to \
+                     a target channel name.\n\
+                     `jyc_send_message` sends directly through the channel's outbound adapter \
+                     without agent processing. `jyc_send_to_thread` injects into a thread queue \
+                     for agent processing.\n\n",
+                );
+            }
+
+            prompt.push_str(
+                "Available channels and their active threads:\n",
             );
             let map = tm_map.lock().await;
             for (channel_name, tm) in map.iter() {

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -203,10 +203,7 @@ impl JycAgentService {
     /// Called by the monitor during startup to inject the outbound adapter map
     /// into each agent service after all channels have been initialized.
     pub fn set_outbounds(&self, outbounds: OutboundsMap) {
-        *self
-            .outbounds
-            .lock()
-            .expect("outbounds poisoned") = Some(outbounds);
+        *self.outbounds.lock().expect("outbounds poisoned") = Some(outbounds);
     }
 
     /// Discover skills from multiple paths, with priority-based deduplication.
@@ -414,11 +411,7 @@ impl JycAgentService {
             .lock()
             .expect("thread_managers poisoned")
             .clone();
-        let outbounds_configured = self
-            .outbounds
-            .lock()
-            .expect("outbounds poisoned")
-            .is_some();
+        let outbounds_configured = self.outbounds.lock().expect("outbounds poisoned").is_some();
         if let Some(ref tm_map) = tm_map_opt {
             prompt.push_str(
                 "\n## Cross-Thread Communication\n\n\
@@ -437,9 +430,7 @@ impl JycAgentService {
                 );
             }
 
-            prompt.push_str(
-                "Available channels and their active threads:\n",
-            );
+            prompt.push_str("Available channels and their active threads:\n");
             let map = tm_map.lock().await;
             for (channel_name, tm) in map.iter() {
                 let channel_type = tm.channel_type();
@@ -1062,11 +1053,7 @@ impl AgentService for JycAgentService {
             .lock()
             .expect("thread_managers poisoned")
             .clone();
-        let outbounds = self
-            .outbounds
-            .lock()
-            .expect("outbounds poisoned")
-            .clone();
+        let outbounds = self.outbounds.lock().expect("outbounds poisoned").clone();
         let result = agent_loop::run(AgentLoopConfig {
             provider: provider.as_ref(),
             small_provider: small_provider

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -17,6 +17,7 @@ use jyc_types::{ChannelPattern, InboundMessage, McpServerConfig, QueueItem};
 use crate::agent_loop::{self, AgentLoopConfig};
 use crate::provider;
 use crate::session;
+use crate::tools::OutboundsMap;
 use crate::tools::ThreadManagersMap;
 use crate::tools::registry::ToolRegistry;
 use crate::types::AgentConfig;
@@ -138,6 +139,12 @@ pub struct JycAgentService {
     thread_managers: std::sync::Mutex<Option<ThreadManagersMap>>,
     /// Current channel name for source context in cross-thread tools.
     channel_name: String,
+    /// Cross-channel outbound adapters keyed by channel name.
+    /// Passed through to `AgentLoopConfig` so the `jyc_send_message` tool
+    /// can send proactive messages through any channel's outbound adapter.
+    /// Uses `std::sync::Mutex` for interior mutability (set after construction
+    /// via `set_outbounds()` on an `Arc<Self>`).
+    outbounds: std::sync::Mutex<Option<OutboundsMap>>,
 }
 
 impl JycAgentService {
@@ -176,6 +183,7 @@ impl JycAgentService {
             channel_disabled_skills,
             thread_managers: std::sync::Mutex::new(None),
             channel_name,
+            outbounds: std::sync::Mutex::new(None),
         }
     }
 
@@ -188,6 +196,17 @@ impl JycAgentService {
             .thread_managers
             .lock()
             .expect("thread_managers poisoned") = Some(tm);
+    }
+
+    /// Set the cross-channel outbound adapters map.
+    ///
+    /// Called by the monitor during startup to inject the outbound adapter map
+    /// into each agent service after all channels have been initialized.
+    pub fn set_outbounds(&self, outbounds: OutboundsMap) {
+        *self
+            .outbounds
+            .lock()
+            .expect("outbounds poisoned") = Some(outbounds);
     }
 
     /// Discover skills from multiple paths, with priority-based deduplication.
@@ -1023,6 +1042,11 @@ impl AgentService for JycAgentService {
             .lock()
             .expect("thread_managers poisoned")
             .clone();
+        let outbounds = self
+            .outbounds
+            .lock()
+            .expect("outbounds poisoned")
+            .clone();
         let result = agent_loop::run(AgentLoopConfig {
             provider: provider.as_ref(),
             small_provider: small_provider
@@ -1043,6 +1067,7 @@ impl AgentService for JycAgentService {
             outbound: self.outbound.clone(),
             thread_managers: thread_managers.clone(),
             current_channel: Some(self.channel_name.clone()),
+            outbounds,
         })
         .await?;
 

--- a/crates/jyc-agent/src/tools/mcp_bridge.rs
+++ b/crates/jyc-agent/src/tools/mcp_bridge.rs
@@ -221,41 +221,40 @@ impl Tool for SendMessageTool {
         }
 
         // Determine which outbound adapter to use
-        let outbound: Arc<dyn jyc_types::channel::OutboundAdapter> =
-            if let Some(ref ch) = channel {
-                // Cross-channel: look up from outbounds map
-                let outbounds_map = match ctx.outbounds.as_ref() {
-                    Some(m) => m,
-                    None => {
-                        return Ok(ToolOutput::error(format!(
-                            "Cross-channel messaging is not available: no outbounds map configured. \
+        let outbound: Arc<dyn jyc_types::channel::OutboundAdapter> = if let Some(ref ch) = channel {
+            // Cross-channel: look up from outbounds map
+            let outbounds_map = match ctx.outbounds.as_ref() {
+                Some(m) => m,
+                None => {
+                    return Ok(ToolOutput::error(format!(
+                        "Cross-channel messaging is not available: no outbounds map configured. \
                              Cannot send to channel '{}'",
-                            ch
-                        )));
-                    }
-                };
-                let map = outbounds_map.lock().await;
-                match map.get(ch) {
-                    Some(o) => o.clone(),
-                    None => {
-                        return Ok(ToolOutput::error(format!(
-                            "Unknown channel '{}'. Available channels: {}",
-                            ch,
-                            map.keys().cloned().collect::<Vec<_>>().join(", ")
-                        )));
-                    }
-                }
-            } else {
-                // Same-channel: use current outbound adapter
-                match ctx.outbound.as_ref() {
-                    Some(o) => o.clone(),
-                    None => {
-                        return Ok(ToolOutput::error(
-                            "No outbound adapter available for proactive messaging",
-                        ));
-                    }
+                        ch
+                    )));
                 }
             };
+            let map = outbounds_map.lock().await;
+            match map.get(ch) {
+                Some(o) => o.clone(),
+                None => {
+                    return Ok(ToolOutput::error(format!(
+                        "Unknown channel '{}'. Available channels: {}",
+                        ch,
+                        map.keys().cloned().collect::<Vec<_>>().join(", ")
+                    )));
+                }
+            }
+        } else {
+            // Same-channel: use current outbound adapter
+            match ctx.outbound.as_ref() {
+                Some(o) => o.clone(),
+                None => {
+                    return Ok(ToolOutput::error(
+                        "No outbound adapter available for proactive messaging",
+                    ));
+                }
+            }
+        };
 
         // Process attachments if provided
         let attachment_objs: Option<Vec<OutboundAttachment>> =
@@ -274,10 +273,10 @@ impl Tool for SendMessageTool {
                                 filename
                             )));
                         }
-                        if let Ok(canonical) = file_path.canonicalize() {
-                            if let Err(msg) = ctx.check_path_boundary(filename, &canonical) {
-                                return Ok(ToolOutput::error(msg));
-                            }
+                        if let Ok(canonical) = file_path.canonicalize()
+                            && let Err(msg) = ctx.check_path_boundary(filename, &canonical)
+                        {
+                            return Ok(ToolOutput::error(msg));
                         }
 
                         // Determine content type from extension (simple mapping)
@@ -383,7 +382,9 @@ fn detect_content_type(filename: &str) -> String {
         "html" | "htm" => "text/html".to_string(),
         "md" => "text/markdown".to_string(),
         "xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet".to_string(),
-        "docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document".to_string(),
+        "docx" => {
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document".to_string()
+        }
         _ => "application/octet-stream".to_string(),
     }
 }

--- a/crates/jyc-agent/src/tools/mcp_bridge.rs
+++ b/crates/jyc-agent/src/tools/mcp_bridge.rs
@@ -6,9 +6,11 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::{Value, json};
+use std::sync::Arc;
 use tracing;
 
 use crate::tools::{Tool, ToolContext, ToolOutput};
+use jyc_types::channel::OutboundAttachment;
 
 /// Reply message tool — writes reply for delivery by the monitor process.
 ///
@@ -133,6 +135,13 @@ impl Tool for ReplyMessageTool {
 /// This is the in-process equivalent of the `jyc_send_message` MCP tool.
 /// Unlike `ReplyMessageTool` which replies within the current thread, this
 /// tool sends messages to arbitrary recipients for alerts and notifications.
+///
+/// Supports:
+/// - `channel`: optional target channel name for cross-channel messaging.
+///   When omitted, uses the current channel's outbound adapter (backward compatible).
+/// - `attachments`: optional list of file paths (relative to working directory)
+///   to include as attachments. Only supported by channels with attachment capability
+///   (e.g. email). Non-email channels return an error if attachments are provided.
 pub struct SendMessageTool;
 
 #[async_trait]
@@ -162,6 +171,18 @@ impl Tool for SendMessageTool {
                 "message": {
                     "type": "string",
                     "description": "The message body to send"
+                },
+                "channel": {
+                    "type": "string",
+                    "description": "Optional target channel name for cross-channel sending. \
+                                     When omitted, uses the current channel. \
+                                     The recipient format must match the target channel type."
+                },
+                "attachments": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Optional list of file paths within the working directory to attach. \
+                                     Only supported by email channels."
                 }
             },
             "required": ["recipient", "message"]
@@ -181,6 +202,16 @@ impl Tool for SendMessageTool {
             .and_then(|m| m.as_str())
             .ok_or_else(|| anyhow::anyhow!("Missing 'message' parameter"))?;
 
+        let channel: Option<String> = input
+            .get("channel")
+            .and_then(|c| c.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+
+        let attachment_filenames: Option<Vec<String>> = input
+            .get("attachments")
+            .and_then(|a| serde_json::from_value(a.clone()).ok());
+
         if recipient.trim().is_empty() {
             return Ok(ToolOutput::error("Recipient cannot be empty"));
         }
@@ -189,37 +220,139 @@ impl Tool for SendMessageTool {
             return Ok(ToolOutput::error("Message cannot be empty"));
         }
 
-        let outbound = match ctx.outbound.as_ref() {
-            Some(o) => o,
-            None => {
-                return Ok(ToolOutput::error(
-                    "No outbound adapter available for proactive messaging",
-                ));
-            }
-        };
+        // Determine which outbound adapter to use
+        let outbound: Arc<dyn jyc_types::channel::OutboundAdapter> =
+            if let Some(ref ch) = channel {
+                // Cross-channel: look up from outbounds map
+                let outbounds_map = match ctx.outbounds.as_ref() {
+                    Some(m) => m,
+                    None => {
+                        return Ok(ToolOutput::error(format!(
+                            "Cross-channel messaging is not available: no outbounds map configured. \
+                             Cannot send to channel '{}'",
+                            ch
+                        )));
+                    }
+                };
+                let map = outbounds_map.lock().await;
+                match map.get(ch) {
+                    Some(o) => o.clone(),
+                    None => {
+                        return Ok(ToolOutput::error(format!(
+                            "Unknown channel '{}'. Available channels: {}",
+                            ch,
+                            map.keys().cloned().collect::<Vec<_>>().join(", ")
+                        )));
+                    }
+                }
+            } else {
+                // Same-channel: use current outbound adapter
+                match ctx.outbound.as_ref() {
+                    Some(o) => o.clone(),
+                    None => {
+                        return Ok(ToolOutput::error(
+                            "No outbound adapter available for proactive messaging",
+                        ));
+                    }
+                }
+            };
 
-        match outbound.send_message(recipient, subject, message).await {
-            Ok(result) => {
-                tracing::info!(
-                    recipient = %recipient,
-                    message_id = %result.message_id,
-                    "Proactive message sent"
-                );
-                Ok(ToolOutput::success(format!(
-                    "Message sent to '{}' (message_id: {})",
-                    recipient, result.message_id
-                )))
+        // Process attachments if provided
+        let attachment_objs: Option<Vec<OutboundAttachment>> =
+            if let Some(ref filenames) = attachment_filenames {
+                if filenames.is_empty() {
+                    None
+                } else {
+                    let mut atts = Vec::new();
+                    for filename in filenames {
+                        let file_path = ctx.working_dir.join(filename);
+
+                        // Security: ensure within working directory (canonical prefix check)
+                        if !file_path.exists() {
+                            return Ok(ToolOutput::error(format!(
+                                "Attachment not found: '{}'",
+                                filename
+                            )));
+                        }
+                        if let Ok(canonical) = file_path.canonicalize() {
+                            if let Err(msg) = ctx.check_path_boundary(filename, &canonical) {
+                                return Ok(ToolOutput::error(msg));
+                            }
+                        }
+
+                        // Determine content type from extension (simple mapping)
+                        let content_type = detect_content_type(filename);
+
+                        atts.push(OutboundAttachment {
+                            filename: filename.clone(),
+                            path: file_path,
+                            content_type,
+                        });
+                    }
+                    Some(atts)
+                }
+            } else {
+                None
+            };
+
+        // Send the message
+        if let Some(ref atts) = attachment_objs {
+            match outbound
+                .send_message_with_attachments(recipient, subject, message, Some(atts))
+                .await
+            {
+                Ok(result) => {
+                    tracing::info!(
+                        recipient = %recipient,
+                        attachment_count = atts.len(),
+                        message_id = %result.message_id,
+                        channel = ?channel,
+                        "Proactive message with attachments sent"
+                    );
+                    Ok(ToolOutput::success(format!(
+                        "Message sent to '{}' (message_id: {}) with {} attachment(s)",
+                        recipient,
+                        result.message_id,
+                        atts.len()
+                    )))
+                }
+                Err(e) => {
+                    tracing::error!(
+                        recipient = %recipient,
+                        error = %e,
+                        "Failed to send proactive message with attachments"
+                    );
+                    Ok(ToolOutput::error(format!(
+                        "Failed to send message to '{}': {}",
+                        recipient, e
+                    )))
+                }
             }
-            Err(e) => {
-                tracing::error!(
-                    recipient = %recipient,
-                    error = %e,
-                    "Failed to send proactive message"
-                );
-                Ok(ToolOutput::error(format!(
-                    "Failed to send message to '{}': {}",
-                    recipient, e
-                )))
+        } else {
+            match outbound.send_message(recipient, subject, message).await {
+                Ok(result) => {
+                    tracing::info!(
+                        recipient = %recipient,
+                        message_id = %result.message_id,
+                        channel = ?channel,
+                        "Proactive message sent"
+                    );
+                    Ok(ToolOutput::success(format!(
+                        "Message sent to '{}' (message_id: {})",
+                        recipient, result.message_id
+                    )))
+                }
+                Err(e) => {
+                    tracing::error!(
+                        recipient = %recipient,
+                        error = %e,
+                        "Failed to send proactive message"
+                    );
+                    Ok(ToolOutput::error(format!(
+                        "Failed to send message to '{}': {}",
+                        recipient, e
+                    )))
+                }
             }
         }
     }
@@ -229,4 +362,28 @@ impl Tool for SendMessageTool {
 pub fn register_mcp_tools(registry: &mut crate::tools::registry::ToolRegistry) {
     registry.register(Box::new(ReplyMessageTool));
     registry.register(Box::new(SendMessageTool));
+}
+
+/// Simple content type detection from file extension.
+/// Falls back to `application/octet-stream` for unknown extensions.
+fn detect_content_type(filename: &str) -> String {
+    let ext = filename.rsplit('.').next().unwrap_or("").to_lowercase();
+    match ext.as_str() {
+        "pdf" => "application/pdf".to_string(),
+        "png" => "image/png".to_string(),
+        "jpg" | "jpeg" => "image/jpeg".to_string(),
+        "gif" => "image/gif".to_string(),
+        "webp" => "image/webp".to_string(),
+        "svg" => "image/svg+xml".to_string(),
+        "csv" => "text/csv".to_string(),
+        "json" => "application/json".to_string(),
+        "xml" => "application/xml".to_string(),
+        "zip" => "application/zip".to_string(),
+        "txt" => "text/plain".to_string(),
+        "html" | "htm" => "text/html".to_string(),
+        "md" => "text/markdown".to_string(),
+        "xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet".to_string(),
+        "docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document".to_string(),
+        _ => "application/octet-stream".to_string(),
+    }
 }

--- a/crates/jyc-agent/src/tools/mod.rs
+++ b/crates/jyc-agent/src/tools/mod.rs
@@ -21,6 +21,11 @@ use jyc_types::channel::OutboundAdapter;
 /// Shared thread managers map keyed by channel name.
 pub type ThreadManagersMap = Arc<tokio::sync::Mutex<HashMap<String, Arc<ThreadManager>>>>;
 
+/// Shared outbound adapters map keyed by channel name.
+/// Used by `jyc_send_message` to support the `channel` parameter for
+/// cross-channel proactive messaging.
+pub type OutboundsMap = Arc<tokio::sync::Mutex<HashMap<String, Arc<dyn OutboundAdapter>>>>;
+
 /// Context provided to tools during execution.
 pub struct ToolContext<'a> {
     /// Working directory for the tool.
@@ -61,6 +66,12 @@ pub struct ToolContext<'a> {
     /// Current thread name, for tools that need source context (e.g.
     /// `jyc_send_to_thread` sets `source_thread` metadata from this).
     pub current_thread: Option<String>,
+    /// Cross-channel outbound adapters keyed by channel name.
+    /// Used by `jyc_send_message` to support the `channel` parameter for
+    /// sending proactive messages through any channel's outbound adapter.
+    /// `None` when running in contexts without cross-channel support
+    /// (e.g. unit tests).
+    pub outbounds: Option<OutboundsMap>,
 }
 
 impl<'a> ToolContext<'a> {
@@ -75,6 +86,7 @@ impl<'a> ToolContext<'a> {
             thread_managers: None,
             current_channel: None,
             current_thread: None,
+            outbounds: None,
         }
     }
 
@@ -89,6 +101,7 @@ impl<'a> ToolContext<'a> {
             thread_managers: None,
             current_channel: None,
             current_thread: None,
+            outbounds: None,
         }
     }
     /// Drain and return any pending image sources accumulated during the

--- a/crates/jyc-agent/tests/unit_tests.rs
+++ b/crates/jyc-agent/tests/unit_tests.rs
@@ -697,20 +697,28 @@ mod mcp_bridge {
         );
     }
 
-    /// Mock outbound adapter that records send_message calls.
+    /// Mock outbound adapter that records send_message and send_message_with_attachments calls.
     struct MockOutbound {
         calls: Arc<Mutex<Vec<(String, String, String)>>>,
+        attachment_calls: Arc<Mutex<Vec<(String, String, String, Vec<String>)>>>,
     }
 
     impl MockOutbound {
         #[allow(clippy::type_complexity)]
-        fn new() -> (Self, Arc<Mutex<Vec<(String, String, String)>>>) {
+        fn new() -> (
+            Self,
+            Arc<Mutex<Vec<(String, String, String)>>>,
+            Arc<Mutex<Vec<(String, String, String, Vec<String>)>>>,
+        ) {
             let calls = Arc::new(Mutex::new(Vec::new()));
+            let attachment_calls = Arc::new(Mutex::new(Vec::new()));
             (
                 Self {
                     calls: calls.clone(),
+                    attachment_calls: attachment_calls.clone(),
                 },
                 calls,
+                attachment_calls,
             )
         }
     }
@@ -759,6 +767,29 @@ mod mcp_bridge {
             ));
             Ok(SendResult {
                 message_id: "mock-msg".to_string(),
+            })
+        }
+
+        async fn send_message_with_attachments(
+            &self,
+            recipient: &str,
+            subject: &str,
+            body: &str,
+            attachments: Option<&[OutboundAttachment]>,
+        ) -> anyhow::Result<SendResult> {
+            let att_filenames: Vec<String> = attachments
+                .unwrap_or_default()
+                .iter()
+                .map(|a| a.filename.clone())
+                .collect();
+            self.attachment_calls.lock().unwrap().push((
+                recipient.to_string(),
+                subject.to_string(),
+                body.to_string(),
+                att_filenames,
+            ));
+            Ok(SendResult {
+                message_id: "mock-attachment-msg".to_string(),
             })
         }
     }
@@ -812,7 +843,7 @@ mod mcp_bridge {
     async fn send_message_sends_via_outbound() {
         let tmp = tempfile::tempdir().unwrap();
         let tool = SendMessageTool;
-        let (mock, calls) = MockOutbound::new();
+        let (mock, calls, _attachment_calls) = MockOutbound::new();
         let mut ctx = ToolContext::new(tmp.path());
         ctx.outbound = Some(Arc::new(mock));
 
@@ -837,6 +868,200 @@ mod mcp_bridge {
         assert_eq!(recorded[0].0, "wecomkf:kf001:user123");
         assert_eq!(recorded[0].1, "Alert");
         assert_eq!(recorded[0].2, "System is down");
+    }
+
+    #[tokio::test]
+    async fn send_message_with_channel_cross_channel() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tool = SendMessageTool;
+        let (mock, calls, _attachment_calls) = MockOutbound::new();
+        let mut ctx = ToolContext::new(tmp.path());
+        // Set up an outbounds map with the mock for channel "email"
+        let mut outbounds_map: std::collections::HashMap<String, Arc<dyn OutboundAdapter>> =
+            std::collections::HashMap::new();
+        outbounds_map.insert("email".to_string(), Arc::new(mock));
+        ctx.outbounds = Some(Arc::new(tokio::sync::Mutex::new(outbounds_map)));
+
+        let result = tool
+            .execute(
+                json!({
+                    "channel": "email",
+                    "recipient": "user@example.com",
+                    "subject": "Cross-channel alert",
+                    "message": "Hello from another channel"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.content.contains("user@example.com"));
+        assert!(result.content.contains("mock-msg"));
+
+        let recorded = calls.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0].0, "user@example.com");
+        assert_eq!(recorded[0].1, "Cross-channel alert");
+    }
+
+    #[tokio::test]
+    async fn send_message_rejects_unknown_channel() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tool = SendMessageTool;
+        let (mock, _calls, _attachment_calls) = MockOutbound::new();
+        let mut ctx = ToolContext::new(tmp.path());
+        let mut outbounds_map: std::collections::HashMap<String, Arc<dyn OutboundAdapter>> =
+            std::collections::HashMap::new();
+        outbounds_map.insert("email".to_string(), Arc::new(mock));
+        ctx.outbounds = Some(Arc::new(tokio::sync::Mutex::new(outbounds_map)));
+
+        let result = tool
+            .execute(
+                json!({
+                    "channel": "nonexistent",
+                    "recipient": "user@example.com",
+                    "message": "hello"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert!(result.content.contains("Unknown channel"));
+        assert!(result.content.contains("nonexistent"));
+    }
+
+    #[tokio::test]
+    async fn send_message_rejects_missing_outbounds_map() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tool = SendMessageTool;
+        let mut ctx = ToolContext::new(tmp.path());
+        // outbounds is None (not configured)
+        ctx.outbounds = None;
+
+        let result = tool
+            .execute(
+                json!({
+                    "channel": "email",
+                    "recipient": "user@example.com",
+                    "message": "hello"
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert!(
+            result
+                .content
+                .contains("Cross-channel messaging is not available")
+        );
+    }
+
+    #[tokio::test]
+    async fn send_message_with_attachments_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tool = SendMessageTool;
+        let (mock, _calls, attachment_calls) = MockOutbound::new();
+        let mut ctx = ToolContext::new(tmp.path());
+        ctx.outbound = Some(Arc::new(mock));
+
+        // Create a test attachment file
+        let file_path = tmp.path().join("report.pdf");
+        tokio::fs::write(&file_path, b"pdf content").await.unwrap();
+
+        let result = tool
+            .execute(
+                json!({
+                    "recipient": "user@example.com",
+                    "subject": "Report",
+                    "message": "Here is your report",
+                    "attachments": ["report.pdf"]
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.content.contains("user@example.com"));
+        assert!(result.content.contains("mock-attachment-msg"));
+        assert!(result.content.contains("1 attachment(s)"));
+
+        let recorded = attachment_calls.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0].0, "user@example.com");
+        assert_eq!(recorded[0].1, "Report");
+        assert_eq!(recorded[0].3, vec!["report.pdf"]);
+    }
+
+    #[tokio::test]
+    async fn send_message_attachment_not_found() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tool = SendMessageTool;
+        let (mock, _calls, _attachment_calls) = MockOutbound::new();
+        let mut ctx = ToolContext::new(tmp.path());
+        ctx.outbound = Some(Arc::new(mock));
+
+        let result = tool
+            .execute(
+                json!({
+                    "recipient": "user@example.com",
+                    "message": "Here is your report",
+                    "attachments": ["nonexistent.pdf"]
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert!(result.content.contains("Attachment not found"));
+        assert!(result.content.contains("nonexistent.pdf"));
+    }
+
+    #[tokio::test]
+    async fn send_message_cross_channel_with_attachments() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tool = SendMessageTool;
+        let (mock, _calls, attachment_calls) = MockOutbound::new();
+        let mut ctx = ToolContext::new(tmp.path());
+        // Set up outbounds map for cross-channel
+        let mut outbounds_map: std::collections::HashMap<String, Arc<dyn OutboundAdapter>> =
+            std::collections::HashMap::new();
+        outbounds_map.insert("email".to_string(), Arc::new(mock));
+        ctx.outbounds = Some(Arc::new(tokio::sync::Mutex::new(outbounds_map)));
+
+        // Create a test attachment file
+        let file_path = tmp.path().join("data.csv");
+        tokio::fs::write(&file_path, b"a,b,c\n1,2,3").await.unwrap();
+
+        let result = tool
+            .execute(
+                json!({
+                    "channel": "email",
+                    "recipient": "external@example.com",
+                    "subject": "CSV Export",
+                    "message": "Here is your export",
+                    "attachments": ["data.csv"]
+                }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.content.contains("external@example.com"));
+        assert!(result.content.contains("mock-attachment-msg"));
+        assert!(result.content.contains("1 attachment(s)"));
+
+        let recorded = attachment_calls.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0].0, "external@example.com");
+        assert_eq!(recorded[0].3, vec!["data.csv"]);
     }
 }
 

--- a/crates/jyc-agent/tests/unit_tests.rs
+++ b/crates/jyc-agent/tests/unit_tests.rs
@@ -698,6 +698,7 @@ mod mcp_bridge {
     }
 
     /// Mock outbound adapter that records send_message and send_message_with_attachments calls.
+    #[allow(clippy::type_complexity)]
     struct MockOutbound {
         calls: Arc<Mutex<Vec<(String, String, String)>>>,
         attachment_calls: Arc<Mutex<Vec<(String, String, String, Vec<String>)>>>,

--- a/crates/jyc-channels/src/email/outbound.rs
+++ b/crates/jyc-channels/src/email/outbound.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use tokio::sync::Mutex;
 
@@ -216,6 +216,66 @@ impl OutboundAdapter for EmailOutboundAdapter {
         let message_id = smtp
             .send_mail(&self.from_address, recipient, subject, body)
             .await?;
+        Ok(SendResult { message_id })
+    }
+
+    /// Send a fresh message email with file attachments.
+    ///
+    /// Validates attachments against config (if present), loads file bytes,
+    /// then sends via SMTP with multipart/mixed MIME structure.
+    async fn send_message_with_attachments(
+        &self,
+        recipient: &str,
+        subject: &str,
+        body: &str,
+        attachments: Option<&[OutboundAttachment]>,
+    ) -> Result<SendResult> {
+        let Some(atts) = attachments else {
+            return Ok(SendResult {
+                message_id: self.send_message(recipient, subject, body).await?.message_id,
+            });
+        };
+
+        // Validate attachments if configuration is present
+        if let Some(ref config) = self.attachment_config {
+            if let Err(e) =
+                attachment_validator::validate_outbound_attachments(atts, config).await
+            {
+                let filenames: Vec<&str> =
+                    atts.iter().map(|a| a.filename.as_str()).collect();
+                tracing::error!(
+                    error = %format!("{:#}", e),
+                    attachments = ?filenames,
+                    "Outbound attachment validation failed"
+                );
+                return Err(e.context("Failed to validate outbound attachments"));
+            }
+            tracing::debug!("Outbound attachments validated successfully");
+        }
+
+        // Load file bytes from paths
+        let mut email_attachments = Vec::new();
+        for att in atts {
+            let data = tokio::fs::read(&att.path).await
+                .with_context(|| format!("Failed to read attachment '{}' from {}", att.filename, att.path.display()))?;
+            email_attachments.push(EmailAttachment {
+                filename: att.filename.clone(),
+                content_type: att.content_type.clone(),
+                data,
+            });
+        }
+
+        let mut smtp = self.smtp.lock().await;
+        let message_id = smtp
+            .send_mail_with_attachments(
+                &self.from_address,
+                recipient,
+                subject,
+                body,
+                &email_attachments,
+            )
+            .await?;
+
         Ok(SendResult { message_id })
     }
 }

--- a/crates/jyc-channels/src/email/outbound.rs
+++ b/crates/jyc-channels/src/email/outbound.rs
@@ -232,17 +232,18 @@ impl OutboundAdapter for EmailOutboundAdapter {
     ) -> Result<SendResult> {
         let Some(atts) = attachments else {
             return Ok(SendResult {
-                message_id: self.send_message(recipient, subject, body).await?.message_id,
+                message_id: self
+                    .send_message(recipient, subject, body)
+                    .await?
+                    .message_id,
             });
         };
 
         // Validate attachments if configuration is present
         if let Some(ref config) = self.attachment_config {
-            if let Err(e) =
-                attachment_validator::validate_outbound_attachments(atts, config).await
+            if let Err(e) = attachment_validator::validate_outbound_attachments(atts, config).await
             {
-                let filenames: Vec<&str> =
-                    atts.iter().map(|a| a.filename.as_str()).collect();
+                let filenames: Vec<&str> = atts.iter().map(|a| a.filename.as_str()).collect();
                 tracing::error!(
                     error = %format!("{:#}", e),
                     attachments = ?filenames,
@@ -256,8 +257,13 @@ impl OutboundAdapter for EmailOutboundAdapter {
         // Load file bytes from paths
         let mut email_attachments = Vec::new();
         for att in atts {
-            let data = tokio::fs::read(&att.path).await
-                .with_context(|| format!("Failed to read attachment '{}' from {}", att.filename, att.path.display()))?;
+            let data = tokio::fs::read(&att.path).await.with_context(|| {
+                format!(
+                    "Failed to read attachment '{}' from {}",
+                    att.filename,
+                    att.path.display()
+                )
+            })?;
             email_attachments.push(EmailAttachment {
                 filename: att.filename.clone(),
                 content_type: att.content_type.clone(),

--- a/crates/jyc-channels/src/feishu/outbound.rs
+++ b/crates/jyc-channels/src/feishu/outbound.rs
@@ -45,6 +45,73 @@ impl FeishuOutboundAdapter {
             footer_enabled,
         }
     }
+
+    /// Send attachments as separate Feishu messages (upload → send).
+    ///
+    /// Images are uploaded via `upload_image` then sent via `send_image_message`.
+    /// Other files are uploaded via `upload_file` then sent via `send_file_message`.
+    /// Errors are logged as warnings rather than failing the entire operation.
+    async fn send_attachments(&self, chat_id: &str, attachments: &[OutboundAttachment]) {
+        use crate::feishu::client::{feishu_file_type, is_image_content_type};
+
+        for att in attachments {
+            if is_image_content_type(&att.content_type) {
+                // Image: upload → send image message
+                match self.client.upload_image(&att.path, &att.filename).await {
+                    Ok(image_key) => {
+                        match self.client.send_image_message(chat_id, &image_key).await {
+                            Ok(_) => tracing::info!(
+                                filename = %att.filename,
+                                "Image attachment sent via Feishu"
+                            ),
+                            Err(e) => tracing::warn!(
+                                filename = %att.filename,
+                                error = %e,
+                                "Failed to send Feishu image message"
+                            ),
+                        }
+                    }
+                    Err(e) => tracing::warn!(
+                        filename = %att.filename,
+                        error = %e,
+                        "Failed to upload Feishu image attachment"
+                    ),
+                }
+            } else {
+                // File: upload → send file message
+                let ext = att
+                    .path
+                    .extension()
+                    .map(|e| e.to_string_lossy().to_lowercase())
+                    .unwrap_or_default();
+                let file_type = feishu_file_type(&ext);
+
+                match self
+                    .client
+                    .upload_file(&att.path, &att.filename, file_type)
+                    .await
+                {
+                    Ok(file_key) => match self.client.send_file_message(chat_id, &file_key).await {
+                        Ok(_) => tracing::info!(
+                            filename = %att.filename,
+                            file_type = %file_type,
+                            "File attachment sent via Feishu"
+                        ),
+                        Err(e) => tracing::warn!(
+                            filename = %att.filename,
+                            error = %e,
+                            "Failed to send Feishu file message"
+                        ),
+                    },
+                    Err(e) => tracing::warn!(
+                        filename = %att.filename,
+                        error = %e,
+                        "Failed to upload Feishu file attachment"
+                    ),
+                }
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -140,68 +207,10 @@ impl jyc_types::OutboundAdapter for FeishuOutboundAdapter {
         );
 
         // 2. Send attachments as separate messages (upload → send)
-        if let Some(attachments) = attachments {
-            use crate::feishu::client::{feishu_file_type, is_image_content_type};
-
-            for att in attachments {
-                if is_image_content_type(&att.content_type) {
-                    // Image: upload → send image message
-                    match self.client.upload_image(&att.path, &att.filename).await {
-                        Ok(image_key) => {
-                            match self.client.send_image_message(chat_id, &image_key).await {
-                                Ok(_) => tracing::info!(
-                                    filename = %att.filename,
-                                    "Image attachment sent"
-                                ),
-                                Err(e) => tracing::warn!(
-                                    filename = %att.filename,
-                                    error = %e,
-                                    "Failed to send image attachment message"
-                                ),
-                            }
-                        }
-                        Err(e) => tracing::warn!(
-                            filename = %att.filename,
-                            error = %e,
-                            "Failed to upload image attachment"
-                        ),
-                    }
-                } else {
-                    // File: upload → send file message
-                    let ext = att
-                        .path
-                        .extension()
-                        .map(|e| e.to_string_lossy().to_lowercase())
-                        .unwrap_or_default();
-                    let file_type = feishu_file_type(&ext);
-
-                    match self
-                        .client
-                        .upload_file(&att.path, &att.filename, file_type)
-                        .await
-                    {
-                        Ok(file_key) => {
-                            match self.client.send_file_message(chat_id, &file_key).await {
-                                Ok(_) => tracing::info!(
-                                    filename = %att.filename,
-                                    file_type = %file_type,
-                                    "File attachment sent"
-                                ),
-                                Err(e) => tracing::warn!(
-                                    filename = %att.filename,
-                                    error = %e,
-                                    "Failed to send file attachment message"
-                                ),
-                            }
-                        }
-                        Err(e) => tracing::warn!(
-                            filename = %att.filename,
-                            error = %e,
-                            "Failed to upload file attachment"
-                        ),
-                    }
-                }
-            }
+        if let Some(attachments) = attachments
+            && !attachments.is_empty()
+        {
+            self.send_attachments(chat_id, attachments).await;
         }
 
         // 5. Store reply to chat log
@@ -285,68 +294,10 @@ impl jyc_types::OutboundAdapter for FeishuOutboundAdapter {
         );
 
         // Send attachments as separate messages (upload → send)
-        if let Some(attachments) = attachments {
-            use crate::feishu::client::{feishu_file_type, is_image_content_type};
-
-            for att in attachments {
-                if is_image_content_type(&att.content_type) {
-                    // Image: upload → send image message
-                    match self.client.upload_image(&att.path, &att.filename).await {
-                        Ok(image_key) => {
-                            match self.client.send_image_message(recipient, &image_key).await {
-                                Ok(_) => tracing::info!(
-                                    filename = %att.filename,
-                                    "Image attachment sent via Feishu"
-                                ),
-                                Err(e) => tracing::warn!(
-                                    filename = %att.filename,
-                                    error = %e,
-                                    "Failed to send Feishu image message"
-                                ),
-                            }
-                        }
-                        Err(e) => tracing::warn!(
-                            filename = %att.filename,
-                            error = %e,
-                            "Failed to upload Feishu image attachment"
-                        ),
-                    }
-                } else {
-                    // File: upload → send file message
-                    let ext = att
-                        .path
-                        .extension()
-                        .map(|e| e.to_string_lossy().to_lowercase())
-                        .unwrap_or_default();
-                    let file_type = feishu_file_type(&ext);
-
-                    match self
-                        .client
-                        .upload_file(&att.path, &att.filename, file_type)
-                        .await
-                    {
-                        Ok(file_key) => {
-                            match self.client.send_file_message(recipient, &file_key).await {
-                                Ok(_) => tracing::info!(
-                                    filename = %att.filename,
-                                    file_type = %file_type,
-                                    "File attachment sent via Feishu"
-                                ),
-                                Err(e) => tracing::warn!(
-                                    filename = %att.filename,
-                                    error = %e,
-                                    "Failed to send Feishu file message"
-                                ),
-                            }
-                        }
-                        Err(e) => tracing::warn!(
-                            filename = %att.filename,
-                            error = %e,
-                            "Failed to upload Feishu file attachment"
-                        ),
-                    }
-                }
-            }
+        if let Some(attachments) = attachments
+            && !attachments.is_empty()
+        {
+            self.send_attachments(recipient, attachments).await;
         }
 
         Ok(SendResult {

--- a/crates/jyc-channels/src/feishu/outbound.rs
+++ b/crates/jyc-channels/src/feishu/outbound.rs
@@ -242,4 +242,115 @@ impl jyc_types::OutboundAdapter for FeishuOutboundAdapter {
             message_id: result.message_id,
         })
     }
+
+    /// Send a message with file attachments to a Feishu chat.
+    ///
+    /// Sends text first, then uploads and sends each attachment as a separate
+    /// Feishu message (image or file). Reuses the same upload/send logic as
+    /// `send_reply`'s attachment handling.
+    async fn send_message_with_attachments(
+        &self,
+        recipient: &str,
+        subject: &str,
+        body: &str,
+        attachments: Option<&[OutboundAttachment]>,
+    ) -> Result<SendResult> {
+        // Ensure client is initialized
+        self.client.initialize().await.context(
+            "Failed to initialize Feishu client before sending message with attachments",
+        )?;
+
+        // Validate attachments if configuration is present
+        if let Some(attachments) = attachments
+            && let Some(ref config) = self.attachment_config
+        {
+            attachment_validator::validate_outbound_attachments(attachments, config)
+                .await
+                .context("Failed to validate outbound attachments")?;
+            tracing::debug!("Outbound attachments validated successfully for Feishu");
+        }
+
+        // Send text message first
+        let alert_text = format!("**{}**\n\n{}", subject, body);
+        let result = self
+            .client
+            .send_text_message(recipient, &alert_text)
+            .await
+            .context("Failed to send Feishu text message")?;
+
+        tracing::info!(
+            chat_id = %recipient,
+            text_len = alert_text.len(),
+            "Feishu text message sent with attachments"
+        );
+
+        // Send attachments as separate messages (upload → send)
+        if let Some(attachments) = attachments {
+            use crate::feishu::client::{feishu_file_type, is_image_content_type};
+
+            for att in attachments {
+                if is_image_content_type(&att.content_type) {
+                    // Image: upload → send image message
+                    match self.client.upload_image(&att.path, &att.filename).await {
+                        Ok(image_key) => {
+                            match self.client.send_image_message(recipient, &image_key).await {
+                                Ok(_) => tracing::info!(
+                                    filename = %att.filename,
+                                    "Image attachment sent via Feishu"
+                                ),
+                                Err(e) => tracing::warn!(
+                                    filename = %att.filename,
+                                    error = %e,
+                                    "Failed to send Feishu image message"
+                                ),
+                            }
+                        }
+                        Err(e) => tracing::warn!(
+                            filename = %att.filename,
+                            error = %e,
+                            "Failed to upload Feishu image attachment"
+                        ),
+                    }
+                } else {
+                    // File: upload → send file message
+                    let ext = att
+                        .path
+                        .extension()
+                        .map(|e| e.to_string_lossy().to_lowercase())
+                        .unwrap_or_default();
+                    let file_type = feishu_file_type(&ext);
+
+                    match self
+                        .client
+                        .upload_file(&att.path, &att.filename, file_type)
+                        .await
+                    {
+                        Ok(file_key) => {
+                            match self.client.send_file_message(recipient, &file_key).await {
+                                Ok(_) => tracing::info!(
+                                    filename = %att.filename,
+                                    file_type = %file_type,
+                                    "File attachment sent via Feishu"
+                                ),
+                                Err(e) => tracing::warn!(
+                                    filename = %att.filename,
+                                    error = %e,
+                                    "Failed to send Feishu file message"
+                                ),
+                            }
+                        }
+                        Err(e) => tracing::warn!(
+                            filename = %att.filename,
+                            error = %e,
+                            "Failed to upload Feishu file attachment"
+                        ),
+                    }
+                }
+            }
+        }
+
+        Ok(SendResult {
+            message_id: result.message_id,
+        })
+    }
 }

--- a/crates/jyc-channels/src/wecom_bot/outbound.rs
+++ b/crates/jyc-channels/src/wecom_bot/outbound.rs
@@ -160,6 +160,61 @@ impl WecomBotOutboundAdapter {
             .await
             .context("Failed to update WeCom Bot processing indicator")
     }
+
+    /// Upload and send media attachments through the WebSocket.
+    ///
+    /// For each attachment: upload via `upload_attachment`, build a media message
+    /// body via `build_media_message_body`, and send via the WebSocket.
+    /// `cmd` is the command to use (e.g. `"aibot_send_msg"` or `"aibot_respond_msg"`).
+    /// When `chat_id` is `Some`, it is included in the message body.
+    async fn send_media_attachments(
+        &self,
+        handle: &WecomBotConnectionHandle,
+        attachments: &[OutboundAttachment],
+        cmd: &str,
+        req_id: &str,
+        chat_id: Option<&str>,
+    ) {
+        for att in attachments {
+            let media_type = wecom_media_type(&att.content_type, &att.filename);
+
+            match upload_attachment(handle, &att.path, &att.filename, &att.content_type).await {
+                Ok(media_id) => {
+                    let mut body = build_media_message_body(media_type, &media_id);
+                    if let Some(cid) = chat_id {
+                        body["chatid"] = serde_json::Value::String(cid.to_string());
+                    }
+                    let json = serde_json::json!({
+                        "cmd": cmd,
+                        "headers": {"req_id": req_id},
+                        "body": body,
+                    })
+                    .to_string();
+
+                    if let Err(e) = handle.sender.send(json) {
+                        tracing::warn!(
+                            filename = %att.filename,
+                            error = %e,
+                            "Failed to send WeCom Bot attachment message"
+                        );
+                    } else {
+                        tracing::info!(
+                            filename = %att.filename,
+                            media_type = %media_type,
+                            "WeCom Bot attachment message sent"
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        filename = %att.filename,
+                        error = %e,
+                        "Failed to upload WeCom Bot attachment"
+                    );
+                }
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -299,59 +354,28 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
         );
 
         // 9. Upload and send attachments as separate media messages.
-        if let Some(attachments) = attachments {
+        if let Some(attachments) = attachments
+            && !attachments.is_empty()
+        {
             let handle = {
                 let guard = self.handle.lock().await;
                 guard
                     .clone()
                     .context("WeCom Bot outbound handle not set; cannot upload attachments")?
             };
-
-            for att in attachments {
-                let media_type = wecom_media_type(&att.content_type, &att.filename);
-
-                match upload_attachment(&handle, &att.path, &att.filename, &att.content_type).await
-                {
-                    Ok(media_id) => {
-                        let att_cmd = if proactive_chatid.is_some() {
-                            "aibot_send_msg"
-                        } else {
-                            "aibot_respond_msg"
-                        };
-                        let mut body = build_media_message_body(media_type, &media_id);
-                        if let Some(ref chatid) = proactive_chatid {
-                            body["chatid"] = serde_json::Value::String(chatid.clone());
-                        }
-                        let json = serde_json::json!({
-                            "cmd": att_cmd,
-                            "headers": {"req_id": req_id},
-                            "body": body,
-                        })
-                        .to_string();
-
-                        if let Err(e) = handle.sender.send(json) {
-                            tracing::warn!(
-                                filename = %att.filename,
-                                error = %e,
-                                "Failed to send WeCom Bot attachment message"
-                            );
-                        } else {
-                            tracing::info!(
-                                filename = %att.filename,
-                                media_type = %media_type,
-                                "WeCom Bot attachment message sent"
-                            );
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            filename = %att.filename,
-                            error = %e,
-                            "Failed to upload WeCom Bot attachment"
-                        );
-                    }
-                }
-            }
+            let att_cmd = if proactive_chatid.is_some() {
+                "aibot_send_msg"
+            } else {
+                "aibot_respond_msg"
+            };
+            self.send_media_attachments(
+                &handle,
+                attachments,
+                att_cmd,
+                &req_id,
+                proactive_chatid.as_deref(),
+            )
+            .await;
         }
 
         // 10. Store reply to chat log
@@ -398,7 +422,7 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
                     .as_millis(),
-                uuid::Uuid::new_v4().to_string().replace('-', "")[..8].to_string()
+                &uuid::Uuid::new_v4().to_string().replace('-', "")[..8]
             )},
             "body": body_json
         })
@@ -456,52 +480,22 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
                     .clone()
                     .context("WeCom Bot outbound handle not set; cannot upload attachments")?
             };
-
-            for att in attachments {
-                let media_type = wecom_media_type(&att.content_type, &att.filename);
-
-                match upload_attachment(&handle, &att.path, &att.filename, &att.content_type).await
-                {
-                    Ok(media_id) => {
-                        let mut body = build_media_message_body(media_type, &media_id);
-                        body["chatid"] = serde_json::Value::String(recipient.to_string());
-
-                        let json = serde_json::json!({
-                            "cmd": "aibot_send_msg",
-                            "headers": {"req_id": format!("aibot_send_msg_{}_{}",
-                                std::time::SystemTime::now()
-                                    .duration_since(std::time::UNIX_EPOCH)
-                                    .unwrap_or_default()
-                                    .as_millis(),
-                                uuid::Uuid::new_v4().to_string().replace('-', "")[..8].to_string()
-                            )},
-                            "body": body,
-                        })
-                        .to_string();
-
-                        if let Err(e) = handle.sender.send(json) {
-                            tracing::warn!(
-                                filename = %att.filename,
-                                error = %e,
-                                "Failed to send WeCom Bot attachment message"
-                            );
-                        } else {
-                            tracing::info!(
-                                filename = %att.filename,
-                                media_type = %media_type,
-                                "WeCom Bot attachment message sent"
-                            );
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            filename = %att.filename,
-                            error = %e,
-                            "Failed to upload WeCom Bot attachment"
-                        );
-                    }
-                }
-            }
+            let req_id = format!(
+                "aibot_send_msg_{}_{}",
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis(),
+                &uuid::Uuid::new_v4().to_string().replace('-', "")[..8]
+            );
+            self.send_media_attachments(
+                &handle,
+                attachments,
+                "aibot_send_msg",
+                &req_id,
+                Some(recipient),
+            )
+            .await;
         }
 
         Ok(SendResult {

--- a/crates/jyc-channels/src/wecom_bot/outbound.rs
+++ b/crates/jyc-channels/src/wecom_bot/outbound.rs
@@ -420,6 +420,95 @@ impl OutboundAdapter for WecomBotOutboundAdapter {
         Ok(SendResult { message_id })
     }
 
+    /// Send a message with file attachments to a WeCom Bot conversation.
+    ///
+    /// Sends text first via `aibot_send_msg`, then uploads each attachment
+    /// and sends as a separate media message. Reuses the same module-level
+    /// functions (`upload_attachment`, `build_media_message_body`,
+    /// `wecom_media_type`) as `send_reply`'s attachment handling.
+    async fn send_message_with_attachments(
+        &self,
+        recipient: &str,
+        subject: &str,
+        body: &str,
+        attachments: Option<&[OutboundAttachment]>,
+    ) -> Result<SendResult> {
+        // Validate attachments if configuration is present
+        if let Some(attachments) = attachments
+            && let Some(ref config) = self.attachment_config
+        {
+            attachment_validator::validate_outbound_attachments(attachments, config)
+                .await
+                .context("Failed to validate outbound attachments")?;
+            tracing::debug!("Outbound attachments validated successfully for WeCom Bot");
+        }
+
+        // Send text message first (reuse send_message logic)
+        let text_result = self.send_message(recipient, subject, body).await?;
+
+        // Send attachments as separate media messages
+        if let Some(attachments) = attachments
+            && !attachments.is_empty()
+        {
+            let handle = {
+                let guard = self.handle.lock().await;
+                guard
+                    .clone()
+                    .context("WeCom Bot outbound handle not set; cannot upload attachments")?
+            };
+
+            for att in attachments {
+                let media_type = wecom_media_type(&att.content_type, &att.filename);
+
+                match upload_attachment(&handle, &att.path, &att.filename, &att.content_type).await
+                {
+                    Ok(media_id) => {
+                        let mut body = build_media_message_body(media_type, &media_id);
+                        body["chatid"] = serde_json::Value::String(recipient.to_string());
+
+                        let json = serde_json::json!({
+                            "cmd": "aibot_send_msg",
+                            "headers": {"req_id": format!("aibot_send_msg_{}_{}",
+                                std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .unwrap_or_default()
+                                    .as_millis(),
+                                uuid::Uuid::new_v4().to_string().replace('-', "")[..8].to_string()
+                            )},
+                            "body": body,
+                        })
+                        .to_string();
+
+                        if let Err(e) = handle.sender.send(json) {
+                            tracing::warn!(
+                                filename = %att.filename,
+                                error = %e,
+                                "Failed to send WeCom Bot attachment message"
+                            );
+                        } else {
+                            tracing::info!(
+                                filename = %att.filename,
+                                media_type = %media_type,
+                                "WeCom Bot attachment message sent"
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            filename = %att.filename,
+                            error = %e,
+                            "Failed to upload WeCom Bot attachment"
+                        );
+                    }
+                }
+            }
+        }
+
+        Ok(SendResult {
+            message_id: text_result.message_id,
+        })
+    }
+
     /// Send a processing indicator (`finish=false`) so the user sees
     /// "正在思考中..." while AI is working.
     ///

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -120,6 +120,8 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
     let mut all_workspace_dirs: Vec<std::path::PathBuf> = Vec::new();
     // Collect JycAgentService instances for wiring cross-channel thread managers
     let mut all_agent_services: Vec<Arc<JycAgentService>> = Vec::new();
+    // Collect outbound adapters keyed by channel name for cross-channel messaging
+    let mut all_outbounds: Vec<(String, Arc<dyn OutboundAdapter>)> = Vec::new();
     let config_snapshot = config.load();
     let agent_config = Arc::new(config_snapshot.agent.clone());
 
@@ -334,6 +336,9 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
             .await
             .with_context(|| format!("channel '{channel_name}': outbound connection failed"))?;
         tracing::info!(channel = %channel_name, channel_type = %channel_type, "Outbound connected");
+
+        // Collect outbound adapter for cross-channel messaging
+        all_outbounds.push((channel_name.clone(), outbound.clone()));
 
         // Create agent based on configured mode
         // Resolve effective model per-channel: channel-level override beats global
@@ -1033,7 +1038,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
         anyhow::bail!("No channels configured");
     }
 
-    // 4.5. Wire cross-channel thread managers into agent services
+    // 4.5. Wire cross-channel thread managers and outbound adapters into agent services
     {
         let tm_map: HashMap<String, Arc<ThreadManager>> = all_thread_managers
             .iter()
@@ -1045,6 +1050,19 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
         }
         tracing::info!(
             "Wired thread managers into {} agent service(s)",
+            all_agent_services.len()
+        );
+
+        // Build and inject outbound adapters map
+        let outbounds_map: HashMap<String, Arc<dyn OutboundAdapter>> = all_outbounds
+            .into_iter()
+            .collect();
+        let outbounds_map = Arc::new(tokio::sync::Mutex::new(outbounds_map));
+        for svc in &all_agent_services {
+            svc.set_outbounds(outbounds_map.clone());
+        }
+        tracing::info!(
+            "Wired outbound adapters into {} agent service(s)",
             all_agent_services.len()
         );
 

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -1054,9 +1054,8 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
         );
 
         // Build and inject outbound adapters map
-        let outbounds_map: HashMap<String, Arc<dyn OutboundAdapter>> = all_outbounds
-            .into_iter()
-            .collect();
+        let outbounds_map: HashMap<String, Arc<dyn OutboundAdapter>> =
+            all_outbounds.into_iter().collect();
         let outbounds_map = Arc::new(tokio::sync::Mutex::new(outbounds_map));
         for svc in &all_agent_services {
             svc.set_outbounds(outbounds_map.clone());

--- a/crates/jyc-services/src/smtp/client.rs
+++ b/crates/jyc-services/src/smtp/client.rs
@@ -163,8 +163,6 @@ impl SmtpClient {
         references: Option<&[String]>,
         attachments: Option<&[EmailAttachment]>,
     ) -> Result<String> {
-        let html_body = markdown_to_html(markdown_body);
-
         // Build subject with Re: prefix
         let reply_subject = if subject.to_lowercase().starts_with("re:") {
             subject.to_string()
@@ -172,72 +170,17 @@ impl SmtpClient {
             format!("Re: {subject}")
         };
 
-        let from_mailbox: Mailbox = if let Some(name) = from_name {
-            format!("{name} <{from}>")
-                .parse()
-                .with_context(|| format!("invalid from address: {from}"))?
-        } else {
-            from.parse()
-                .with_context(|| format!("invalid from address: {from}"))?
-        };
-
-        let to_mailbox: Mailbox = to
-            .parse()
-            .with_context(|| format!("invalid to address: {to}"))?;
-
-        let mut builder = Message::builder()
-            .from(from_mailbox)
-            .to(to_mailbox)
-            .subject(&reply_subject);
-
-        // Add threading headers
-        if let Some(reply_to) = in_reply_to {
-            builder = builder.header(InReplyTo::from(reply_to.to_string()));
-        }
-        if let Some(refs) = references {
-            let refs_str = refs.join(" ");
-            builder = builder.header(References::from(refs_str));
-        }
-
-        // Build the body part (text + HTML alternative)
-        let body_part = MultiPart::alternative()
-            .singlepart(
-                SinglePart::builder()
-                    .header(ContentType::TEXT_PLAIN)
-                    .body(markdown_body.to_string()),
-            )
-            .singlepart(
-                SinglePart::builder()
-                    .header(ContentType::TEXT_HTML)
-                    .body(html_body),
-            );
-
-        // Build the email: if attachments, wrap in mixed multipart
-        let email = if let Some(atts) = attachments {
-            if atts.is_empty() {
-                builder
-                    .multipart(body_part)
-                    .context("failed to build email message")?
-            } else {
-                let mut mixed = MultiPart::mixed().multipart(body_part);
-                for att in atts {
-                    let ct: ContentType = att
-                        .content_type
-                        .parse()
-                        .unwrap_or(ContentType::parse("application/octet-stream").unwrap());
-                    let attachment =
-                        Attachment::new(att.filename.clone()).body(att.data.clone(), ct);
-                    mixed = mixed.singlepart(attachment);
-                }
-                builder
-                    .multipart(mixed)
-                    .context("failed to build email with attachments")?
-            }
-        } else {
-            builder
-                .multipart(body_part)
-                .context("failed to build email message")?
-        };
+        // Build the email message using the shared helper
+        let email = self.build_email(
+            from,
+            from_name,
+            to,
+            &reply_subject,
+            markdown_body,
+            in_reply_to,
+            references,
+            attachments,
+        )?;
 
         let message_id = email
             .headers()
@@ -264,33 +207,8 @@ impl SmtpClient {
         subject: &str,
         markdown_body: &str,
     ) -> Result<String> {
-        let html_body = markdown_to_html(markdown_body);
-
-        let from_mailbox: Mailbox = from
-            .parse()
-            .with_context(|| format!("invalid from address: {from}"))?;
-        let to_mailbox: Mailbox = to
-            .parse()
-            .with_context(|| format!("invalid to address: {to}"))?;
-
-        let email = Message::builder()
-            .from(from_mailbox)
-            .to(to_mailbox)
-            .subject(subject)
-            .multipart(
-                MultiPart::alternative()
-                    .singlepart(
-                        SinglePart::builder()
-                            .header(ContentType::TEXT_PLAIN)
-                            .body(markdown_body.to_string()),
-                    )
-                    .singlepart(
-                        SinglePart::builder()
-                            .header(ContentType::TEXT_HTML)
-                            .body(html_body),
-                    ),
-            )
-            .context("failed to build email message")?;
+        // Build a simple email without attachments or threading headers
+        let email = self.build_email(from, None, to, subject, markdown_body, None, None, None)?;
 
         let message_id = email
             .headers()
@@ -309,7 +227,6 @@ impl SmtpClient {
     ///
     /// Same as `send_mail` but attaches files to a `multipart/mixed` wrapper.
     /// No `In-Reply-To` or `References` headers (this is a fresh message, not a reply).
-    /// Follows the same MIME multipart pattern as `send_reply` for attachment parts.
     pub async fn send_mail_with_attachments(
         &mut self,
         from: &str,
@@ -318,51 +235,16 @@ impl SmtpClient {
         markdown_body: &str,
         attachments: &[EmailAttachment],
     ) -> Result<String> {
-        let html_body = markdown_to_html(markdown_body);
-
-        let from_mailbox: Mailbox = from
-            .parse()
-            .with_context(|| format!("invalid from address: {from}"))?;
-        let to_mailbox: Mailbox = to
-            .parse()
-            .with_context(|| format!("invalid to address: {to}"))?;
-
-        let body_part = MultiPart::alternative()
-            .singlepart(
-                SinglePart::builder()
-                    .header(ContentType::TEXT_PLAIN)
-                    .body(markdown_body.to_string()),
-            )
-            .singlepart(
-                SinglePart::builder()
-                    .header(ContentType::TEXT_HTML)
-                    .body(html_body),
-            );
-
-        let email = if attachments.is_empty() {
-            Message::builder()
-                .from(from_mailbox)
-                .to(to_mailbox)
-                .subject(subject)
-                .multipart(body_part)
-                .context("failed to build email message")?
-        } else {
-            let mut mixed = MultiPart::mixed().multipart(body_part);
-            for att in attachments {
-                let ct: ContentType = att
-                    .content_type
-                    .parse()
-                    .unwrap_or(ContentType::parse("application/octet-stream").unwrap());
-                let attachment = Attachment::new(att.filename.clone()).body(att.data.clone(), ct);
-                mixed = mixed.singlepart(attachment);
-            }
-            Message::builder()
-                .from(from_mailbox)
-                .to(to_mailbox)
-                .subject(subject)
-                .multipart(mixed)
-                .context("failed to build email with attachments")?
-        };
+        let email = self.build_email(
+            from,
+            None,
+            to,
+            subject,
+            markdown_body,
+            None,
+            None,
+            Some(attachments),
+        )?;
 
         let message_id = email
             .headers()
@@ -375,6 +257,94 @@ impl SmtpClient {
         tracing::info!(to = %to, subject = %subject, attachments = attachments.len(), "Email with attachments sent");
 
         Ok(message_id)
+    }
+
+    /// Private helper: build a lettre `Message` from the given components.
+    ///
+    /// Handles markdown→HTML conversion, multipart/alternative body,
+    /// multipart/mixed wrapper for attachments, and optional threading headers.
+    /// Does NOT send the email — the caller is responsible for calling
+    /// `send_with_retry` and extracting the `Message-ID`.
+    #[allow(clippy::too_many_arguments)]
+    fn build_email(
+        &self,
+        from: &str,
+        from_name: Option<&str>,
+        to: &str,
+        subject: &str,
+        markdown_body: &str,
+        in_reply_to: Option<&str>,
+        references: Option<&[String]>,
+        attachments: Option<&[EmailAttachment]>,
+    ) -> Result<Message> {
+        let html_body = markdown_to_html(markdown_body);
+
+        let from_mailbox: Mailbox = if let Some(name) = from_name {
+            format!("{name} <{from}>")
+                .parse()
+                .with_context(|| format!("invalid from address: {from}"))?
+        } else {
+            from.parse()
+                .with_context(|| format!("invalid from address: {from}"))?
+        };
+
+        let to_mailbox: Mailbox = to
+            .parse()
+            .with_context(|| format!("invalid to address: {to}"))?;
+
+        let mut builder = Message::builder()
+            .from(from_mailbox)
+            .to(to_mailbox)
+            .subject(subject);
+
+        // Add threading headers (used by send_reply, skipped by send_mail*)
+        if let Some(reply_to) = in_reply_to {
+            builder = builder.header(InReplyTo::from(reply_to.to_string()));
+        }
+        if let Some(refs) = references {
+            let refs_str = refs.join(" ");
+            builder = builder.header(References::from(refs_str));
+        }
+
+        // Build the body part (text + HTML alternative)
+        let body_part = MultiPart::alternative()
+            .singlepart(
+                SinglePart::builder()
+                    .header(ContentType::TEXT_PLAIN)
+                    .body(markdown_body.to_string()),
+            )
+            .singlepart(
+                SinglePart::builder()
+                    .header(ContentType::TEXT_HTML)
+                    .body(html_body),
+            );
+
+        // Build the email: if attachments, wrap in mixed multipart
+        if let Some(atts) = attachments {
+            if atts.is_empty() {
+                builder
+                    .multipart(body_part)
+                    .context("failed to build email message")
+            } else {
+                let mut mixed = MultiPart::mixed().multipart(body_part);
+                for att in atts {
+                    let ct: ContentType = att
+                        .content_type
+                        .parse()
+                        .unwrap_or(ContentType::parse("application/octet-stream").unwrap());
+                    let attachment =
+                        Attachment::new(att.filename.clone()).body(att.data.clone(), ct);
+                    mixed = mixed.singlepart(attachment);
+                }
+                builder
+                    .multipart(mixed)
+                    .context("failed to build email with attachments")
+            }
+        } else {
+            builder
+                .multipart(body_part)
+                .context("failed to build email message")
+        }
     }
 
     /// Send an email with structured retry logic based on SMTP error classification.

--- a/crates/jyc-services/src/smtp/client.rs
+++ b/crates/jyc-services/src/smtp/client.rs
@@ -305,6 +305,79 @@ impl SmtpClient {
         Ok(message_id)
     }
 
+    /// Send a fresh (non-reply) email with file attachments — no threading headers.
+    ///
+    /// Same as `send_mail` but attaches files to a `multipart/mixed` wrapper.
+    /// No `In-Reply-To` or `References` headers (this is a fresh message, not a reply).
+    /// Follows the same MIME multipart pattern as `send_reply` for attachment parts.
+    pub async fn send_mail_with_attachments(
+        &mut self,
+        from: &str,
+        to: &str,
+        subject: &str,
+        markdown_body: &str,
+        attachments: &[EmailAttachment],
+    ) -> Result<String> {
+        let html_body = markdown_to_html(markdown_body);
+
+        let from_mailbox: Mailbox = from
+            .parse()
+            .with_context(|| format!("invalid from address: {from}"))?;
+        let to_mailbox: Mailbox = to
+            .parse()
+            .with_context(|| format!("invalid to address: {to}"))?;
+
+        let body_part = MultiPart::alternative()
+            .singlepart(
+                SinglePart::builder()
+                    .header(ContentType::TEXT_PLAIN)
+                    .body(markdown_body.to_string()),
+            )
+            .singlepart(
+                SinglePart::builder()
+                    .header(ContentType::TEXT_HTML)
+                    .body(html_body),
+            );
+
+        let email = if attachments.is_empty() {
+            Message::builder()
+                .from(from_mailbox)
+                .to(to_mailbox)
+                .subject(subject)
+                .multipart(body_part)
+                .context("failed to build email message")?
+        } else {
+            let mut mixed = MultiPart::mixed().multipart(body_part);
+            for att in attachments {
+                let ct: ContentType = att
+                    .content_type
+                    .parse()
+                    .unwrap_or(ContentType::parse("application/octet-stream").unwrap());
+                let attachment =
+                    Attachment::new(att.filename.clone()).body(att.data.clone(), ct);
+                mixed = mixed.singlepart(attachment);
+            }
+            Message::builder()
+                .from(from_mailbox)
+                .to(to_mailbox)
+                .subject(subject)
+                .multipart(mixed)
+                .context("failed to build email with attachments")?
+        };
+
+        let message_id = email
+            .headers()
+            .get_raw("Message-ID")
+            .unwrap_or_default()
+            .to_string();
+
+        self.send_with_retry(email).await?;
+
+        tracing::info!(to = %to, subject = %subject, attachments = attachments.len(), "Email with attachments sent");
+
+        Ok(message_id)
+    }
+
     /// Send an email with structured retry logic based on SMTP error classification.
     ///
     /// Error handling strategy:

--- a/crates/jyc-services/src/smtp/client.rs
+++ b/crates/jyc-services/src/smtp/client.rs
@@ -353,8 +353,7 @@ impl SmtpClient {
                     .content_type
                     .parse()
                     .unwrap_or(ContentType::parse("application/octet-stream").unwrap());
-                let attachment =
-                    Attachment::new(att.filename.clone()).body(att.data.clone(), ct);
+                let attachment = Attachment::new(att.filename.clone()).body(att.data.clone(), ct);
                 mixed = mixed.singlepart(attachment);
             }
             Message::builder()

--- a/crates/jyc-types/src/channel.rs
+++ b/crates/jyc-types/src/channel.rs
@@ -231,7 +231,9 @@ pub trait OutboundAdapter: Send + Sync {
         _body: &str,
         _attachments: Option<&[OutboundAttachment]>,
     ) -> Result<SendResult> {
-        Err(anyhow::anyhow!("Attachments not supported for this channel type"))
+        Err(anyhow::anyhow!(
+            "Attachments not supported for this channel type"
+        ))
     }
 
     /// Send a processing indicator to inform the user that AI is working.

--- a/crates/jyc-types/src/channel.rs
+++ b/crates/jyc-types/src/channel.rs
@@ -220,6 +220,20 @@ pub trait OutboundAdapter: Send + Sync {
     /// Send a fresh (non-reply) message to an arbitrary recipient.
     async fn send_message(&self, recipient: &str, subject: &str, body: &str) -> Result<SendResult>;
 
+    /// Send a fresh message with file attachments.
+    ///
+    /// Default implementation returns an error so non-email channels fail
+    /// gracefully rather than silently dropping attachments.
+    async fn send_message_with_attachments(
+        &self,
+        _recipient: &str,
+        _subject: &str,
+        _body: &str,
+        _attachments: Option<&[OutboundAttachment]>,
+    ) -> Result<SendResult> {
+        Err(anyhow::anyhow!("Attachments not supported for this channel type"))
+    }
+
     /// Send a processing indicator to inform the user that AI is working.
     ///
     /// Channels that support streaming (e.g., WeCom Bot) can show a


### PR DESCRIPTION
## Spec

Enhance `jyc_send_message` builtin tool to support cross-channel sending (via optional `channel` parameter) and file attachments (via optional `attachments` parameter). This enables scenarios like: a Feishu agent generates an Excel report and sends it as an email attachment to an external recipient via the email channel's SMTP outbound adapter — without triggering any agent processing on the target channel.

Complements the existing `jyc_send_to_thread` tool: `send_to_thread` injects messages into a thread queue for agent processing; `send_message` sends messages directly through an outbound adapter, bypassing agent processing entirely.

Three channels get `send_message_with_attachments` implementation — all reusing existing attachment upload/send logic from their respective `send_reply` methods:

- **email**: extract shared MIME-building into `SmtpClient::build_email()` private helper, add `send_mail_with_attachments()`
- **feishu**: reuse `FeishuClient::upload_image()` / `upload_file()` / `send_image_message()` / `send_file_message()`
- **wecom_bot**: reuse module-level `upload_attachment()` / `build_media_message_body()` / `wecom_media_type()`

Fixes #267

## Implementation Plan

### Step 1: Extract shared MIME builder in SmtpClient, add send_mail_with_attachments
**What:** `crates/jyc-services/src/smtp/client.rs` — extract the MIME multipart building logic (body + optional attachments) from `send_reply` into a private `build_email(from, to, subject, body, in_reply_to, references, attachments)` method. Then refactor `send_reply` to call it. Add new `send_mail_with_attachments(from, to, subject, body, attachments)` that calls the same `build_email` helper without threading headers. No code duplication — all three methods share the same MIME construction.
**Why:** `send_reply` and `send_mail` currently duplicate MIME-building code. Extracting a helper eliminates duplication and enables attachment support for fresh emails.
**Verify:** `cargo check -p jyc-services` — compiles. Existing SmtpClient behavior unchanged.

### Step 2: Add `send_message_with_attachments` to OutboundAdapter trait
**What:** `crates/jyc-types/src/channel.rs` — add a new method with default implementation returning error "Attachments not supported for this channel type". Channels that don't support attachments (github, gitee, wechat, wecom, wecomkf) inherit the error. Channels that do (email, feishu, wecom_bot) override.
**Why:** Trait extension with sensible default — no breaking changes to existing implementations.
**Verify:** `cargo check -p jyc-types` — compiles.

### Step 3: Implement send_message_with_attachments for EmailOutboundAdapter
**What:** `crates/jyc-channels/src/email/outbound.rs` — override the trait method. Load file bytes from `OutboundAttachment` paths into `EmailAttachment` structs. Call `SmtpClient::send_mail_with_attachments(from, recipient, subject, body, attachments)`. Optionally apply `attachment_validator::validate_outbound_attachments` if config is present.
**Why:** Email is the primary cross-channel use case — agent in any channel can send email with attachments via email channel's SMTP.
**Verify:** `cargo check -p jyc-channels` — compiles.

### Step 4: Implement send_message_with_attachments for FeishuOutboundAdapter
**What:** `crates/jyc-channels/src/feishu/outbound.rs` — override the trait method. Send text via `client.send_text_message(recipient, body)`. For each attachment: if image → `client.upload_image()` + `client.send_image_message()`; if file → `client.upload_file()` + `client.send_file_message()`. Reuses the exact same client methods that `send_reply` already uses.
**Why:** Enables cross-channel file sharing to Feishu conversations.
**Verify:** `cargo check -p jyc-channels` — compiles.

### Step 5: Implement send_message_with_attachments for WecomBotOutboundAdapter
**What:** `crates/jyc-channels/src/wecom_bot/outbound.rs` — override the trait method. Send text via `aibot_send_msg` (same as existing `send_message`). For each attachment: call `upload_attachment()` → `build_media_message_body()` → send via `aibot_send_msg` with `chatid`. Reuses the exact same module-level functions that `send_reply`'s attachment section already uses.
**Why:** Enables cross-channel file sharing to WeCom Bot conversations.
**Verify:** `cargo check -p jyc-channels` — compiles.

### Step 6: Add `outbounds` map to ToolContext
**What:** `crates/jyc-agent/src/tools/mod.rs` — add `outbounds` field (same type pattern as `thread_managers`). Update constructors (set to `None`).
**Why:** `SendMessageTool` needs access to all channel outbound adapters for the `channel` parameter.
**Verify:** `cargo check -p jyc-agent` — compiles.

### Step 7: Wire `outbounds` through JycAgentService
**What:** `crates/jyc-agent/src/service.rs` — add `outbounds` field + `set_outbounds()` setter (same pattern as `set_thread_managers()`). Pass through to `ToolContext` in `build_tool_registry`.
**Why:** Consistent wiring pattern — monitor creates adapters, service receives via setter after init.
**Verify:** `cargo check -p jyc-agent` — compiles.

### Step 8: Enhance SendMessageTool (mcp_bridge.rs)
**What:** `crates/jyc-agent/src/tools/mcp_bridge.rs` — add `channel` (optional) and `attachments` (optional) to input schema. In execute: if channel specified, lookup from `ctx.outbounds`; if attachments, validate paths (canonical prefix), build `OutboundAttachment` list, call `send_message_with_attachments`; if channel omitted, use `ctx.outbound` (full backward compat).
**Why:** Core enhancement — cross-channel with optional attachments, zero regression.
**Verify:** `cargo check -p jyc-agent` + `cargo test -p jyc-agent --test unit_tests`.

### Step 9: Build and inject `outbounds` map in Monitor
**What:** `crates/jyc-cli/src/cli/monitor.rs` — after thread_managers wiring, collect all outbound adapters into `HashMap<String, Arc<dyn OutboundAdapter>>`, wrap in `Arc<tokio::sync::Mutex<...>>`, call `svc.set_outbounds()` on each `JycAgentService`.
**Why:** Monitor is the initialization orchestrator — same pattern as existing thread_managers wiring.
**Verify:** `cargo check -p jyc-cli` — compiles.

### Step 10: Update system prompt
**What:** `crates/jyc-agent/src/service.rs` — extend "Cross-Thread Communication" section to list channels supporting direct outbound messaging and explain `send_to_thread` (agent processes) vs `send_message` with `channel` (direct, no agent).
**Why:** Agent needs channel type info to correctly select between tools.
**Verify:** `cargo check -p jyc-agent` — compiles.

### Step 11: Full test suite
**What:** `cargo test --workspace`, `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`.
**Verify:** All commands pass with zero errors.

## Design Decisions
- **New trait method with default error impl** — no breaking changes, channels opt in
- **Three channels implement (email/feishu/wecom_bot), five inherit error** — all reuse existing upload logic
- **SmtpClient: extract private `build_email()` helper** — zero duplication, `send_reply` refactored to use it
- **`outbounds` map mirrors `thread_managers` pattern** — same types, same wiring
- **`channel` is optional** — omitting preserves exact existing behavior
- **Attachment validation reuses canonical-prefix pattern** — same security as `ReplyMessageTool`
