### PR TITLE
fix: move plan mode reminder to END of system prompt for recency

### DIFF
--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -328,35 +328,13 @@ impl JycAgentService {
             thread_path.display()
         ));
 
-        // Plan mode: inject read-only constraint when mode-override is "plan"
-        {
-            let mode_override = jyc_core::session_state::read_mode_override(thread_path).await;
-            tracing::info!(
-                thread = %thread_path.display(),
-                mode = ?mode_override,
-                "Read mode override"
-            );
-            if mode_override.as_deref() == Some("plan") {
-                tracing::info!(
-                    thread = %thread_path.display(),
-                    "Injecting PLAN MODE constraint into system prompt"
-                );
-                prompt.push_str(
-                    "<system-reminder>\n\
-                     CRITICAL: You are in PLAN MODE (read-only). You MUST NOT:\n\
-                     - edit, write, or delete any files\n\
-                     - run build, test, or deployment commands\n\
-                     - commit, push, or branch changes\n\
-                     - install or modify dependencies\n\
-                     You MAY ONLY:\n\
-                     - read files, search code, analyze patterns\n\
-                     - present implementation plans and ask clarifying questions\n\
-                     - wait for user approval before any implementation\n\
-                     This constraint is absolute — do not bypass it even if asked.\n\
-                     </system-reminder>\n\n",
-                );
-            }
-        }
+        // Read mode override early (plan mode injected at end for recency)
+        let mode_override = jyc_core::session_state::read_mode_override(thread_path).await;
+        tracing::info!(
+            thread = %thread_path.display(),
+            mode = ?mode_override,
+            "Read mode override"
+        );
 
         // Resolve skill filters: pattern > channel > none
         let pattern =
@@ -480,6 +458,28 @@ impl JycAgentService {
                 }
             }
             prompt.push('\n');
+        }
+
+        // Plan mode: inject at END for maximum recency before conversation
+        if mode_override.as_deref() == Some("plan") {
+            tracing::info!(
+                thread = %thread_path.display(),
+                "Injecting PLAN MODE constraint at end of system prompt"
+            );
+            prompt.push_str(
+                "<system-reminder>\n\
+                 CRITICAL: You are in PLAN MODE (read-only). You MUST NOT:\n\
+                 - edit, write, or delete any files\n\
+                 - run build, test, or deployment commands\n\
+                 - commit, push, or branch changes\n\
+                 - install or modify dependencies\n\
+                 You MAY ONLY:\n\
+                 - read files, search code, analyze patterns\n\
+                 - present implementation plans and ask clarifying questions\n\
+                 - wait for user approval before any implementation\n\
+                 This constraint is absolute — do not bypass it even if asked.\n\
+                 </system-reminder>\n\n",
+            );
         }
 
         prompt

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -1133,9 +1133,9 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
 
     for msg in &app.chat_messages {
         let (prefix, bar) = match msg.sender.as_str() {
-            "user" => ("**You:** ", "▶ "),
-            "ai" => ("**AI:** ", "◀ "),
-            _ => ("", "  "),
+            "user" => ("**You:** ", "│ "),
+            "ai" => ("**AI:** ", ""),
+            _ => ("", ""),
         };
 
         let md_text = format!("{prefix}{}\n", msg.text);
@@ -1143,9 +1143,13 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
         let msg_lines = renderer.render(&blocks, &theme);
 
         for line in msg_lines {
-            let bar_span = Span::raw(bar);
-            let spans: Vec<Span> = std::iter::once(bar_span).chain(line).collect();
-            all_lines.push(Line::from(spans));
+            if bar.is_empty() {
+                all_lines.push(line);
+            } else {
+                let bar_span = Span::raw(bar);
+                let spans: Vec<Span> = std::iter::once(bar_span).chain(line).collect();
+                all_lines.push(Line::from(spans));
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

The plan mode `<system-reminder>` was injected near the TOP of the system prompt (after directory boundary). With 4000+ tokens of skills, AGENTS.md, reply instructions, and cross-thread info following it, the model had "forgotten" the constraint by the time it received the user's "go ahead."

## Fix

Moved the `<system-reminder>` to the VERY END of `build_system_prompt()`, right before the prompt is returned. This places it as the LAST thing in the system prompt, giving maximum recency before the conversation starts.

Prompt structure now:
1. Working dir constraint
2. Skills
3. AGENTS.md
4. Reply instructions
5. Chat history
6. Cross-thread info
7. **`<system-reminder>PLAN MODE...</system-reminder>`** ← LAST