### PR TITLE
debug: test chat bar color rendering with Red/Blue

### DIFF
--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -1133,8 +1133,8 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
 
     for msg in &app.chat_messages {
         let (prefix, bar_color) = match msg.sender.as_str() {
-            "user" => ("**You:** ", Color::Cyan),
-            "ai" => ("**AI:** ", Color::Green),
+            "user" => ("**You:** ", Color::Red),
+            "ai" => ("**AI:** ", Color::Blue),
             _ => ("", Color::DarkGray),
         };
 


### PR DESCRIPTION
Debug PR to determine root cause of chat bar color issue. Changed user bar to Red and AI bar to Blue.

If bars show as Red/Blue → Cyan/Green were too similar; switch to higher-contrast colors.
If bars still same color → ratatui-markdown theme overriding styles; need different approach.