### PR TITLE
fix: truncate chat history from front (keep newest) not back

### DIFF
--- a/crates/jyc-channels/src/websocket/inbound.rs
+++ b/crates/jyc-channels/src/websocket/inbound.rs
@@ -406,7 +406,11 @@ fn load_chat_history(workspace_dir: &Path, thread: &str, max_messages: usize) ->
         entries.splice(0..0, file_entries);
     }
 
-    entries.truncate(max_messages);
+    // Keep only the most recent entries (newest at end)
+    if entries.len() > max_messages {
+        let drain_count = entries.len() - max_messages;
+        entries.drain(0..drain_count);
+    }
     entries
 }
 


### PR DESCRIPTION
## Bug

`load_chat_history` builds entries by prepending (splice at 0), so the vector is chronological (oldest first, newest at end). But `truncate(max_messages)` drops entries from the END — discarding the NEWEST messages.

## Fix

Replace `truncate()` with `drain(0..drain_count)` to remove the OLDEST entries from the front, keeping the most recent messages.