### PR TITLE
fix: use arrow characters to distinguish user/AI messages

### DIFF
--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -331,7 +331,16 @@ impl JycAgentService {
         // Plan mode: inject read-only constraint when mode-override is "plan"
         {
             let mode_override = jyc_core::session_state::read_mode_override(thread_path).await;
+            tracing::info!(
+                thread = %thread_path.display(),
+                mode = ?mode_override,
+                "Read mode override"
+            );
             if mode_override.as_deref() == Some("plan") {
+                tracing::info!(
+                    thread = %thread_path.display(),
+                    "Injecting PLAN MODE constraint into system prompt"
+                );
                 prompt.push_str(
                     "<system-reminder>\n\
                      CRITICAL: You are in PLAN MODE (read-only). You MUST NOT:\n\
@@ -1102,6 +1111,17 @@ impl AgentService for JycAgentService {
         let system_prompt = self
             .build_system_prompt(thread_path, message.matched_pattern.as_deref())
             .await;
+        tracing::debug!(
+            thread = %thread_name,
+            prompt_len = system_prompt.len(),
+            has_plan_mode = system_prompt.contains("PLAN MODE"),
+            "System prompt built"
+        );
+        tracing::trace!(
+            thread = %thread_name,
+            prompt = %system_prompt,
+            "Full system prompt (enable RUST_LOG=trace to see)"
+        );
         let user_blocks = self.build_user_blocks(message, provider.supports_images());
 
         // 5. Build tool registry

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -1132,10 +1132,10 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
     let mut all_lines: Vec<Line> = Vec::new();
 
     for msg in &app.chat_messages {
-        let (prefix, bar_color) = match msg.sender.as_str() {
-            "user" => ("**You:** ", Color::Red),
-            "ai" => ("**AI:** ", Color::Blue),
-            _ => ("", Color::DarkGray),
+        let (prefix, bar) = match msg.sender.as_str() {
+            "user" => ("**You:** ", "▶ "),
+            "ai" => ("**AI:** ", "◀ "),
+            _ => ("", "  "),
         };
 
         let md_text = format!("{prefix}{}\n", msg.text);
@@ -1143,7 +1143,7 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
         let msg_lines = renderer.render(&blocks, &theme);
 
         for line in msg_lines {
-            let bar_span = Span::styled("│ ", Style::new().fg(bar_color));
+            let bar_span = Span::raw(bar);
             let spans: Vec<Span> = std::iter::once(bar_span).chain(line).collect();
             all_lines.push(Line::from(spans));
         }

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -1133,8 +1133,8 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
 
     for msg in &app.chat_messages {
         let (prefix, bar_color) = match msg.sender.as_str() {
-            "user" => ("**You:** ", Color::Cyan),
-            "ai" => ("**AI:** ", Color::Green),
+            "user" => ("**You:** ", Color::Red),
+            "ai" => ("**AI:** ", Color::Blue),
             _ => ("", Color::DarkGray),
         };
 


### PR DESCRIPTION
## Change

No more color-dependent distinction. Uses Unicode arrows instead:

- User messages: `▶ **You:** hello`
- AI messages: `◀ **AI:** hi there`

No color styling — works in any terminal regardless of color support.