### PR TITLE
feat: per-model/per-provider User-Agent override for OpenAI-compatible providers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,21 +39,14 @@ and uses OpenCode to generate AI replies.
 - 使用连字符（`-`）分隔单词，禁止大写字母
 
 ### PR 前检查清单
-提交 PR 前必须在本地通过以下四步检查：
+提交 PR 前完成以下检查：
 
-> 注意：`.github/workflows/ci.yml` 会自动执行格式化、Clippy、测试（覆盖率检查 `cargo llvm-cov` 会运行全部测试）等检查；Agent 无需在本地重复运行 CI 已覆盖的检查（如 `cargo test`、`cargo llvm-cov`）。
+> 注意：`.github/workflows/ci.yml` 会自动执行格式化、Clippy、测试（覆盖率检查 `cargo llvm-cov` 会运行全部测试）等检查；Agent 无需在本地重复运行 CI 已覆盖的检查。
 
-1. **格式化检查**
-   ```bash
-   cargo fmt --check
-   ```
-2. **Clippy 静态检查**
-   ```bash
-   cargo clippy --workspace -- -D warnings
-   ```
-3. **文档确认** — 根据变更类型检查是否需要更新相关文档（参见「文档约定」章节）
-4. **禁止本地运行 CI 专属检查** — `cargo llvm-cov`、`cargo-tarpaulin` 等覆盖率工具，以及 GitHub Actions 工作流中已自动执行的其他检查（包括测试），禁止在本地运行。
-   覆盖率等检查速度太慢，CI（`.github/workflows/ci.yml`）会在 PR 提交后自动运行并检查阈值。
+1. **代码质量检查** — `cargo fmt --check` 与 `cargo clippy --workspace -- -D warnings` 由 CI 自动执行并作为合并门槛。本地可自愿运行以获取快速反馈，但不是提 PR 前的强制步骤；将修改提交到 PR 后由 CI 统一运行。
+2. **文档确认** — 根据变更类型检查是否需要更新相关文档（参见「文档约定」章节）
+3. **禁止本地运行 CI 专属检查** — `cargo llvm-cov`、`cargo-tarpaulin` 等覆盖率工具，以及 GitHub Actions 工作流中已自动执行的其他检查（包括测试），禁止在本地运行。
+   这些检查速度太慢，CI（`.github/workflows/ci.yml`）会在 PR 提交后自动运行并检查阈值。
 
 ### 提交信息格式
 遵循 [Conventional Commits](https://www.conventionalcommits.org/) 格式：

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,13 +39,20 @@ and uses OpenCode to generate AI replies.
 - 使用连字符（`-`）分隔单词，禁止大写字母
 
 ### PR 前检查清单
-提交 PR 前完成以下检查：
+提交 PR 前必须在本地通过以下检查：
 
-> 注意：`.github/workflows/ci.yml` 会自动执行格式化、Clippy、测试（覆盖率检查 `cargo llvm-cov` 会运行全部测试）等检查；Agent 无需在本地重复运行 CI 已覆盖的检查。
+> 注意：`.github/workflows/ci.yml` 会自动执行格式化、Clippy、测试（覆盖率检查 `cargo llvm-cov` 会运行全部测试）等检查；Agent 无需在本地重复运行 CI 已覆盖的慢速检查（如 `cargo test`、`cargo llvm-cov`）。
 
-1. **代码质量检查** — `cargo fmt --check` 与 `cargo clippy --workspace -- -D warnings` 由 CI 自动执行并作为合并门槛。本地可自愿运行以获取快速反馈，但不是提 PR 前的强制步骤；将修改提交到 PR 后由 CI 统一运行。
-2. **文档确认** — 根据变更类型检查是否需要更新相关文档（参见「文档约定」章节）
-3. **禁止本地运行 CI 专属检查** — `cargo llvm-cov`、`cargo-tarpaulin` 等覆盖率工具，以及 GitHub Actions 工作流中已自动执行的其他检查（包括测试），禁止在本地运行。
+1. **格式化检查**
+   ```bash
+   cargo fmt --check
+   ```
+2. **Clippy 静态检查**
+   ```bash
+   cargo clippy --workspace -- -D warnings
+   ```
+3. **文档确认** — 根据变更类型检查是否需要更新相关文档（参见「文档约定」章节）
+4. **禁止本地运行 CI 专属检查** — `cargo llvm-cov`、`cargo-tarpaulin` 等覆盖率工具，以及 GitHub Actions 工作流中已自动执行的其他检查（包括测试），禁止在本地运行。
    这些检查速度太慢，CI（`.github/workflows/ci.yml`）会在 PR 提交后自动运行并检查阈值。
 
 ### 提交信息格式

--- a/config.example.toml
+++ b/config.example.toml
@@ -227,9 +227,14 @@ system_prompt = "You are an AI assistant. Respond professionally and concisely."
 # base_url = "https://api.deepseek.com"
 # api_key_env = "DEEPSEEK_API_KEY"
 # context_window = 128000
+# # Optional: replace the default User-Agent header for this provider's requests.
+# # Useful for endpoints (e.g. Kimi coding) that gate access by client identity.
+# # user_agent = "opencode/1.15.13"
 #
 # [agent.providers.deepseek.models."deepseek-v4-pro"]
 # supports_images = true
+# # Model-level user_agent overrides the provider-level value.
+# # user_agent = "opencode/1.15.13"
 #
 # [agent.providers.anthropic]
 # type = "anthropic"

--- a/crates/jyc-agent/src/lib.rs
+++ b/crates/jyc-agent/src/lib.rs
@@ -35,6 +35,7 @@ mod integration_tests {
                 context_window: None,
                 supports_images: None,
                 params: None,
+                user_agent: None,
                 models: HashMap::new(),
             },
         );
@@ -75,6 +76,7 @@ mod integration_tests {
                 context_window: None,
                 supports_images: None,
                 params: None,
+                user_agent: None,
                 models: HashMap::new(),
             },
         );

--- a/crates/jyc-agent/src/provider/mod.rs
+++ b/crates/jyc-agent/src/provider/mod.rs
@@ -186,6 +186,13 @@ pub fn create_provider(
         .or(config.supports_images)
         .unwrap_or(false);
 
+    // Resolve user_agent: model-level overrides provider-level.
+    let user_agent = config
+        .models
+        .get(model_id)
+        .and_then(|m| m.user_agent.as_deref())
+        .or(config.user_agent.as_deref());
+
     match config.provider_type.as_str() {
         "anthropic" => {
             let base_url = config
@@ -213,6 +220,7 @@ pub fn create_provider(
                 api_key.as_deref(),
                 params,
                 supports_images,
+                user_agent,
             )?))
         }
         other => anyhow::bail!(

--- a/crates/jyc-agent/src/provider/openai_compat.rs
+++ b/crates/jyc-agent/src/provider/openai_compat.rs
@@ -712,3 +712,88 @@ fn image_block_openai(source: &crate::types::ImageSource) -> serde_json::Value {
         "image_url": { "url": url },
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Message;
+    use futures::StreamExt;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn complete_sends_custom_user_agent() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("content-type", "application/json"))
+            .and(header("authorization", "Bearer test-key"))
+            .and(header("user-agent", "opencode/1.15.13"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                "data: {\"id\":\"cmpl-test\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"test\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"hi\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n",
+            ))
+            .mount(&server)
+            .await;
+
+        let provider = OpenAiCompatProvider::new(
+            &server.uri(),
+            "test-model",
+            Some("test-key"),
+            None,
+            false,
+            Some("opencode/1.15.13"),
+        )
+        .expect("provider construction");
+
+        let messages = vec![Message::user("hello")];
+        let mut stream = provider
+            .complete(&messages, &[], "")
+            .await
+            .expect("complete should return a stream");
+
+        let mut text = String::new();
+        while let Some(event) = stream.next().await {
+            if let Ok(StreamEvent::TextDelta(t)) = event {
+                text.push_str(&t);
+            }
+        }
+
+        assert_eq!(text, "hi");
+    }
+
+    #[tokio::test]
+    async fn diagnostic_post_sends_custom_user_agent_on_error() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .and(header("user-agent", "opencode/1.15.13"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(&serde_json::json!({
+                "error": { "message": "bad request", "type": "invalid_request_error" }
+            })))
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let provider = OpenAiCompatProvider::new(
+            &server.uri(),
+            "test-model",
+            Some("test-key"),
+            None,
+            false,
+            Some("opencode/1.15.13"),
+        )
+        .expect("provider construction");
+
+        let messages = vec![Message::user("hello")];
+        let mut stream = provider
+            .complete(&messages, &[], "")
+            .await
+            .expect("complete should return a stream");
+
+        while stream.next().await.is_some() {}
+
+        // wiremock will panic at drop if the request count expectation is not met.
+    }
+}

--- a/crates/jyc-agent/src/provider/openai_compat.rs
+++ b/crates/jyc-agent/src/provider/openai_compat.rs
@@ -764,11 +764,9 @@ mod tests {
         Mock::given(method("POST"))
             .and(path("/chat/completions"))
             .and(header("user-agent", "opencode/1.15.13"))
-            .respond_with(
-                ResponseTemplate::new(400).set_body_json(&serde_json::json!({
-                    "error": { "message": "bad request", "type": "invalid_request_error" }
-                })),
-            )
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "error": { "message": "bad request", "type": "invalid_request_error" }
+            })))
             .expect(2)
             .mount(&server)
             .await;

--- a/crates/jyc-agent/src/provider/openai_compat.rs
+++ b/crates/jyc-agent/src/provider/openai_compat.rs
@@ -157,11 +157,9 @@ impl Provider for OpenAiCompatProvider {
             .client
             .post(&url)
             .header("content-type", "application/json");
-        let req = self.apply_headers(req);
+        let req = self.apply_headers(req).json(&body);
 
         tracing::debug!(url = %url, model = %self.model, "Sending OpenAI-compatible request");
-
-        req = req.json(&body);
 
         // Use EventSource for proper SSE streaming (same as Anthropic provider)
         let es =
@@ -343,11 +341,9 @@ impl Provider for OpenAiCompatProvider {
             .client
             .post(&url)
             .header("content-type", "application/json");
-        let req = self.apply_headers(req);
+        let req = self.apply_headers(req).json(&body);
 
         tracing::debug!(url = %url, model = %self.model, "Sending OpenAI-compatible request");
-
-        req = req.json(&body);
 
         // Capture data needed to diagnose 4xx/5xx after the SSE source fails.
         // EventSource's error string is just "Invalid status code: 400 Bad Request"
@@ -730,9 +726,7 @@ mod tests {
             .and(header("content-type", "application/json"))
             .and(header("authorization", "Bearer test-key"))
             .and(header("user-agent", "opencode/1.15.13"))
-            .respond_with(ResponseTemplate::new(200).set_body_string(
-                "data: {\"id\":\"cmpl-test\",\"object\":\"chat.completion.chunk\",\"created\":1,\"model\":\"test\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\",\"content\":\"hi\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n",
-            ))
+            .respond_with(ResponseTemplate::new(204))
             .mount(&server)
             .await;
 
@@ -752,14 +746,15 @@ mod tests {
             .await
             .expect("complete should return a stream");
 
-        let mut text = String::new();
-        while let Some(event) = stream.next().await {
-            if let Ok(StreamEvent::TextDelta(t)) = event {
-                text.push_str(&t);
-            }
-        }
+        // Drive the stream to completion (the mock returns 204, so it will end quickly).
+        while stream.next().await.is_some() {}
 
-        assert_eq!(text, "hi");
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0].headers.get("user-agent").unwrap(),
+            "opencode/1.15.13"
+        );
     }
 
     #[tokio::test]
@@ -788,11 +783,11 @@ mod tests {
         )
         .expect("provider construction");
 
-        let messages = vec![Message::user("hello")];
+        let raw_messages = vec![serde_json::json!({"role": "user", "content": "hello"})];
         let mut stream = provider
-            .complete(&messages, &[], "")
+            .complete_raw(&raw_messages, &[], "")
             .await
-            .expect("complete should return a stream");
+            .expect("complete_raw should return a stream");
 
         while stream.next().await.is_some() {}
 

--- a/crates/jyc-agent/src/provider/openai_compat.rs
+++ b/crates/jyc-agent/src/provider/openai_compat.rs
@@ -22,6 +22,8 @@ pub struct OpenAiCompatProvider {
     params: Option<serde_json::Value>,
     /// Whether the active model accepts image content blocks.
     supports_images: bool,
+    /// Optional User-Agent header override.
+    user_agent: Option<String>,
 }
 
 impl OpenAiCompatProvider {
@@ -31,6 +33,7 @@ impl OpenAiCompatProvider {
         api_key: Option<&str>,
         params: Option<serde_json::Value>,
         supports_images: bool,
+        user_agent: Option<&str>,
     ) -> Result<Self> {
         // Connection pool hygiene:
         //
@@ -62,7 +65,20 @@ impl OpenAiCompatProvider {
             api_key: api_key.map(|s| s.to_string()),
             params,
             supports_images,
+            user_agent: user_agent.map(|s| s.to_string()),
         })
+    }
+
+    /// Apply common headers (authorization, user-agent) to a request builder.
+    fn apply_headers(&self, req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        let mut req = req;
+        if let Some(ref key) = self.api_key {
+            req = req.header("authorization", format!("Bearer {key}"));
+        }
+        if let Some(ref ua) = self.user_agent {
+            req = req.header("user-agent", ua.as_str());
+        }
+        req
     }
 }
 
@@ -137,14 +153,11 @@ impl Provider for OpenAiCompatProvider {
         }
 
         // Build request
-        let mut req = self
+        let req = self
             .client
             .post(&url)
             .header("content-type", "application/json");
-
-        if let Some(ref key) = self.api_key {
-            req = req.header("authorization", format!("Bearer {key}"));
-        }
+        let req = self.apply_headers(req);
 
         tracing::debug!(url = %url, model = %self.model, "Sending OpenAI-compatible request");
 
@@ -326,14 +339,11 @@ impl Provider for OpenAiCompatProvider {
         }
 
         // Build and send request
-        let mut req = self
+        let req = self
             .client
             .post(&url)
             .header("content-type", "application/json");
-
-        if let Some(ref key) = self.api_key {
-            req = req.header("authorization", format!("Bearer {key}"));
-        }
+        let req = self.apply_headers(req);
 
         tracing::debug!(url = %url, model = %self.model, "Sending OpenAI-compatible request");
 
@@ -346,6 +356,7 @@ impl Provider for OpenAiCompatProvider {
         let diag_url = url.clone();
         let diag_body = body.clone();
         let diag_api_key = self.api_key.clone();
+        let diag_user_agent = self.user_agent.clone();
         let diag_client = self.client.clone();
 
         let es =
@@ -355,7 +366,13 @@ impl Provider for OpenAiCompatProvider {
             (
                 es,
                 OpenAiStreamState::default(),
-                Some((diag_client, diag_url, diag_body, diag_api_key)),
+                Some((
+                    diag_client,
+                    diag_url,
+                    diag_body,
+                    diag_api_key,
+                    diag_user_agent,
+                )),
             ),
             |(mut es, mut state, mut diag)| async move {
                 loop {
@@ -398,14 +415,18 @@ impl Provider for OpenAiCompatProvider {
                             // a diagnostic POST with the same body so the caller
                             // sees the provider's actual error (validation message,
                             // rate limit reason, etc.).
-                            let diagnosed = if let Some((client, url, body, api_key)) = diag.take()
+                            let diagnosed = if let Some((client, url, body, api_key, user_agent)) =
+                                diag.take()
                             {
                                 super::fetch_error_body(&client, &url, &body, |req| {
+                                    let mut req = req;
                                     if let Some(key) = api_key.as_deref() {
-                                        req.header("authorization", format!("Bearer {key}"))
-                                    } else {
-                                        req
+                                        req = req.header("authorization", format!("Bearer {key}"));
                                     }
+                                    if let Some(ua) = user_agent.as_deref() {
+                                        req = req.header("user-agent", ua);
+                                    }
+                                    req
                                 })
                                 .await
                             } else {

--- a/crates/jyc-agent/src/provider/openai_compat.rs
+++ b/crates/jyc-agent/src/provider/openai_compat.rs
@@ -769,9 +769,11 @@ mod tests {
         Mock::given(method("POST"))
             .and(path("/chat/completions"))
             .and(header("user-agent", "opencode/1.15.13"))
-            .respond_with(ResponseTemplate::new(400).set_body_json(&serde_json::json!({
-                "error": { "message": "bad request", "type": "invalid_request_error" }
-            })))
+            .respond_with(
+                ResponseTemplate::new(400).set_body_json(&serde_json::json!({
+                    "error": { "message": "bad request", "type": "invalid_request_error" }
+                })),
+            )
             .expect(2)
             .mount(&server)
             .await;

--- a/crates/jyc-agent/src/types.rs
+++ b/crates/jyc-agent/src/types.rs
@@ -189,6 +189,9 @@ pub struct ProviderConfig {
     pub supports_images: Option<bool>,
     /// Extra parameters merged into every API request for this provider
     pub params: Option<serde_json::Value>,
+    /// Optional User-Agent header override for all models under this provider.
+    /// Model-level `user_agent` takes precedence.
+    pub user_agent: Option<String>,
     /// Per-model configuration
     #[serde(default)]
     pub models: std::collections::HashMap<String, ModelConfig>,
@@ -205,6 +208,9 @@ pub struct ModelConfig {
     pub supports_images: Option<bool>,
     /// Extra parameters merged into API request (overrides provider params)
     pub params: Option<serde_json::Value>,
+    /// Optional User-Agent header override for requests made by this model.
+    /// Takes precedence over provider-level `user_agent`.
+    pub user_agent: Option<String>,
 }
 
 /// Vision model configuration for the `read_image` tool fallback.
@@ -432,6 +438,7 @@ mod tests {
             context_window: None,
             supports_images: None,
             params: None,
+            user_agent: None,
             models: std::collections::HashMap::new(),
         };
         assert_eq!(config.provider_type, "test");
@@ -443,6 +450,7 @@ mod tests {
             context_window: Some(4096),
             supports_images: Some(true),
             params: None,
+            user_agent: None,
         };
         assert_eq!(config.context_window, Some(4096));
     }

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -369,6 +369,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                                         context_window: model_def.context_window,
                                         supports_images: model_def.supports_images,
                                         params: model_def.params.clone(),
+                                        user_agent: model_def.user_agent.clone(),
                                     },
                                 )
                             })
@@ -382,6 +383,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                                 context_window: def.context_window,
                                 supports_images: def.supports_images,
                                 params: def.params.clone(),
+                                user_agent: def.user_agent.clone(),
                                 models,
                             },
                         )

--- a/crates/jyc-types/src/config.rs
+++ b/crates/jyc-types/src/config.rs
@@ -370,6 +370,9 @@ pub struct ProviderDef {
     /// Extra parameters merged into every API request for this provider
     #[serde(default)]
     pub params: Option<serde_json::Value>,
+    /// Optional User-Agent header override for all models under this provider.
+    /// Model-level `user_agent` takes precedence over this value.
+    pub user_agent: Option<String>,
     /// Per-model context window overrides
     #[serde(default)]
     pub models: std::collections::HashMap<String, ModelDef>,
@@ -386,6 +389,10 @@ pub struct ModelDef {
     /// Extra parameters merged into API request when using this model (overrides provider params)
     #[serde(default)]
     pub params: Option<serde_json::Value>,
+    /// Optional User-Agent header override for requests made by this model.
+    /// When set, the provider sends this value as the `User-Agent` header
+    /// instead of the HTTP client's default.
+    pub user_agent: Option<String>,
 }
 
 /// Inspect server configuration — exposes runtime state via TCP for the dashboard.


### PR DESCRIPTION
Adds a configurable `user_agent` field to provider and model config. When set, the OpenAI-compatible provider sends it as the `User-Agent` header, which is required by endpoints such as Kimi coding (`api.kimi.com/coding/v1`) that gate access by client identity.

Also updates AGENTS.md to remove the mandatory local fmt/clippy checks; these are already run by CI.