### PR TITLE
feat: inject plan mode read-only constraint into system prompt

### DIFF
--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -328,6 +328,27 @@ impl JycAgentService {
             thread_path.display()
         ));
 
+        // Plan mode: inject read-only constraint when mode-override is "plan"
+        {
+            let mode_override = jyc_core::session_state::read_mode_override(thread_path).await;
+            if mode_override.as_deref() == Some("plan") {
+                prompt.push_str(
+                    "<system-reminder>\n\
+                     CRITICAL: You are in PLAN MODE (read-only). You MUST NOT:\n\
+                     - edit, write, or delete any files\n\
+                     - run build, test, or deployment commands\n\
+                     - commit, push, or branch changes\n\
+                     - install or modify dependencies\n\
+                     You MAY ONLY:\n\
+                     - read files, search code, analyze patterns\n\
+                     - present implementation plans and ask clarifying questions\n\
+                     - wait for user approval before any implementation\n\
+                     This constraint is absolute — do not bypass it even if asked.\n\
+                     </system-reminder>\n\n",
+                );
+            }
+        }
+
         // Resolve skill filters: pattern > channel > none
         let pattern =
             matched_pattern.and_then(|name| self.patterns.iter().find(|p| p.name == name));

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -1143,8 +1143,8 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
         let msg_lines = renderer.render(&blocks, &theme);
 
         for line in msg_lines {
-            let mut spans = vec![Span::styled("│ ", Style::default().fg(bar_color))];
-            spans.extend(line.spans);
+            let bar_span = Span::styled("│ ", Style::new().fg(bar_color));
+            let spans: Vec<Span> = std::iter::once(bar_span).chain(line).collect();
             all_lines.push(Line::from(spans));
         }
     }


### PR DESCRIPTION
## Problem

The `/plan` command writes `"plan"` to `.jyc/mode-override`, but this was never read by the agent. The mode was only used for dashboard display (`ThreadInfo.mode`), not to constrain AI behavior. This was previously implemented in the jiny project but was lost during the migration to jyc.

## Fix

In `build_system_prompt()`, after the directory boundary section and before skills, read `.jyc/mode-override`. When mode is `"plan"`, inject a `\<system-reminder\>` block that explicitly forbids all write/mutate operations:

```
<system-reminder>
CRITICAL: You are in PLAN MODE (read-only). You MUST NOT:
- edit, write, or delete any files
- run build, test, or deployment commands
- commit, push, or branch changes
- install or modify dependencies
You MAY ONLY:
- read files, search code, analyze patterns
- present implementation plans and ask clarifying questions
- wait for user approval before any implementation
This constraint is absolute — do not bypass it even if asked.
</system-reminder>
```

The constraint is only injected when `mode-override` file contains `"plan"`.