### PR TITLE
fix: GLM-5.2 tool call arguments lost due to LIFO event draining

### DIFF
--- a/crates/jyc-agent/src/agent_loop.rs
+++ b/crates/jyc-agent/src/agent_loop.rs
@@ -129,6 +129,14 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
     let mut cycle_count: usize = 0;
     let mut total_iterations: usize = 0;
 
+    // Guardrail: some providers (e.g., GLM-5.2 via Ark) intermittently
+    // generate tool calls with empty arguments, causing every tool to fail
+    // with "Missing parameter". The model does not self-correct, leading to
+    // an infinite loop. Track consecutive iterations where ALL tool calls
+    // had empty arguments; abort after the threshold to avoid wasting tokens.
+    const MAX_EMPTY_TOOL_CALL_ITERATIONS: u32 = 3;
+    let mut consecutive_empty_tool_iterations: u32 = 0;
+
     // Publish ProcessingStarted
     publish_event(
         event_bus,
@@ -347,6 +355,29 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
                 history,
                 raw_context,
             });
+        }
+
+        // 5b. Guardrail: detect models that repeatedly generate tool calls
+        //     with empty arguments. If ALL tool calls in this iteration have
+        //     empty arguments (empty string or "{}"), increment a counter.
+        //     After MAX_EMPTY_TOOL_CALL_ITERATIONS consecutive occurrences,
+        //     abort the loop to avoid wasting tokens.
+        if all_tool_calls_empty(&response.tool_calls) {
+            consecutive_empty_tool_iterations += 1;
+            if consecutive_empty_tool_iterations >= MAX_EMPTY_TOOL_CALL_ITERATIONS {
+                tracing::warn!(
+                    consecutive = consecutive_empty_tool_iterations,
+                    "Model repeatedly generated tool calls with empty arguments, aborting loop"
+                );
+                anyhow::bail!(
+                    "model generated tool calls with empty arguments for {} consecutive \
+                     iterations — this usually indicates the provider does not support \
+                     function calling correctly",
+                    consecutive_empty_tool_iterations
+                );
+            }
+        } else {
+            consecutive_empty_tool_iterations = 0;
         }
 
         // 6. Execute tool calls
@@ -712,6 +743,16 @@ struct ToolCall {
     arguments: String,
 }
 
+/// Check if all tool calls have empty arguments (empty string, whitespace-only,
+/// or `{}`). Used by the guardrail to detect models that generate tool calls
+/// without proper arguments. Returns `false` for an empty slice.
+fn all_tool_calls_empty(tool_calls: &[ToolCall]) -> bool {
+    !tool_calls.is_empty()
+        && tool_calls
+            .iter()
+            .all(|tc| tc.arguments.trim().is_empty() || tc.arguments.trim() == "{}")
+}
+
 /// Collected response from streaming.
 #[derive(Debug, Default)]
 struct CollectedResponse {
@@ -866,9 +907,21 @@ async fn collect_response(stream: crate::provider::EventStream) -> Result<Collec
                 response.reasoning_content.push_str(&text);
             }
             StreamEvent::ToolUseStart { id, name } => {
+                // Flush previous tool call if one is in progress.
+                // This handles providers that send multiple tool calls in a
+                // single response — the next ToolUseStart arrives before the
+                // previous ToolUseEnd, so we must save the previous call now.
+                if let (Some(prev_id), Some(prev_name)) =
+                    (current_tool_id.take(), current_tool_name.take())
+                {
+                    response.tool_calls.push(ToolCall {
+                        id: prev_id,
+                        name: prev_name,
+                        arguments: std::mem::take(&mut current_tool_args),
+                    });
+                }
                 current_tool_id = Some(id);
                 current_tool_name = Some(name);
-                current_tool_args.clear();
             }
             StreamEvent::ToolInputDelta(delta) => {
                 current_tool_args.push_str(&delta);
@@ -1225,5 +1278,53 @@ mod retry_tests {
             vec![Some(2), Some(3)],
             "expected retry events for attempts 2 and 3"
         );
+    }
+}
+
+#[cfg(test)]
+mod guardrail_tests {
+    use super::*;
+
+    fn tc(id: &str, name: &str, args: &str) -> ToolCall {
+        ToolCall {
+            id: id.to_string(),
+            name: name.to_string(),
+            arguments: args.to_string(),
+        }
+    }
+
+    #[test]
+    fn empty_string_args_detected() {
+        assert!(all_tool_calls_empty(&[tc("1", "bash", "")]));
+    }
+
+    #[test]
+    fn empty_object_args_detected() {
+        assert!(all_tool_calls_empty(&[tc("1", "bash", "{}")]));
+    }
+
+    #[test]
+    fn whitespace_only_args_detected() {
+        assert!(all_tool_calls_empty(&[tc("1", "bash", "  ")]));
+    }
+
+    #[test]
+    fn non_empty_args_not_detected() {
+        assert!(!all_tool_calls_empty(&[tc(
+            "1",
+            "bash",
+            r#"{"command":"ls"}"#
+        )]));
+    }
+
+    #[test]
+    fn mixed_args_not_all_empty() {
+        let calls = [tc("1", "bash", ""), tc("2", "read", r#"{"file_path":"x"}"#)];
+        assert!(!all_tool_calls_empty(&calls));
+    }
+
+    #[test]
+    fn empty_slice_not_detected() {
+        assert!(!all_tool_calls_empty(&[]));
     }
 }

--- a/crates/jyc-agent/src/provider/openai_compat.rs
+++ b/crates/jyc-agent/src/provider/openai_compat.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use reqwest_eventsource::{Event, EventSource};
 use serde_json;
+use std::collections::VecDeque;
 
 use crate::provider::{EventStream, Provider};
 use crate::types::{ContentBlock, Message, Role, StreamEvent, ToolDefinition};
@@ -170,8 +171,8 @@ impl Provider for OpenAiCompatProvider {
             (es, OpenAiStreamState::default()),
             |(mut es, mut state)| async move {
                 loop {
-                    // Drain buffered events first
-                    if let Some(event) = state.pending_events.pop() {
+                    // Drain buffered events first (FIFO)
+                    if let Some(event) = state.pending_events.pop_front() {
                         return Some((Ok(event), (es, state)));
                     }
 
@@ -181,8 +182,8 @@ impl Provider for OpenAiCompatProvider {
                             let data = &msg.data;
 
                             if data.trim() == "[DONE]" {
-                                state.pending_events.push(StreamEvent::Done);
-                                if let Some(event) = state.pending_events.pop() {
+                                state.pending_events.push_back(StreamEvent::Done);
+                                if let Some(event) = state.pending_events.pop_front() {
                                     return Some((Ok(event), (es, state)));
                                 }
                                 return None;
@@ -192,7 +193,7 @@ impl Provider for OpenAiCompatProvider {
                                 state.pending_events.extend(events);
                             }
 
-                            if let Some(event) = state.pending_events.pop() {
+                            if let Some(event) = state.pending_events.pop_front() {
                                 return Some((Ok(event), (es, state)));
                             }
                             // No events from this chunk (e.g., reasoning_content only), continue
@@ -201,7 +202,7 @@ impl Provider for OpenAiCompatProvider {
                             let err_msg = format!("{e}");
                             if err_msg.contains("Stream ended") {
                                 // Drain remaining events
-                                if let Some(event) = state.pending_events.pop() {
+                                if let Some(event) = state.pending_events.pop_front() {
                                     return Some((Ok(event), (es, state)));
                                 }
                                 return None;
@@ -213,7 +214,7 @@ impl Provider for OpenAiCompatProvider {
                         }
                         None => {
                             // Drain remaining events
-                            if let Some(event) = state.pending_events.pop() {
+                            if let Some(event) = state.pending_events.pop_front() {
                                 return Some((Ok(event), (es, state)));
                             }
                             return None;
@@ -372,7 +373,7 @@ impl Provider for OpenAiCompatProvider {
             ),
             |(mut es, mut state, mut diag)| async move {
                 loop {
-                    if let Some(event) = state.pending_events.pop() {
+                    if let Some(event) = state.pending_events.pop_front() {
                         return Some((Ok(event), (es, state, diag)));
                     }
 
@@ -386,8 +387,8 @@ impl Provider for OpenAiCompatProvider {
                         Some(Ok(Event::Message(msg))) => {
                             let data = &msg.data;
                             if data.trim() == "[DONE]" {
-                                state.pending_events.push(StreamEvent::Done);
-                                if let Some(event) = state.pending_events.pop() {
+                                state.pending_events.push_back(StreamEvent::Done);
+                                if let Some(event) = state.pending_events.pop_front() {
                                     return Some((Ok(event), (es, state, diag)));
                                 }
                                 return None;
@@ -395,14 +396,14 @@ impl Provider for OpenAiCompatProvider {
                             if let Some(events) = parse_openai_chunk(data, &mut state) {
                                 state.pending_events.extend(events);
                             }
-                            if let Some(event) = state.pending_events.pop() {
+                            if let Some(event) = state.pending_events.pop_front() {
                                 return Some((Ok(event), (es, state, diag)));
                             }
                         }
                         Some(Err(e)) => {
                             let err_msg = format!("{e}");
                             if err_msg.contains("Stream ended") {
-                                if let Some(event) = state.pending_events.pop() {
+                                if let Some(event) = state.pending_events.pop_front() {
                                     return Some((Ok(event), (es, state, diag)));
                                 }
                                 return None;
@@ -437,7 +438,7 @@ impl Provider for OpenAiCompatProvider {
                             return Some((Err(anyhow::anyhow!(final_msg)), (es, state, diag)));
                         }
                         None => {
-                            if let Some(event) = state.pending_events.pop() {
+                            if let Some(event) = state.pending_events.pop_front() {
                                 return Some((Ok(event), (es, state, diag)));
                             }
                             return None;
@@ -456,8 +457,8 @@ impl Provider for OpenAiCompatProvider {
 struct OpenAiStreamState {
     /// Tool calls being assembled from deltas.
     tool_calls: Vec<ToolCallAccumulator>,
-    /// Events ready to be yielded.
-    pending_events: Vec<StreamEvent>,
+    /// Events ready to be yielded (FIFO queue).
+    pending_events: VecDeque<StreamEvent>,
 }
 
 #[derive(Default, Clone)]
@@ -515,6 +516,10 @@ fn parse_openai_chunk(data: &str, state: &mut OpenAiStreamState) -> Option<Vec<S
 
         // Tool calls
         if let Some(tool_calls) = delta.get("tool_calls").and_then(|t| t.as_array()) {
+            tracing::trace!(
+                tool_calls_json = %serde_json::to_string(tool_calls).unwrap_or_default(),
+                "SSE chunk contains tool_calls"
+            );
             for tc in tool_calls {
                 let index = tc.get("index").and_then(|i| i.as_u64()).unwrap_or(0) as usize;
 
@@ -535,9 +540,28 @@ fn parse_openai_chunk(data: &str, state: &mut OpenAiStreamState) -> Option<Vec<S
                     if let Some(name) = function.get("name").and_then(|n| n.as_str()) {
                         acc.name = name.to_string();
                     }
-                    if let Some(args) = function.get("arguments").and_then(|a| a.as_str()) {
-                        acc.arguments.push_str(args);
-                        events.push(StreamEvent::ToolInputDelta(args.to_string()));
+                    // Arguments: standard OpenAI sends a string (possibly
+                    // chunked across deltas); some providers (e.g., GLM-5.2
+                    // via Ark) send a JSON object directly. Handle both.
+                    if let Some(args_val) = function.get("arguments") {
+                        match args_val {
+                            serde_json::Value::String(s) => {
+                                acc.arguments.push_str(s);
+                                events.push(StreamEvent::ToolInputDelta(s.to_string()));
+                            }
+                            serde_json::Value::Object(_) => {
+                                let serialized =
+                                    serde_json::to_string(args_val).unwrap_or_default();
+                                acc.arguments.push_str(&serialized);
+                                events.push(StreamEvent::ToolInputDelta(serialized));
+                            }
+                            _ => {
+                                tracing::trace!(
+                                    args_value = %args_val,
+                                    "Unexpected arguments type in tool_calls delta"
+                                );
+                            }
+                        }
                     }
                 }
 
@@ -790,5 +814,100 @@ mod tests {
         while stream.next().await.is_some() {}
 
         // wiremock will panic at drop if the request count expectation is not met.
+    }
+
+    #[test]
+    fn parse_tool_call_string_arguments() {
+        let mut state = OpenAiStreamState::default();
+        let chunk = serde_json::json!({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_1",
+                        "function": {
+                            "name": "bash",
+                            "arguments": "{\"command\":\"ls\"}"
+                        }
+                    }]
+                }
+            }]
+        })
+        .to_string();
+        let events = parse_openai_chunk(&chunk, &mut state).expect("should parse");
+
+        assert!(!events.is_empty());
+        assert_eq!(state.tool_calls.len(), 1);
+        assert_eq!(state.tool_calls[0].name, "bash");
+        assert_eq!(state.tool_calls[0].arguments, r#"{"command":"ls"}"#);
+    }
+
+    #[test]
+    fn parse_tool_call_object_arguments() {
+        // GLM-5.2 via Ark sends arguments as a JSON object, not a string.
+        let mut state = OpenAiStreamState::default();
+        let chunk = serde_json::json!({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_1",
+                        "function": {
+                            "name": "bash",
+                            "arguments": {"command": "ls"}
+                        }
+                    }]
+                }
+            }]
+        })
+        .to_string();
+        let events = parse_openai_chunk(&chunk, &mut state).expect("should parse");
+
+        assert!(!events.is_empty());
+        assert_eq!(state.tool_calls.len(), 1);
+        assert_eq!(state.tool_calls[0].name, "bash");
+        assert_eq!(state.tool_calls[0].arguments, r#"{"command":"ls"}"#);
+    }
+
+    #[test]
+    fn parse_tool_call_chunked_string_arguments() {
+        // Standard OpenAI streaming: arguments arrive as string fragments
+        // across multiple SSE chunks and must be accumulated.
+        let mut state = OpenAiStreamState::default();
+
+        let chunk1 = serde_json::json!({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "id": "call_1",
+                        "function": {
+                            "name": "bash",
+                            "arguments": "{\"comm"
+                        }
+                    }]
+                }
+            }]
+        })
+        .to_string();
+        parse_openai_chunk(&chunk1, &mut state);
+
+        let chunk2 = serde_json::json!({
+            "choices": [{
+                "delta": {
+                    "tool_calls": [{
+                        "index": 0,
+                        "function": {
+                            "arguments": "and\":\"ls\"}"
+                        }
+                    }]
+                }
+            }]
+        })
+        .to_string();
+        parse_openai_chunk(&chunk2, &mut state);
+
+        assert_eq!(state.tool_calls.len(), 1);
+        assert_eq!(state.tool_calls[0].arguments, r#"{"command":"ls"}"#);
     }
 }

--- a/crates/jyc-agent/src/tools/builtin/bash.rs
+++ b/crates/jyc-agent/src/tools/builtin/bash.rs
@@ -73,18 +73,19 @@ impl Tool for BashTool {
         // Best-effort boundary check: scan for absolute-path tokens and
         // verify each is within the working directory. This catches obvious
         // escape attempts (cat /etc/passwd) without fully sandboxing bash.
-        for token in command.split_whitespace() {
-            if token.starts_with('/') {
-                let candidate = std::path::Path::new(token);
-                // Only check tokens that start with `/` and correspond to
-                // existing filesystem paths. This catches obvious escape
-                // attempts (e.g. `cat /etc/passwd`) while allowing flags
-                // like `-C` and commands that shell out to relative paths.
-                if candidate.exists()
-                    && let Err(msg) = ctx.check_path_boundary(token, candidate)
-                {
-                    return Ok(ToolOutput::error(msg));
-                }
+        //
+        // Only tokens OUTSIDE of quoted strings are checked. This avoids
+        // false positives on path-like substrings inside data arguments
+        // (e.g., `//` in a markdown comment passed via `--body "..."`).
+        for token in unquoted_path_tokens(command) {
+            let candidate = std::path::Path::new(&token);
+            // Only check tokens that correspond to existing filesystem
+            // paths. This catches obvious escape attempts (e.g.
+            // `cat /etc/passwd`) while allowing flags like `-C`.
+            if candidate.exists()
+                && let Err(msg) = ctx.check_path_boundary(&token, candidate)
+            {
+                return Ok(ToolOutput::error(msg));
             }
         }
 
@@ -149,5 +150,169 @@ impl Tool for BashTool {
                 timeout_secs
             ))),
         }
+    }
+}
+
+/// Extract absolute-path tokens (starting with `/`) from the **unquoted**
+/// portions of a bash command string.
+///
+/// Bash quoting rules handled:
+/// - Single quotes `'...'`: everything inside is literal; the closing `'`
+///   is the next `'` character.
+/// - Double quotes `"..."`: everything inside is literal except `\"`
+///   (escaped quote) which does not close the string.
+/// - Backslash outside quotes: escapes the next character (e.g., `\"`
+///   produces a literal `"` without opening a quoted region).
+///
+/// Tokens inside quotes are **skipped** to avoid false positives on
+/// path-like substrings in data arguments (e.g., `//` in a markdown
+/// comment passed via `--body "..."`).
+fn unquoted_path_tokens(command: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut chars = command.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if in_single {
+            // Inside single quotes: only `'` ends the region.
+            if ch == '\'' {
+                in_single = false;
+            }
+            continue;
+        }
+        if in_double {
+            // Inside double quotes: `\"` is an escaped quote, everything
+            // else (including `\`) is literal until the closing `"`.
+            if ch == '\\' {
+                chars.next(); // skip escaped char
+                continue;
+            }
+            if ch == '"' {
+                in_double = false;
+            }
+            continue;
+        }
+        // Outside quotes
+        match ch {
+            '\'' => {
+                // Flush current token before entering single-quote region
+                if !current.is_empty() {
+                    if current.starts_with('/') {
+                        tokens.push(std::mem::take(&mut current));
+                    } else {
+                        current.clear();
+                    }
+                }
+                in_single = true;
+            }
+            '"' => {
+                if !current.is_empty() {
+                    if current.starts_with('/') {
+                        tokens.push(std::mem::take(&mut current));
+                    } else {
+                        current.clear();
+                    }
+                }
+                in_double = true;
+            }
+            '\\' => {
+                // Escaped char outside quotes — skip next char
+                chars.next();
+            }
+            c if c.is_whitespace() => {
+                if !current.is_empty() {
+                    if current.starts_with('/') {
+                        tokens.push(std::mem::take(&mut current));
+                    } else {
+                        current.clear();
+                    }
+                }
+            }
+            _ => {
+                current.push(ch);
+            }
+        }
+    }
+    // Flush trailing token
+    if !current.is_empty() && current.starts_with('/') {
+        tokens.push(current);
+    }
+    tokens
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unquoted_absolute_path_detected() {
+        let tokens = unquoted_path_tokens("cat /etc/passwd");
+        assert_eq!(tokens, vec!["/etc/passwd"]);
+    }
+
+    #[test]
+    fn quoted_path_skipped() {
+        // Path inside double quotes should not be extracted
+        let tokens = unquoted_path_tokens(r#"echo "// comment""#);
+        assert!(tokens.is_empty(), "expected no tokens, got {:?}", tokens);
+    }
+
+    #[test]
+    fn single_quoted_path_skipped() {
+        let tokens = unquoted_path_tokens(r#"echo '// comment'"#);
+        assert!(tokens.is_empty(), "expected no tokens, got {:?}", tokens);
+    }
+
+    #[test]
+    fn markdown_body_with_double_slash_skipped() {
+        // Simulates: gh pr comment --body "Review\n\n### // comment\n..."
+        let cmd = r###"gh pr comment 273 --body "## Review\n\n### // comment\n\nDetails here.""###;
+        let tokens = unquoted_path_tokens(cmd);
+        assert!(
+            !tokens.contains(&"//".to_string()),
+            "double-slash inside quotes must not be extracted, got {:?}",
+            tokens
+        );
+    }
+
+    #[test]
+    fn unquoted_path_after_quoted_string_detected() {
+        let tokens = unquoted_path_tokens(r#"echo "hello" /etc/passwd"#);
+        assert_eq!(tokens, vec!["/etc/passwd"]);
+    }
+
+    #[test]
+    fn escaped_quote_outside_does_not_open_region() {
+        // `\"` outside quotes is a literal quote, not a string opener
+        let tokens = unquoted_path_tokens(r#"echo \"hello\" /tmp"#);
+        assert!(tokens.contains(&"/tmp".to_string()), "got {:?}", tokens);
+    }
+
+    #[test]
+    fn escaped_quote_inside_double_quotes() {
+        // `\"` inside double quotes does not close the string
+        let tokens = unquoted_path_tokens(r#"echo "he said \"hi\"" /var/log"#);
+        assert_eq!(tokens, vec!["/var/log"]);
+    }
+
+    #[test]
+    fn multiple_unquoted_paths_detected() {
+        let tokens = unquoted_path_tokens("cp /etc/hosts /tmp/backup");
+        assert_eq!(tokens, vec!["/etc/hosts", "/tmp/backup"]);
+    }
+
+    #[test]
+    fn relative_paths_ignored() {
+        let tokens = unquoted_path_tokens("cd repo && gh issue view 197");
+        assert!(tokens.is_empty());
+    }
+
+    #[test]
+    fn mixed_quoted_and_unquoted() {
+        let cmd = r###"cd repo && gh pr comment 273 --body "see // here" && cat /etc/hostname"###;
+        let tokens = unquoted_path_tokens(cmd);
+        assert_eq!(tokens, vec!["/etc/hostname"]);
     }
 }


### PR DESCRIPTION
## Problem

GLM-5.2 via Ark generates tool calls with valid arguments, but the agent receives empty arguments, causing repeated "Missing 'command' parameter" failures and infinite loops.

## Root Cause

GLM-5.2 sends the complete tool call (name + id + arguments) in a **single SSE chunk**, unlike standard OpenAI streaming (kimi/deepseek) which sends name and arguments across separate chunks. Two bugs caused arguments to be lost:

1. **LIFO event draining** (`openai_compat.rs`): `pending_events` was a `Vec` drained with `pop()` (LIFO). When a single chunk produced `[ToolUseStart, ToolInputDelta]`, the delta was yielded first, then `ToolUseStart` cleared the accumulated args. Fix: changed to `VecDeque` with `pop_front()` (FIFO).

2. **Single current_tool slot** (`agent_loop.rs`): `collect_response` used one `current_tool` state. When GLM sent 2+ tool calls, the second `ToolUseStart` overwrote the first without saving. Fix: `ToolUseStart` now flushes the previous tool call before starting a new one.

## Additional Fixes

- **Empty-args guardrail**: aborts the agent loop after 3 consecutive iterations where all tool calls have empty arguments, preventing infinite token waste.
- **Quote-aware bash boundary check**: `unquoted_path_tokens()` skips path-like substrings inside quoted strings (e.g., `//` in a markdown body passed via `--body "..."`), preventing false "Access denied" errors.
- **Arguments format compatibility**: `parse_openai_chunk` now handles both string (standard OpenAI) and object (GLM-5.2) `arguments` fields.
- **Trace logging**: SSE chunks containing `tool_calls` are logged at trace level for debugging.

## Testing

- Unit tests for string/object/chunked arguments parsing
- Unit tests for the empty-args guardrail (6 cases)
- Unit tests for quote-aware token extraction (10 cases)
- `cargo fmt --check` and `cargo clippy -p jyc-agent -- -D warnings` pass