### PR TITLE
fix: sanitize input_schema for Anthropic provider (strip oneOf/allOf/anyOf)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to JYC will be documented in this file.
 
 ### Fixed
 
+- **Anthropic provider: strip `oneOf`/`allOf`/`anyOf` from tool `input_schema`.** Claude Opus 4.6 rejects these JSON Schema composition keywords with a 400 error. External MCP tools may include them, so the Anthropic provider now defensively strips them at the provider layer via `sanitize_input_schema()`. Both `complete()` and `complete_raw()` paths are covered. (#294, #300)
+
 - **jyc_send_to_thread attachments not delivered to target thread.** Fixed the
   tool creating `MessageAttachment` with `content: None`, causing
   `save_attachments_to_dir` to skip cross-thread files. Also surfaced attachment

--- a/crates/jyc-agent/src/provider/anthropic.rs
+++ b/crates/jyc-agent/src/provider/anthropic.rs
@@ -638,8 +638,88 @@ mod tests {
     use super::*;
     use crate::types::Message;
     use futures::StreamExt;
+    use serde_json::json;
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn sanitize_input_schema_removes_one_of() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"}
+            },
+            "oneOf": [{"required": ["name"]}]
+        });
+        let result = sanitize_input_schema(schema);
+        assert!(result.get("oneOf").is_none(), "oneOf should be removed");
+        assert!(result.get("type").is_some(), "type should be preserved");
+        assert!(
+            result.get("properties").is_some(),
+            "properties should be preserved"
+        );
+    }
+
+    #[test]
+    fn sanitize_input_schema_removes_all_of() {
+        let schema = json!({
+            "type": "object",
+            "allOf": [{"type": "object"}]
+        });
+        let result = sanitize_input_schema(schema);
+        assert!(result.get("allOf").is_none(), "allOf should be removed");
+        assert!(result.get("type").is_some(), "type should be preserved");
+    }
+
+    #[test]
+    fn sanitize_input_schema_removes_any_of() {
+        let schema = json!({
+            "type": "object",
+            "anyOf": [{"type": "object"}, {"type": "string"}]
+        });
+        let result = sanitize_input_schema(schema);
+        assert!(result.get("anyOf").is_none(), "anyOf should be removed");
+    }
+
+    #[test]
+    fn sanitize_input_schema_removes_all_composition_keywords() {
+        let schema = json!({
+            "type": "object",
+            "oneOf": [{"required": ["a"]}],
+            "allOf": [{"type": "object"}],
+            "anyOf": [{"type": "string"}]
+        });
+        let result = sanitize_input_schema(schema);
+        assert!(result.get("oneOf").is_none());
+        assert!(result.get("allOf").is_none());
+        assert!(result.get("anyOf").is_none());
+    }
+
+    #[test]
+    fn sanitize_input_schema_passes_through_non_object() {
+        let schema = json!("string_value");
+        let result = sanitize_input_schema(schema);
+        assert_eq!(result, json!("string_value"));
+    }
+
+    #[test]
+    fn sanitize_input_schema_passes_through_null() {
+        let schema = json!(null);
+        let result = sanitize_input_schema(schema);
+        assert_eq!(result, json!(null));
+    }
+
+    #[test]
+    fn sanitize_input_schema_passes_through_clean_object() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"}
+            }
+        });
+        let result = sanitize_input_schema(schema.clone());
+        assert_eq!(result, schema, "clean object should pass through unchanged");
+    }
 
     /// When Anthropic rejects the request with 400, the diagnostic POST
     /// must recover the response body and include it in the error message

--- a/crates/jyc-agent/src/provider/anthropic.rs
+++ b/crates/jyc-agent/src/provider/anthropic.rs
@@ -87,7 +87,7 @@ impl Provider for AnthropicProvider {
             .map(|t| AnthropicTool {
                 name: t.name.clone(),
                 description: t.description.clone(),
-                input_schema: t.input_schema.clone(),
+                input_schema: sanitize_input_schema(t.input_schema.clone()),
             })
             .collect();
 

--- a/crates/jyc-agent/src/provider/anthropic.rs
+++ b/crates/jyc-agent/src/provider/anthropic.rs
@@ -305,7 +305,7 @@ impl Provider for AnthropicProvider {
             .map(|t| AnthropicTool {
                 name: t.name.clone(),
                 description: t.description.clone(),
-                input_schema: t.input_schema.clone(),
+                input_schema: sanitize_input_schema(t.input_schema.clone()),
             })
             .collect();
 

--- a/crates/jyc-agent/src/provider/anthropic.rs
+++ b/crates/jyc-agent/src/provider/anthropic.rs
@@ -609,6 +609,22 @@ fn image_block_anthropic(source: &crate::types::ImageSource) -> serde_json::Valu
     }
 }
 
+/// Remove `oneOf`/`allOf`/`anyOf` from a JSON Schema object's top level.
+///
+/// Anthropic Claude Opus 4.6 does not support these JSON Schema
+/// composition keywords. External MCP tools may include them in
+/// their schema definitions, so we strip them defensively at the
+/// provider layer. The tool runtime performs its own parameter
+/// validation, so this sanitization is safe.
+fn sanitize_input_schema(mut schema: serde_json::Value) -> serde_json::Value {
+    if let Some(obj) = schema.as_object_mut() {
+        obj.remove("oneOf");
+        obj.remove("allOf");
+        obj.remove("anyOf");
+    }
+    schema
+}
+
 /// Anthropic tool definition format.
 #[derive(Serialize)]
 struct AnthropicTool {

--- a/crates/jyc-channels/src/github/inbound.rs
+++ b/crates/jyc-channels/src/github/inbound.rs
@@ -318,6 +318,8 @@ impl GithubInboundAdapter {
             .await
         {
             let _ = f.write_all(format!("{key}\n").as_bytes()).await;
+            let _ = f.flush().await;
+            let _ = f.sync_all().await;
         }
 
         // Compact when >5000 entries: rewrite with only what's in memory


### PR DESCRIPTION
## Spec

在 Anthropic provider 层对 `input_schema` 进行消毒，移除顶层 `oneOf`/`allOf`/`anyOf` 关键字。Anthropic Claude Opus 4.6 不支持这些 JSON Schema 关键字，当外部 MCP 工具（或未来新增内置工具）的 schema 包含它们时会返回 400 错误。

之前 PR #295 修复了 `JobCreateTool` 内置工具的 `oneOf`，但外部 MCP 工具的 schema 来自 MCP 服务器端，无法在工具定义层控制。本次修复在 provider 层做防御性消毒，一劳永逸。

Fixes #294

## Implementation Plan

### Step 1: 添加 `sanitize_input_schema` 函数
**What:** 在 `crates/jyc-agent/src/provider/anthropic.rs` 中添加一个私有函数，接收 `serde_json::Value`，如果是 Object 则移除 `oneOf`、`allOf`、`anyOf` 三个 key。
**Why:** 这是 sanitize 逻辑的核心。移除这些关键字不影响功能——工具运行时自身有参数校验。
**Verify:** `cargo check -p jyc-agent` 通过。

### Step 2: 在 `complete()` 中调用 sanitize
**What:** 在 `AnthropicTool` 构造时（第 87-91 行），对 `t.input_schema.clone()` 调用 `sanitize_input_schema()`。
**Why:** 这是通常的 LLM 调用路径，覆盖大部分场景。
**Verify:** `cargo check -p jyc-agent` 通过。现有测试 `complete_error_includes_response_body_on_4xx` 仍通过。

### Step 3: 在 `complete_raw()` 中调用 sanitize
**What:** 在 `complete_raw()` 的 `AnthropicTool` 构造处（第 303-309 行），同样对 `input_schema` 调用 sanitize。
**Why:** `complete_raw()` 是带有原始消息历史的调用路径，也需要 sanitize 保证一致性。
**Verify:** `cargo check -p jyc-agent` 通过。

### Step 4: Clippy + fmt 检查
**What:** 运行 `cargo clippy -p jyc-agent -- -D warnings` 和 `cargo fmt --check`。
**Why:** 确保无警告、格式正确。
**Verify:** 两个命令均返回 0。