### PR TITLE
feat: load recent chat history in dashboard chat pane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,10 +386,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -898,6 +910,15 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1493,6 +1514,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
 name = "imap-proto"
 version = "0.16.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,6 +1758,7 @@ dependencies = [
  "jyc-types",
  "jyc-utils",
  "ratatui",
+ "ratatui-markdown",
  "serde",
  "serde_json",
  "tempfile",
@@ -2070,6 +2116,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2411,6 +2467,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2567,6 +2666,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,6 +2826,18 @@ dependencies = [
  "ar_archive_writer",
  "cc",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -2895,6 +3019,21 @@ dependencies = [
  "strum",
  "unicode-segmentation",
  "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "ratatui-markdown"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e44e5c1fcb6b71a3e639b5218ea181ef42b8b05ae87ba4afdc962b48548079ab"
+dependencies = [
+ "image",
+ "pest",
+ "pest_derive",
+ "ratatui",
+ "serde_json",
+ "toml",
  "unicode-width 0.2.0",
 ]
 
@@ -4208,6 +4347,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"

--- a/crates/jyc-channels/src/websocket/inbound.rs
+++ b/crates/jyc-channels/src/websocket/inbound.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -61,6 +62,18 @@ impl ChannelMatcher for WebsocketMatcher {
 enum ServerMessage {
     #[serde(rename = "patterns")]
     Patterns { patterns: Vec<String> },
+    #[serde(rename = "history")]
+    History {
+        thread: String,
+        messages: Vec<HistoryEntry>,
+    },
+}
+
+/// A single entry in chat history.
+#[derive(Debug, Clone, serde::Serialize)]
+struct HistoryEntry {
+    sender: String,
+    text: String,
 }
 
 /// Inbound JSON protocol messages from clients.
@@ -90,6 +103,8 @@ pub struct WebsocketInboundAdapter {
     broadcast_tx: broadcast::Sender<String>,
     /// Message callback — set during `start()`, used by the WebSocket handler.
     on_message: std::sync::Arc<tokio::sync::Mutex<Option<OnMessageCallback>>>,
+    /// Workspace directory for loading chat history.
+    workspace_dir: Option<PathBuf>,
 }
 
 impl WebsocketInboundAdapter {
@@ -104,7 +119,13 @@ impl WebsocketInboundAdapter {
             patterns,
             broadcast_tx,
             on_message: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
+            workspace_dir: None,
         }
+    }
+
+    /// Set the workspace directory for loading chat history.
+    pub fn set_workspace_dir(&mut self, dir: PathBuf) {
+        self.workspace_dir = Some(dir);
     }
 
     /// Return the channel name for this adapter.
@@ -131,6 +152,7 @@ impl jyc_inspect::server::WebsocketHandler for WebsocketInboundAdapter {
         let broadcast_rx = self.broadcast_tx.subscribe();
         let channel_name = self.channel_name.clone();
         let on_message = self.on_message.clone();
+        let workspace_dir = self.workspace_dir.clone();
 
         handle_connection_impl(
             ws_stream,
@@ -139,6 +161,7 @@ impl jyc_inspect::server::WebsocketHandler for WebsocketInboundAdapter {
             pattern_names,
             broadcast_rx,
             on_message,
+            workspace_dir,
         )
         .await
     }
@@ -193,6 +216,7 @@ async fn handle_connection_impl<S>(
     pattern_names: Vec<String>,
     mut broadcast_rx: broadcast::Receiver<String>,
     on_message: std::sync::Arc<tokio::sync::Mutex<Option<OnMessageCallback>>>,
+    workspace_dir: Option<PathBuf>,
 ) -> anyhow::Result<()>
 where
     S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + Sync + 'static,
@@ -247,6 +271,22 @@ where
                     }
                     ClientMessage::Subscribe { thread } => {
                         tracing::info!(addr = %addr, thread = %thread, "Client subscribed to thread");
+
+                        // Load and send chat history
+                        if let Some(ref dir) = workspace_dir {
+                            let history = load_chat_history(dir, &thread, 100);
+                            if !history.is_empty() {
+                                let response = ServerMessage::History {
+                                    thread: thread.clone(),
+                                    messages: history,
+                                };
+                                let json = serde_json::to_string(&response)?;
+                                if let Err(e) = ws_tx.send(tokio_tungstenite::tungstenite::Message::Text(json)).await {
+                                    tracing::warn!(error = %e, addr = %addr, "Failed to send history");
+                                    break;
+                                }
+                            }
+                        }
                     }
                     ClientMessage::Message { thread, text } => {
                         let message = InboundMessage {
@@ -307,6 +347,67 @@ where
         .await;
     tracing::info!(addr = %addr, "WebSocket connection closed");
     Ok(())
+}
+
+/// Load recent chat history messages from JSONL files for a thread.
+///
+/// Reads `chat_history_*.jsonl` files in the thread directory, parses each
+/// line, and returns up to `max_messages` most recent entries.
+fn load_chat_history(workspace_dir: &Path, thread: &str, max_messages: usize) -> Vec<HistoryEntry> {
+    let thread_dir = workspace_dir.join(thread);
+    if !thread_dir.exists() {
+        return vec![];
+    }
+
+    // Collect and sort chat history files by name (descending = newest first)
+    let mut files: Vec<PathBuf> = match std::fs::read_dir(&thread_dir) {
+        Ok(entries) => entries
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with("chat_history_") && n.ends_with(".jsonl"))
+            })
+            .collect(),
+        Err(_) => return vec![],
+    };
+    files.sort_by(|a, b| b.cmp(a)); // newest first
+
+    let mut entries = Vec::new();
+    for file in files {
+        if entries.len() >= max_messages {
+            break;
+        }
+        let content = match std::fs::read_to_string(&file) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        // Parse lines in reverse (most recent first within the file)
+        let mut file_entries: Vec<HistoryEntry> = content
+            .lines()
+            .rev()
+            .filter_map(|line| {
+                let parsed: serde_json::Value = serde_json::from_str(line).ok()?;
+                let msg_type = parsed.get("type")?.as_str()?;
+                let content = parsed.get("content")?.as_str()?;
+                let sender = match msg_type {
+                    "received" => "user",
+                    "reply" => "ai",
+                    _ => return None,
+                };
+                Some(HistoryEntry {
+                    sender: sender.to_string(),
+                    text: content.to_string(),
+                })
+            })
+            .collect();
+        file_entries.reverse(); // restore chronological order
+        entries.splice(0..0, file_entries);
+    }
+
+    entries.truncate(max_messages);
+    entries
 }
 
 #[cfg(test)]

--- a/crates/jyc-cli/Cargo.toml
+++ b/crates/jyc-cli/Cargo.toml
@@ -23,6 +23,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 anyhow = "1"
 ratatui = "0.29"
+ratatui-markdown = "0.3"
 crossterm = "0.28"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -326,6 +326,23 @@ impl App {
                     self.chat_pattern_selected = 0;
                 }
             }
+            Some("history") => {
+                if let (Some(thread), Some(messages)) = (
+                    parsed.get("thread").and_then(|v| v.as_str()),
+                    parsed.get("messages").and_then(|v| v.as_array()),
+                ) && self.chat_thread.as_deref() == Some(thread)
+                {
+                    self.chat_messages = messages
+                        .iter()
+                        .filter_map(|m| {
+                            Some(ChatMessage {
+                                sender: m.get("sender")?.as_str()?.to_string(),
+                                text: m.get("text")?.as_str()?.to_string(),
+                            })
+                        })
+                        .collect();
+                }
+            }
             Some("reply") => {
                 if let (Some(thread), Some(text)) = (
                     parsed.get("thread").and_then(|v| v.as_str()),

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -1093,33 +1093,37 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
     if app.chat_focus == ChatFocus::ChatPane {
         block = block.border_style(Style::default().fg(Color::Cyan));
     }
-
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let mut lines = vec![];
+    // Split: scrollable messages (top) + fixed input line (bottom)
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(1)])
+        .split(inner);
 
-    // Show messages
+    // --- Messages area (markdown-rendered) ---
+    let mut md_text = String::new();
     for msg in &app.chat_messages {
-        let (prefix, style) = match msg.sender.as_str() {
-            "user" => ("You: ", Style::default().fg(Color::Cyan)),
-            "ai" => ("AI: ", Style::default().fg(Color::Green)),
-            _ => ("● ", Style::default().fg(Color::DarkGray)),
-        };
-        let indent = Span::raw(" ".repeat(prefix.len()));
-        for (i, line) in msg.text.lines().enumerate() {
-            if i == 0 {
-                lines.push(Line::from(vec![
-                    Span::styled(prefix, style.add_modifier(Modifier::BOLD)),
-                    Span::raw(line),
-                ]));
-            } else {
-                lines.push(Line::from(vec![indent.clone(), Span::raw(line)]));
+        match msg.sender.as_str() {
+            "user" => {
+                md_text.push_str("**You:** ");
+                md_text.push_str(&msg.text);
+                md_text.push('\n');
+            }
+            "ai" => {
+                md_text.push_str("**AI:** ");
+                md_text.push_str(&msg.text);
+                md_text.push('\n');
+            }
+            _ => {
+                md_text.push_str(&msg.text);
+                md_text.push('\n');
             }
         }
     }
 
-    // Show progress indicator when AI is processing
+    // Show progress indicator in markdown
     if let Some(ref state) = app.state
         && let Some(chat_name) = &app.chat_thread
     {
@@ -1128,20 +1132,24 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
             .iter()
             .any(|t| t.name == *chat_name && t.status == ThreadStatus::Processing);
         if is_processing {
-            lines.push(Line::from(vec![
-                Span::raw("  "),
-                Span::styled(
-                    "⏳ AI is thinking...",
-                    Style::default()
-                        .fg(Color::Yellow)
-                        .add_modifier(Modifier::ITALIC),
-                ),
-            ]));
+            md_text.push_str("\n*⏳ AI is thinking...*\n");
         }
     }
 
-    // Show input line at bottom
-    lines.push(Line::from(""));
+    let renderer = ratatui_markdown::markdown::MarkdownRenderer::new(chunks[0].width as usize);
+    let theme = ratatui_markdown::theme::ThemeConfig::default();
+    let blocks = renderer.parse(&md_text);
+    let md_lines = renderer.render(&blocks, &theme);
+
+    let inner_height = chunks[0].height as usize;
+    let max_skip = md_lines.len().saturating_sub(inner_height);
+    let skip = max_skip.saturating_sub(app.chat_scroll);
+    let visible_lines: Vec<Line> = md_lines.into_iter().skip(skip).collect();
+
+    let messages_para = Paragraph::new(visible_lines);
+    frame.render_widget(messages_para, chunks[0]);
+
+    // --- Input line (fixed at bottom) ---
     let focus_indicator = if app.chat_focus == ChatFocus::ChatPane {
         "▶ "
     } else {
@@ -1149,21 +1157,15 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
     };
     let before_cursor = &app.chat_input[..app.chat_cursor];
     let after_cursor = &app.chat_input[app.chat_cursor..];
-    lines.push(Line::from(vec![
+    let input_line = Line::from(vec![
         Span::raw(focus_indicator),
         Span::styled("> ", Style::default().fg(Color::Yellow)),
         Span::raw(before_cursor),
         Span::styled("▌", Style::default().fg(Color::Yellow)),
         Span::raw(after_cursor),
-    ]));
-
-    let inner_height = inner.height as usize;
-    let max_skip = lines.len().saturating_sub(inner_height);
-    let skip = max_skip.saturating_sub(app.chat_scroll);
-    let visible_lines: Vec<Line> = lines.into_iter().skip(skip).collect();
-
-    let paragraph = Paragraph::new(visible_lines).wrap(Wrap { trim: true });
-    frame.render_widget(paragraph, inner);
+    ]);
+    let input_para = Paragraph::new(input_line);
+    frame.render_widget(input_para, chunks[1]);
 }
 
 fn render_activity_log(frame: &mut Frame, area: Rect, app: &App) {

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -328,11 +328,13 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                 let (broadcast_tx, _) = tokio::sync::broadcast::channel(64);
                 let adapter = WebsocketOutboundAdapter::new(broadcast_tx.clone());
                 // Store the inbound adapter for later registration with the inspect server
-                let handler = Arc::new(WebsocketInboundAdapter::new(
+                let mut handler = WebsocketInboundAdapter::new(
                     channel_name.to_string(),
                     patterns.clone(),
                     broadcast_tx,
-                ));
+                );
+                handler.set_workspace_dir(workspace_dir.clone());
+                let handler = Arc::new(handler);
                 websocket_handlers.push(handler);
                 Arc::new(adapter)
             }


### PR DESCRIPTION
## Changes

When entering a chat thread in the dashboard, the most recent 100 messages from the thread's chat history (JSONL files) are loaded and displayed automatically.

### Server-side
- `WebsocketInboundAdapter` now has an optional `workspace_dir` for loading chat history
- New `load_chat_history()` function reads `chat_history_*.jsonl` files and returns recent entries
- On `subscribe`, the server sends a `history` message with recent messages

### Client-side
- Dashboard handles `history` WebSocket messages and populates `chat_messages`