### PR TITLE
fix: remove oneOf from job_create input_schema for Anthropic compat

### DIFF
--- a/crates/jyc-agent/src/tools/builtin/job_tools.rs
+++ b/crates/jyc-agent/src/tools/builtin/job_tools.rs
@@ -97,21 +97,18 @@ impl Tool for JobCreateTool {
             "properties": {
                 "cron": {
                     "type": "string",
-                    "description": "Cron expression for recurring jobs (7-field format: 'sec min hour dom mon dow year')"
+                    "description": "Cron expression for recurring jobs (7-field format: 'sec min hour dom mon dow year'). Exactly one of cron or at must be provided."
                 },
                 "at": {
                     "type": "string",
-                    "description": "ISO 8601 timestamp for one-time jobs (e.g. '2026-06-22T08:00:00Z')"
+                    "description": "ISO 8601 timestamp for one-time jobs (e.g. '2026-06-22T08:00:00Z'). Exactly one of cron or at must be provided."
                 },
                 "prompt": {
                     "type": "string",
                     "description": "Instructions for the AI to execute when the job fires"
                 }
             },
-            "oneOf": [
-                {"required": ["cron", "prompt"]},
-                {"required": ["at", "prompt"]}
-            ]
+            "required": ["prompt"]
         })
     }
 


### PR DESCRIPTION
## Spec

Remove `oneOf` from `JobCreateTool::input_schema()` in `job_tools.rs`. Anthropic Claude Opus 4.6 rejects `oneOf`/`allOf`/`anyOf` at the top level of `input_schema`, causing a 400 Bad Request error. The runtime already validates that either `cron` or `at` must be provided, so the schema-level `oneOf` is redundant and can be safely removed.

Fixes #294

## Implementation Plan

### Step 1: Remove `oneOf` from job_create input_schema
**What:** In `crates/jyc-agent/src/tools/builtin/job_tools.rs`, modify `JobCreateTool::input_schema()` (lines 94–115):
- Remove the `oneOf` block (lines 111–114)
- Change `required` from `["prompt"]` (both `cron` and `at` are optional in the schema; runtime validation enforces the mutual exclusivity)
- Update `cron` and `at` description fields to indicate "exactly one of cron or at must be provided"

**Why:** Anthropic Claude Opus 4.6 (via the Messages API) rejects JSON Schema `oneOf` at the top level of `input_schema`. The `job_create` tool's runtime `execute()` already validates that exactly one of `cron` or `at` is provided (line 177–180), so the schema-level `oneOf` is redundant. Removing it fixes the 400 error while preserving correct behavior.

**Verify:** `cargo fmt --check && cargo clippy --workspace -- -D warnings`

## Design Decisions
- **No schema sanitization in Anthropic provider:** Only the `job_create` tool uses `oneOf` in the codebase. Adding a schema-stripping layer in the provider would be speculative — YAGNI. If MCP bridge tools introduce `oneOf`/`allOf`/`anyOf` in the future, a follow-up issue can add sanitization then.
- **Runtime validation preserved:** The tool's `execute()` already returns a clear error when neither `cron` nor `at` is provided, so removing the schema constraint does not degrade UX.