### PR TITLE
feat: per-pattern configurable access whitelist (read/write paths)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ All notable changes to JYC will be documented in this file.
 
 ### Added
 
+- **Per-pattern filesystem access whitelist (`access.read` / `access.write`).**
+  Patterns can now declare additional paths outside the thread working directory
+  that the agent may read from or write to. Write paths are automatically
+  readable. Tilde (`~`) expands to `$HOME`. Prevents repeated "Access denied"
+  failures when the agent needs to read dependency source (e.g.,
+  `~/.cargo/registry/src`) or write to build directories. (#275)
+
 - **`jyc_send_message` enhanced with cross-channel and attachment support.** The
   builtin tool now accepts an optional `channel` parameter for sending proactive
   messages through any configured channel's outbound adapter (bypassing agent

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -406,7 +406,7 @@ InboundMessage with image attachment
 
 Registered automatically when the provider has `supports_images() == true`. The model can call it mid-loop with either `path` or `url`.
 
-**Boundary checking**: `path` is validated against the working directory + configured attachment roots. `url` must be http/https.
+**Boundary checking**: `path` is validated against the working directory + configured read roots (`additional_read_roots`) + write roots (`additional_write_roots`, since write implies read). Roots are populated from per-pattern `access.read` and `access.write` config. `url` must be http/https.
 
 **Side-channel queue**: Images loaded mid-loop are pushed onto `ToolContext.pending_images`. The agent loop drains this queue after each tool batch and emits a synthetic user-role turn carrying the image blocks. This avoids embedding base64 in `tool_result` content (unsupported by most OpenAI-compat servers for `role: "tool"`).
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -86,6 +86,16 @@ enabled = true
 # Per-pattern skills to disable: merged with channel-level `disabled_skills`.
 # disabled_skills = ["coding-principles"]
 
+# Per-pattern filesystem access whitelist.
+# Extends the agent's read/write boundary beyond the thread working directory.
+# Paths in `write` are also readable automatically.
+# Tilde (~) expands to $HOME. Relative paths resolve against the thread
+# working directory and are ignored (already accessible).
+#
+# [channels.jiny283.patterns.access]
+# read = ["~/.cargo/registry/src"]
+# write = ["/tmp/jyc-builds"]
+
 [channels.jiny283.patterns.rules.sender]
 exact = ["kingye@petalmail.com"]
 

--- a/crates/jyc-agent/src/agent_loop.rs
+++ b/crates/jyc-agent/src/agent_loop.rs
@@ -55,6 +55,9 @@ pub struct AgentLoopConfig<'a> {
     /// `working_dir`.
     #[allow(dead_code)]
     pub additional_read_roots: Vec<std::path::PathBuf>,
+    /// Additional absolute paths permitted for write tools (`write`, `edit`,
+    /// `bash`). Configured via per-pattern `write` paths.
+    pub additional_write_roots: Vec<std::path::PathBuf>,
     /// Whether the inbound-attachment pattern allows image injection.
     /// Mirrors `inject_inbound_images`: when `false`, the `read_image`
     /// tool should not use vision-fallback mode even if a `VisionClient`
@@ -95,6 +98,7 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
         prior_raw_context,
         max_iterations,
         additional_read_roots,
+        additional_write_roots,
         pattern_inject_images,
         outbound,
         thread_managers,
@@ -212,6 +216,7 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
 
             let tool_start = Instant::now();
             let mut ctx = ToolContext::with_roots(working_dir, additional_read_roots.clone());
+            ctx.additional_write_roots = additional_write_roots.clone();
             ctx.pattern_inject_images = pattern_inject_images;
             ctx.outbound = outbound.clone();
             ctx.thread_managers = thread_managers.clone();
@@ -389,6 +394,7 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
         );
 
         let mut ctx = ToolContext::with_roots(working_dir, additional_read_roots.clone());
+        ctx.additional_write_roots = additional_write_roots.clone();
         ctx.pattern_inject_images = pattern_inject_images;
         ctx.outbound = outbound.clone();
         ctx.thread_managers = thread_managers.clone();

--- a/crates/jyc-agent/src/lib.rs
+++ b/crates/jyc-agent/src/lib.rs
@@ -107,6 +107,7 @@ mod integration_tests {
             prior_raw_context: Vec::new(),
             max_iterations: None,
             additional_read_roots: Vec::new(),
+            additional_write_roots: Vec::new(),
             pattern_inject_images: false,
             outbound: None,
             thread_managers: None,

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -567,6 +567,49 @@ impl JycAgentService {
             roots.push(workdir_skills);
         }
 
+        // 3. Per-pattern configured read paths
+        if let Some(pattern) = message
+            .matched_pattern
+            .as_deref()
+            .and_then(|name| self.patterns.iter().find(|p| p.name == name))
+            && let Some(access) = &pattern.access
+        {
+            for p in &access.read {
+                let expanded = expand_path(p);
+                if expanded.is_absolute() {
+                    roots.push(expanded);
+                }
+            }
+            // Write paths are also readable
+            for p in &access.write {
+                let expanded = expand_path(p);
+                if expanded.is_absolute() {
+                    roots.push(expanded);
+                }
+            }
+        }
+
+        roots
+    }
+
+    /// Resolve additional write roots from the matched pattern's `access.write`
+    /// configuration. Paths are tilde-expanded; relative paths are ignored
+    /// (they are already inside the working directory).
+    fn resolve_additional_write_roots(&self, message: &InboundMessage) -> Vec<PathBuf> {
+        let mut roots = Vec::new();
+        if let Some(pattern) = message
+            .matched_pattern
+            .as_deref()
+            .and_then(|name| self.patterns.iter().find(|p| p.name == name))
+            && let Some(access) = &pattern.access
+        {
+            for p in &access.write {
+                let expanded = expand_path(p);
+                if expanded.is_absolute() {
+                    roots.push(expanded);
+                }
+            }
+        }
         roots
     }
 
@@ -868,6 +911,21 @@ impl JycAgentService {
     }
 }
 
+/// Expand a tilde (`~`) prefix to `$HOME`. Other paths are returned as-is.
+fn expand_path(p: &str) -> PathBuf {
+    if let Some(rest) = p.strip_prefix("~/")
+        && let Ok(home) = std::env::var("HOME")
+    {
+        return PathBuf::from(home).join(rest);
+    }
+    if p == "~"
+        && let Ok(home) = std::env::var("HOME")
+    {
+        return PathBuf::from(home);
+    }
+    PathBuf::from(p)
+}
+
 /// Persist skill names to the thread's .jyc/skills.json file.
 ///
 /// This allows the dashboard to read the skills list without re-scanning directories.
@@ -1048,6 +1106,7 @@ impl AgentService for JycAgentService {
 
         // 7. Run agent loop
         let additional_read_roots = self.resolve_additional_read_roots(message, thread_path);
+        let additional_write_roots = self.resolve_additional_write_roots(message);
         let thread_managers = self
             .thread_managers
             .lock()
@@ -1070,6 +1129,7 @@ impl AgentService for JycAgentService {
             prior_raw_context,
             max_iterations: Some(self.config.max_iterations),
             additional_read_roots,
+            additional_write_roots,
             pattern_inject_images: pattern_inject,
             outbound: self.outbound.clone(),
             thread_managers: thread_managers.clone(),

--- a/crates/jyc-agent/src/tools/builtin/bash.rs
+++ b/crates/jyc-agent/src/tools/builtin/bash.rs
@@ -71,8 +71,9 @@ impl Tool for BashTool {
             .unwrap_or(DEFAULT_TIMEOUT_SECS);
 
         // Best-effort boundary check: scan for absolute-path tokens and
-        // verify each is within the working directory. This catches obvious
-        // escape attempts (cat /etc/passwd) without fully sandboxing bash.
+        // verify each is within the working directory (or configured
+        // read/write roots). This catches obvious escape attempts
+        // (cat /etc/passwd) without fully sandboxing bash.
         //
         // Only tokens OUTSIDE of quoted strings are checked. This avoids
         // false positives on path-like substrings inside data arguments
@@ -83,7 +84,7 @@ impl Tool for BashTool {
             // paths. This catches obvious escape attempts (e.g.
             // `cat /etc/passwd`) while allowing flags like `-C`.
             if candidate.exists()
-                && let Err(msg) = ctx.check_path_boundary(&token, candidate)
+                && let Err(msg) = ctx.check_write_boundary(&token, candidate)
             {
                 return Ok(ToolOutput::error(msg));
             }

--- a/crates/jyc-agent/src/tools/builtin/edit.rs
+++ b/crates/jyc-agent/src/tools/builtin/edit.rs
@@ -70,8 +70,8 @@ impl Tool for EditTool {
             ctx.working_dir.join(file_path)
         };
 
-        // Security: ensure path is within working directory.
-        if let Err(msg) = ctx.check_path_boundary(file_path, &path) {
+        // Security: ensure path is within working directory or write roots.
+        if let Err(msg) = ctx.check_write_boundary(file_path, &path) {
             return Ok(ToolOutput::error(msg));
         }
 

--- a/crates/jyc-agent/src/tools/builtin/write.rs
+++ b/crates/jyc-agent/src/tools/builtin/write.rs
@@ -53,8 +53,8 @@ impl Tool for WriteTool {
             ctx.working_dir.join(file_path)
         };
 
-        // Security: ensure path is within working directory.
-        if let Err(msg) = ctx.check_path_boundary(file_path, &path) {
+        // Security: ensure path is within working directory or write roots.
+        if let Err(msg) = ctx.check_write_boundary(file_path, &path) {
             return Ok(ToolOutput::error(msg));
         }
 

--- a/crates/jyc-agent/src/tools/mod.rs
+++ b/crates/jyc-agent/src/tools/mod.rs
@@ -36,6 +36,11 @@ pub struct ToolContext<'a> {
     /// boundary (e.g. `read_image`) accept paths under any of these
     /// roots in addition to `working_dir`.
     pub additional_read_roots: Vec<PathBuf>,
+    /// Additional absolute paths the agent may write to outside
+    /// `working_dir` (e.g. configured per-pattern `write` paths).
+    /// Write tools (`write`, `edit`, `bash`) accept paths under any of
+    /// these roots in addition to `working_dir`.
+    pub additional_write_roots: Vec<PathBuf>,
     /// Side-channel for tools (e.g. `read_image`) that need to inject
     /// additional content blocks into the *next* user turn alongside
     /// the textual tool result. The agent loop drains this after each
@@ -80,6 +85,7 @@ impl<'a> ToolContext<'a> {
         Self {
             working_dir,
             additional_read_roots: Vec::new(),
+            additional_write_roots: Vec::new(),
             pending_images: Mutex::new(Vec::new()),
             pattern_inject_images: false,
             outbound: None,
@@ -95,6 +101,7 @@ impl<'a> ToolContext<'a> {
         Self {
             working_dir,
             additional_read_roots,
+            additional_write_roots: Vec::new(),
             pending_images: Mutex::new(Vec::new()),
             pattern_inject_images: false,
             outbound: None,
@@ -156,6 +163,35 @@ impl<'a> ToolContext<'a> {
             }
         }
 
+        Err(format!(
+            "Access denied: path '{}' is outside the working directory",
+            display_path
+        ))
+    }
+
+    /// Check that `resolved` is within `working_dir`, `additional_read_roots`,
+    /// or `additional_write_roots`. Write paths imply read access.
+    ///
+    /// Used by write/edit/bash tools to enforce the write boundary.
+    pub fn check_write_boundary(
+        &self,
+        display_path: &str,
+        resolved: &Path,
+    ) -> std::result::Result<(), String> {
+        // First check read boundary (working_dir + read_roots)
+        if self.check_path_boundary(display_path, resolved).is_ok() {
+            return Ok(());
+        }
+        // Then check write roots
+        let canonical = resolved
+            .canonicalize()
+            .unwrap_or_else(|_| resolved.to_path_buf());
+        for root in &self.additional_write_roots {
+            let root_canonical = root.canonicalize().unwrap_or_else(|_| root.clone());
+            if canonical.starts_with(&root_canonical) {
+                return Ok(());
+            }
+        }
         Err(format!(
             "Access denied: path '{}' is outside the working directory",
             display_path

--- a/crates/jyc-channels/src/wecom_bot/inbound.rs
+++ b/crates/jyc-channels/src/wecom_bot/inbound.rs
@@ -672,6 +672,7 @@ mod tests {
             disabled_mcp_servers: None,
             skills: None,
             disabled_skills: None,
+            access: None,
         };
 
         let matcher = WecomBotMatcher;

--- a/crates/jyc-types/src/channel.rs
+++ b/crates/jyc-types/src/channel.rs
@@ -407,6 +407,39 @@ pub struct ChannelPattern {
     /// Merged with channel-level `disabled_skills`.
     #[serde(default)]
     pub disabled_skills: Option<Vec<String>>,
+
+    /// Per-pattern filesystem access whitelist.
+    ///
+    /// Extends the agent's read/write boundary beyond the thread working
+    /// directory. Paths listed in `write` are also readable automatically.
+    ///
+    /// Tilde (`~`) expands to `$HOME`. Relative paths resolve against the
+    /// thread working directory and are ignored (already accessible).
+    ///
+    /// ```toml
+    /// [channels.jyc_repo.patterns.access]
+    /// read = ["~/.cargo/registry/src"]
+    /// write = ["/tmp/jyc-builds"]
+    /// ```
+    #[serde(default)]
+    pub access: Option<AccessConfig>,
+}
+
+/// Per-pattern filesystem access whitelist.
+///
+/// `read` paths widen the read boundary for tools like `read`, `bash`,
+/// `grep`, and `glob`. `write` paths widen the write boundary for `write`,
+/// `edit`, and `bash` — and are automatically readable too.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AccessConfig {
+    /// Additional read paths outside the working directory.
+    #[serde(default)]
+    pub read: Vec<String>,
+
+    /// Additional write paths outside the working directory.
+    /// Write paths are also readable automatically.
+    #[serde(default)]
+    pub write: Vec<String>,
 }
 
 impl Default for ChannelPattern {
@@ -432,6 +465,7 @@ impl Default for ChannelPattern {
             disabled_mcp_servers: None,
             skills: None,
             disabled_skills: None,
+            access: None,
         }
     }
 }

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -26,7 +26,7 @@ Execute shell commands in the working directory.
 - `command` (string, required): The bash command to execute
 - `timeout` (integer, optional): Timeout in seconds (default: 120)
 
-**Security:** Best-effort path boundary check — scans for absolute-path tokens and verifies they are within `working_dir`. This is a heuristic, not a sandbox. Full isolation requires OS-level containment.
+**Security:** Best-effort path boundary check — scans for absolute-path tokens (outside quoted strings) and verifies they are within `working_dir` or configured read/write roots (`access.read` / `access.write`). This is a heuristic, not a sandbox. Full isolation requires OS-level containment.
 
 **Limits:** Output truncated at 128 KB.
 
@@ -46,7 +46,7 @@ Read a file or directory listing.
 - `offset` (integer, optional): Line number to start from, 1-indexed (default: 1)
 - `limit` (integer, optional): Maximum lines to read (default: 2000)
 
-**Security:** Path must be within `working_dir` or `additional_read_roots`. Symlink exemption supported for `repo_group` setups.
+**Security:** Path must be within `working_dir`, `additional_read_roots`, or `additional_write_roots`. Symlink exemption supported for `repo_group` setups.
 
 **Example:**
 ```json
@@ -63,11 +63,7 @@ Create or overwrite a file. Creates parent directories as needed.
 - `file_path` (string, required): Path to the file
 - `content` (string, required): Content to write
 
-**Security:** Path must be within `working_dir`.
-
-**Example:**
-```json
-{"file_path": "src/lib.rs", "content": "pub fn hello() {}"}
+**Security:** Path must be within `working_dir` or configured write roots (`access.write`).
 ```
 
 ---
@@ -87,7 +83,7 @@ Perform exact string replacement in a file.
 - Fails if `old_string` matches multiple times and `replace_all` is false
 - Fails if `old_string == new_string`
 
-**Security:** Path must be within `working_dir`.
+**Security:** Path must be within `working_dir` or configured write roots (`access.write`).
 
 **Example:**
 ```json
@@ -338,16 +334,24 @@ disabled_mcp_servers = ["*"]  # Disables all external MCP servers
 
 | Tool | Boundary Check | Notes |
 |------|---------------|-------|
-| `bash` | Best-effort absolute-path heuristic | Not a sandbox; OS-level isolation recommended for untrusted input |
-| `read` | `check_path_boundary()` working_dir + additional_read_roots | Symlink exemption for repo_group |
-| `write` | `check_path_boundary()` working_dir only | Creates parent dirs automatically |
-| `edit` | `check_path_boundary()` working_dir only | — |
+| `bash` | `check_write_boundary()` — scans unquoted absolute-path tokens | Not a sandbox; OS-level isolation recommended for untrusted input |
+| `read` | `check_path_boundary()` working_dir + read_roots + write_roots | Symlink exemption for repo_group |
+| `write` | `check_write_boundary()` working_dir + write_roots | Creates parent dirs automatically |
+| `edit` | `check_write_boundary()` working_dir + write_roots | — |
 | `glob` | `check_path_boundary()` only when explicit `path` provided | Default working_dir is trusted |
 | `grep` | `check_path_boundary()` only when explicit `path` provided | Default working_dir is trusted |
 | `webfetch` | None (network tool) | HTTPS only; 30s default timeout |
-| `read_image` | `check_path_boundary()` working_dir + additional_read_roots | URL mode requires http(s) |
+| `read_image` | `check_path_boundary()` working_dir + read_roots + write_roots | URL mode requires http(s) |
 | `jyc_reply_reply_message` | Attachment path validation | Must be within thread directory |
 | `jyc_send_message` | Recipient format validation | Channel-specific format check |
+
+Read/write roots are configured per-pattern via the `access` sub-table:
+
+```toml
+[channels.xxx.patterns.access]
+read = ["~/.cargo/registry/src"]   # readable by all tools
+write = ["/tmp/jyc-builds"]         # writable + readable (write implies read)
+```
 
 ---
 


### PR DESCRIPTION
Closes #275

## Problem

The agent's tools enforce a path boundary that restricts access to the thread working directory. When the agent needs to read files outside it (e.g., dependency source in `~/.cargo/registry/src`), every attempt fails with "Access denied", causing repeated failures and wasted tokens.

## Solution

Per-pattern `access` sub-table with `read` and `write` path whitelists:

```toml
[[channels.jyc_repo.patterns]]
name = "reviewer"

[channels.jyc_repo.patterns.access]
read = ["~/.cargo/registry/src"]
write = ["/tmp/jyc-builds"]
```

### Key design decisions

- **Write implies read**: paths in `write` are automatically readable — no duplication needed
- **`check_write_boundary()`**: delegates to `check_path_boundary()` first (working_dir + read_roots), then checks write_roots
- **Tilde expansion**: `~` → `$HOME`
- **Short names**: `access.read` / `access.write` (not `additional_read_paths`)
- **Default**: `None` — no behavior change for existing configs

### Files changed

| File | Change |
|------|--------|
| `jyc-types/src/channel.rs` | `AccessConfig` struct, `access` field on `ChannelPattern` |
| `jyc-agent/src/tools/mod.rs` | `additional_write_roots` field, `check_write_boundary()` method |
| `jyc-agent/src/agent_loop.rs` | `additional_write_roots` in `AgentLoopConfig` |
| `jyc-agent/src/service.rs` | `resolve_additional_read_roots` (picks up read+write), `resolve_additional_write_roots`, `expand_path` helper |
| `jyc-agent/src/tools/builtin/{write,edit,bash}.rs` | Use `check_write_boundary` instead of `check_path_boundary` |
| `config.example.toml` | Documents `access` sub-table |
| `CHANGELOG.md` | Entry added |

### Checks

- `cargo fmt --check` ✅
- `cargo clippy -p jyc-types -p jyc-agent -- -D warnings` ✅