### PR TITLE
fix: show bar prefix only on user messages, AI gets plain bold label

### DIFF
--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -1133,9 +1133,9 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
 
     for msg in &app.chat_messages {
         let (prefix, bar) = match msg.sender.as_str() {
-            "user" => ("**You:** ", "▶ "),
-            "ai" => ("**AI:** ", "◀ "),
-            _ => ("", "  "),
+            "user" => ("**You:** ", "│ "),
+            "ai" => ("**AI:** ", ""),
+            _ => ("", ""),
         };
 
         let md_text = format!("{prefix}{}\n", msg.text);
@@ -1143,9 +1143,13 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
         let msg_lines = renderer.render(&blocks, &theme);
 
         for line in msg_lines {
-            let bar_span = Span::raw(bar);
-            let spans: Vec<Span> = std::iter::once(bar_span).chain(line).collect();
-            all_lines.push(Line::from(spans));
+            if bar.is_empty() {
+                all_lines.push(line);
+            } else {
+                let bar_span = Span::raw(bar);
+                let spans: Vec<Span> = std::iter::once(bar_span).chain(line).collect();
+                all_lines.push(Line::from(spans));
+            }
         }
     }
 


### PR DESCRIPTION
## Change

- User messages: `│ **You:** hello` (with vertical bar)
- AI messages: `**AI:** hi there` (plain, no prefix)

Asymmetric design — the bar on user messages alone provides visual distinction. No color, no extra characters on AI side.