### PR TITLE
fix: handle HTTP 429 rate-limit as transient SSE error

### DIFF
--- a/crates/jyc-agent/src/agent_loop.rs
+++ b/crates/jyc-agent/src/agent_loop.rs
@@ -1201,7 +1201,7 @@ mod retry_tests {
     async fn non_transient_errors_fail_immediately() {
         let provider = FlakyProvider {
             fail_count: 99,
-            fail_message: "server overload (HTTP 429 body: {\"error\": \"rate limit\"})"
+            fail_message: "invalid request (HTTP 400 body: {\"error\": \"bad payload\"})"
                 .to_string(),
             calls: AtomicUsize::new(0),
         };

--- a/crates/jyc-agent/src/provider/mod.rs
+++ b/crates/jyc-agent/src/provider/mod.rs
@@ -466,6 +466,27 @@ mod classifier_tests {
     }
 
     #[test]
+    fn diag_status_429_is_transient() {
+        // 429 Too Many Requests — rate-limit that resolves after
+        // the retry window. Retry with backoff.
+        let e = err("SSE stream error: error sending request for url \
+             (https://api.deepseek.com/chat/completions) \
+             (HTTP 429 body: {\"error\":{\"message\":\"rate limit exceeded\"}})");
+        assert!(
+            is_transient_sse_error(&e),
+            "diag-429 is a rate-limit → transient"
+        );
+    }
+
+    #[test]
+    fn extract_diag_status_429() {
+        assert_eq!(
+            extract_diag_status("foo (HTTP 429 body: {\"error\": ...})"),
+            Some(429)
+        );
+    }
+
+    #[test]
     fn decode_body_error_no_diag_is_transient() {
         // Pre-this-fix production case: reqwest body decoder glitched
         // mid-stream, diag wasn't issued (already past Event::Open).

--- a/crates/jyc-agent/src/provider/mod.rs
+++ b/crates/jyc-agent/src/provider/mod.rs
@@ -304,7 +304,8 @@ where
 /// error after issuing a one-shot diagnostic POST. The status code carried
 /// in that suffix is authoritative:
 ///
-/// - `4xx` / `5xx` → the request is structurally rejected (auth, quota,
+/// - `429` → rate-limit exceeded; resolves after the retry window. **Transient.**
+/// - Other `4xx` / `5xx` → the request is structurally rejected (auth, quota,
 ///   schema, model-not-supported). **Terminal.**
 /// - `2xx` → the diagnostic POST succeeded. The original SSE failure was
 ///   purely a transport-level glitch (stale connection in pool, NAT idle
@@ -341,6 +342,11 @@ pub fn is_transient_sse_error(err: &anyhow::Error) -> bool {
 
     // If the diagnostic POST captured a status code, trust it.
     if let Some(status) = extract_diag_status(&msg) {
+        if status == 429 {
+            // 429 Too Many Requests — rate-limit that resolves after
+            // the retry window. Retry with backoff.
+            return true;
+        }
         if (400..600).contains(&status) {
             // Structured rejection — retry won't help.
             return false;


### PR DESCRIPTION
## Spec

Treat HTTP 429 ("Too Many Requests") responses from LLM providers as transient
errors that warrant automatic retry with backoff (instead of failing immediately).
Currently, all 4xx status codes are classified as terminal — but 429 is a rate-limit
that resolves after the retry window, making it semantically transient.

Fixes #279

## Implementation Plan

### Step 1: Classify HTTP 429 as transient in `is_transient_sse_error`
**What:** In `crates/jyc-agent/src/provider/mod.rs`, modify the `is_transient_sse_error` function:
- When `extract_diag_status` returns `429`, return `true` (transient) instead of `false`.
- The current check `if (400..600).contains(&status)` treats ALL 4xx/5xx as terminal.
  Change to: `if (400..600).contains(&status) && status != 429`.
- Also update the doc comment's "Terminal patterns" section to note that 429 is transient.

**Why:** 429 means "overloaded, try again later" — unlike 400 (bad request), 401 (unauthorized),
403 (forbidden), etc. Retrying after backoff is the standard approach.

**Verify:** `cargo clippy --workspace -- -D warnings` passes; reasoning about the change.

### Step 2: Add test cases for 429 transient classification
**What:** In `crates/jyc-agent/src/provider/mod.rs` test module `classifier_tests`:
- Add `diag_status_429_is_transient`: diagnostic POST captured 429 with body → transient.
- Add `extract_diag_status_429`: verify `extract_diag_status` parses 429 correctly.

**Why:** Ensures 429 is classified transient and the status extraction works for 429.

**Verify:** `cargo test -p jyc-agent provider::classifier_tests` — all tests pass, including the new ones.

### Step 3: Format check
**What:** Run `cargo fmt --check` to confirm code style consistency.

**Why:** CI enforces formatting; must pass.

**Verify:** `cargo fmt --check` exits with 0.

## Design Decisions
- **Backoff parameters unchanged**: Existing 3-attempt max with 1s/2s backoff is adequate for
  429 rate-limit recovery. No new configuration needed.
- **Surgical change**: Only `is_transient_sse_error` changes; the retry loop (`complete_with_retry`)
  and `fetch_error_body` (diagnostic POST) are untouched — they already handle the flow correctly.
- **No fallback pattern match for 429 without diag suffix**: When 429 occurs, the diagnostic POST
  always fires (stream error path), so the diag suffix is always present. The `"invalid status code"`
  substring match without diag is for pre-stream rejections (e.g., 401 with empty body) which don't
  apply to 429.