### PR TITLE
fix: persist websocket AI replies to chat log for history loading

### DIFF
--- a/crates/jyc-channels/src/websocket/outbound.rs
+++ b/crates/jyc-channels/src/websocket/outbound.rs
@@ -4,11 +4,13 @@
 //! `tokio::sync::broadcast`.
 
 use std::path::Path;
+use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
 use tokio::sync::broadcast;
 
+use jyc_core::message_storage::MessageStorage;
 use jyc_types::{InboundMessage, OutboundAdapter, OutboundAttachment, SendResult};
 
 /// WebSocket outbound adapter.
@@ -18,12 +20,17 @@ use jyc_types::{InboundMessage, OutboundAdapter, OutboundAttachment, SendResult}
 pub struct WebsocketOutboundAdapter {
     /// Broadcast sender — cloned for each new WebSocket connection.
     broadcast_tx: broadcast::Sender<String>,
+    /// Message storage for persisting replies to chat log.
+    storage: Arc<MessageStorage>,
 }
 
 impl WebsocketOutboundAdapter {
     /// Create a new WebSocket outbound adapter with the given broadcast sender.
-    pub fn new(broadcast_tx: broadcast::Sender<String>) -> Self {
-        Self { broadcast_tx }
+    pub fn new(broadcast_tx: broadcast::Sender<String>, storage: Arc<MessageStorage>) -> Self {
+        Self {
+            broadcast_tx,
+            storage,
+        }
     }
 
     /// Get the broadcast sender for the inbound adapter to clone.
@@ -78,6 +85,16 @@ impl OutboundAdapter for WebsocketOutboundAdapter {
         let thread = _original.topic.as_str();
         self.broadcast_reply(thread, reply_text).await?;
         let message_id = uuid::Uuid::new_v4().to_string();
+
+        // Persist reply to chat log for history loading
+        if let Err(e) = self
+            .storage
+            .store_reply(_thread_path, reply_text, _message_dir)
+            .await
+        {
+            tracing::warn!(error = %e, "Failed to store WebSocket reply to chat log");
+        }
+
         tracing::info!(text_len = reply_text.len(), message_id = %message_id, "WebSocket reply broadcast");
         Ok(SendResult { message_id })
     }
@@ -102,7 +119,9 @@ mod tests {
     #[tokio::test]
     async fn test_send_reply_broadcasts() {
         let (tx, mut rx) = broadcast::channel(16);
-        let adapter = WebsocketOutboundAdapter::new(tx);
+        let tmp = tempfile::TempDir::new().unwrap();
+        let storage = Arc::new(MessageStorage::new(tmp.path()));
+        let adapter = WebsocketOutboundAdapter::new(tx, storage);
 
         let message = InboundMessage {
             id: "test".to_string(),
@@ -127,7 +146,7 @@ mod tests {
         };
 
         let result = adapter
-            .send_reply(&message, "AI reply", Path::new("/tmp"), "msg_001", None)
+            .send_reply(&message, "AI reply", tmp.path(), "msg_001", None)
             .await;
         assert!(result.is_ok());
 
@@ -142,7 +161,9 @@ mod tests {
     async fn test_send_without_receiver_ok() {
         // broadcast with no receivers should still succeed
         let tx = broadcast::channel(16).0;
-        let adapter = WebsocketOutboundAdapter::new(tx);
+        let tmp = tempfile::TempDir::new().unwrap();
+        let storage = Arc::new(MessageStorage::new(tmp.path()));
+        let adapter = WebsocketOutboundAdapter::new(tx, storage);
 
         let message = InboundMessage {
             id: "test".to_string(),
@@ -167,14 +188,16 @@ mod tests {
         };
 
         let result = adapter
-            .send_reply(&message, "AI reply", Path::new("/tmp"), "msg_001", None)
+            .send_reply(&message, "AI reply", tmp.path(), "msg_001", None)
             .await;
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_clean_body_passthrough() {
-        let adapter = WebsocketOutboundAdapter::new(broadcast::channel(16).0);
+        let tmp = tempfile::TempDir::new().unwrap();
+        let storage = Arc::new(MessageStorage::new(tmp.path()));
+        let adapter = WebsocketOutboundAdapter::new(broadcast::channel(16).0, storage);
         assert_eq!(adapter.clean_body("hello\nworld"), "hello\nworld");
     }
 }

--- a/crates/jyc-channels/tests/websocket_integration_test.rs
+++ b/crates/jyc-channels/tests/websocket_integration_test.rs
@@ -161,7 +161,9 @@ async fn test_websocket_adapter_start_and_handle() {
 #[tokio::test]
 async fn test_websocket_broadcast_reply() {
     let (broadcast_tx, mut broadcast_rx) = broadcast::channel(16);
-    let outbound = WebsocketOutboundAdapter::new(broadcast_tx);
+    let tmp = tempfile::TempDir::new().unwrap();
+    let storage = Arc::new(MessageStorage::new(tmp.path()));
+    let outbound = WebsocketOutboundAdapter::new(broadcast_tx, storage);
 
     let message = InboundMessage {
         id: "test".to_string(),

--- a/crates/jyc-channels/tests/websocket_integration_test.rs
+++ b/crates/jyc-channels/tests/websocket_integration_test.rs
@@ -6,6 +6,7 @@ use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 
 use jyc_channels::websocket::{WebsocketInboundAdapter, WebsocketOutboundAdapter};
+use jyc_core::message_storage::MessageStorage;
 use jyc_inspect::server::WebsocketHandler;
 use jyc_types::{
     ChannelPattern, InboundAdapter, InboundAdapterOptions, InboundMessage, MessageContent,
@@ -15,7 +16,9 @@ use jyc_types::{
 #[tokio::test]
 async fn test_websocket_adapter_start_and_handle() {
     let (broadcast_tx, _broadcast_rx) = broadcast::channel(16);
-    let outbound = WebsocketOutboundAdapter::new(broadcast_tx.clone());
+    let tmp = tempfile::TempDir::new().unwrap();
+    let storage = Arc::new(MessageStorage::new(tmp.path()));
+    let outbound = WebsocketOutboundAdapter::new(broadcast_tx.clone(), storage);
 
     let patterns = vec![
         ChannelPattern {

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -1125,28 +1125,31 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
         .constraints([Constraint::Min(0), Constraint::Length(1)])
         .split(inner);
 
-    // --- Messages area (markdown-rendered) ---
-    let mut md_text = String::new();
+    // --- Messages area (markdown-rendered with colored bars) ---
+    let renderer = ratatui_markdown::markdown::MarkdownRenderer::new(chunks[0].width as usize);
+    let theme = ratatui_markdown::theme::ThemeConfig::default();
+
+    let mut all_lines: Vec<Line> = Vec::new();
+
     for msg in &app.chat_messages {
-        match msg.sender.as_str() {
-            "user" => {
-                md_text.push_str("**You:** ");
-                md_text.push_str(&msg.text);
-                md_text.push('\n');
-            }
-            "ai" => {
-                md_text.push_str("**AI:** ");
-                md_text.push_str(&msg.text);
-                md_text.push('\n');
-            }
-            _ => {
-                md_text.push_str(&msg.text);
-                md_text.push('\n');
-            }
+        let (prefix, bar_color) = match msg.sender.as_str() {
+            "user" => ("**You:** ", Color::Cyan),
+            "ai" => ("**AI:** ", Color::Green),
+            _ => ("", Color::DarkGray),
+        };
+
+        let md_text = format!("{prefix}{}\n", msg.text);
+        let blocks = renderer.parse(&md_text);
+        let msg_lines = renderer.render(&blocks, &theme);
+
+        for line in msg_lines {
+            let mut spans = vec![Span::styled("│ ", Style::default().fg(bar_color))];
+            spans.extend(line.spans);
+            all_lines.push(Line::from(spans));
         }
     }
 
-    // Show progress indicator in markdown
+    // Show progress indicator
     if let Some(ref state) = app.state
         && let Some(chat_name) = &app.chat_thread
     {
@@ -1155,19 +1158,22 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
             .iter()
             .any(|t| t.name == *chat_name && t.status == ThreadStatus::Processing);
         if is_processing {
-            md_text.push_str("\n*⏳ AI is thinking...*\n");
+            all_lines.push(Line::from(vec![
+                Span::raw("  "),
+                Span::styled(
+                    "⏳ AI is thinking...",
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::ITALIC),
+                ),
+            ]));
         }
     }
 
-    let renderer = ratatui_markdown::markdown::MarkdownRenderer::new(chunks[0].width as usize);
-    let theme = ratatui_markdown::theme::ThemeConfig::default();
-    let blocks = renderer.parse(&md_text);
-    let md_lines = renderer.render(&blocks, &theme);
-
     let inner_height = chunks[0].height as usize;
-    let max_skip = md_lines.len().saturating_sub(inner_height);
+    let max_skip = all_lines.len().saturating_sub(inner_height);
     let skip = max_skip.saturating_sub(app.chat_scroll);
-    let visible_lines: Vec<Line> = md_lines.into_iter().skip(skip).collect();
+    let visible_lines: Vec<Line> = all_lines.into_iter().skip(skip).collect();
 
     let messages_para = Paragraph::new(visible_lines);
     frame.render_widget(messages_para, chunks[0]);

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -1031,6 +1031,29 @@ fn render_compact_info(frame: &mut Frame, area: Rect, app: &App) {
             Span::styled("Pattern: ", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(t.pattern.as_deref().unwrap_or("-")),
         ];
+        if let Some(ref model) = t.model {
+            spans.push(Span::raw(" | "));
+            spans.push(Span::styled(
+                "Model: ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ));
+            spans.push(Span::raw(model));
+        }
+        if let (Some(cur), Some(max)) = (t.input_tokens, t.max_tokens) {
+            let pct = if max > 0 {
+                cur.checked_mul(100)
+                    .and_then(|v| v.checked_div(max))
+                    .unwrap_or(0)
+            } else {
+                0
+            };
+            spans.push(Span::raw(" | "));
+            spans.push(Span::styled(
+                "Tokens: ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ));
+            spans.push(Span::raw(format!("{cur} / {max} ({pct}%)")));
+        }
         if t.status == ThreadStatus::Processing {
             spans.push(Span::raw(" | "));
             spans.push(Span::styled(

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -326,7 +326,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
             }
             "websocket" => {
                 let (broadcast_tx, _) = tokio::sync::broadcast::channel(64);
-                let adapter = WebsocketOutboundAdapter::new(broadcast_tx.clone());
+                let adapter = WebsocketOutboundAdapter::new(broadcast_tx.clone(), storage.clone());
                 // Store the inbound adapter for later registration with the inspect server
                 let mut handler = WebsocketInboundAdapter::new(
                     channel_name.to_string(),


### PR DESCRIPTION
## Problem

When loading chat history in the dashboard, only user messages appeared — AI replies were missing.

## Root Cause

`WebsocketOutboundAdapter::send_reply` only broadcast replies via the broadcast channel but never persisted them to disk. Other channels (wecom_bot, email, feishu) all call `storage.store_reply()` to write to the `chat_history_*.jsonl` files.

## Fix

Added `Arc\<MessageStorage\>` to `WebsocketOutboundAdapter` and call `storage.store_reply()` in `send_reply` to persist AI replies to the chat log, same as other channel types.