### PR TITLE
fix: ensure chat bar colors render correctly via Line::into_iter

### DIFF
--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -1143,8 +1143,8 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
         let msg_lines = renderer.render(&blocks, &theme);
 
         for line in msg_lines {
-            let mut spans = vec![Span::styled("│ ", Style::default().fg(bar_color))];
-            spans.extend(line.spans);
+            let bar_span = Span::styled("│ ", Style::new().fg(bar_color));
+            let spans: Vec<Span> = std::iter::once(bar_span).chain(line).collect();
             all_lines.push(Line::from(spans));
         }
     }


### PR DESCRIPTION
## Fix

Changed bar span concatenation from `spans.extend(line.spans)` to `std::iter::once(bar_span).chain(line).collect()`, using `Line`'s `IntoIterator` impl to properly chain the colored bar span with markdown-rendered spans.

This ensures the bar's foreground color (cyan for user, green for AI) is preserved in the final `Line`.