### PR TITLE
feat: add /? help command

### DIFF
--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -479,6 +479,7 @@ impl JycAgentService {
                  - wait for user approval before any implementation\n\
                  This constraint is absolute — do not bypass it even if asked.\n\
                  Do not exit plan mode even if the user requests it.\n\
+                 You are in PLAN MODE.\n\
                  </system-reminder>\n\n",
             );
         }

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -479,6 +479,7 @@ impl JycAgentService {
                  - wait for user approval before any implementation\n\
                  This constraint is absolute — do not bypass it even if asked.\n\
                  Do not exit plan mode even if the user requests it.\n\
+                 Even if you previously ran write/edit commands in this conversation, you are now in PLAN MODE and must not make any changes.\n\
                  You are in PLAN MODE.\n\
                  </system-reminder>\n\n",
             );

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -81,7 +81,8 @@ struct App {
     chat_focus: ChatFocus,
     chat_scroll: usize,
     activity_scroll: usize,
-    activity_visible: bool,
+    /// Activity pane split state: 0=80/20, 1=100/0, 2=20/80, 3=0/100
+    activity_split: u8,
     ws_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
     ws_rx: tokio::sync::mpsc::UnboundedReceiver<WsEvent>,
 }
@@ -106,7 +107,7 @@ impl App {
             chat_focus: ChatFocus::ChatPane,
             chat_scroll: 0,
             activity_scroll: 0,
-            activity_visible: true,
+            activity_split: 0,
             ws_tx: None,
             ws_rx,
         }
@@ -177,7 +178,7 @@ impl App {
         self.chat_focus = ChatFocus::ChatPane;
         self.chat_scroll = 0;
         self.activity_scroll = 0;
-        self.activity_visible = true;
+        self.activity_split = 0;
 
         let (cmd_tx, cmd_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
         let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel::<WsEvent>();
@@ -529,10 +530,10 @@ fn handle_chat_keys(app: &mut App, key: event::KeyEvent) {
         return;
     }
 
-    // Ctrl+A toggles activity pane visibility in chatting
-    let is_ctrl_a = key.code == KeyCode::Char('a') && key.modifiers.contains(KeyModifiers::CONTROL);
-    if is_ctrl_a && app.chat_phase == ChatPhase::Chatting {
-        app.activity_visible = !app.activity_visible;
+    // Ctrl+W cycles activity pane split ratio
+    let is_ctrl_w = key.code == KeyCode::Char('w') && key.modifiers.contains(KeyModifiers::CONTROL);
+    if is_ctrl_w && app.chat_phase == ChatPhase::Chatting {
+        app.activity_split = (app.activity_split + 1) % 4;
         return;
     }
 
@@ -739,15 +740,33 @@ fn ui_chat_mode(frame: &mut Frame, area: Rect, app: &mut App) {
             render_pattern_select(frame, main_chunks[2], app);
         }
         ChatPhase::Chatting => {
-            if app.activity_visible {
-                let content = Layout::default()
-                    .direction(Direction::Horizontal)
-                    .constraints([Constraint::Percentage(80), Constraint::Percentage(20)])
-                    .split(main_chunks[2]);
-                render_chat_conversation(frame, content[0], app);
-                render_activity_log(frame, content[1], app);
-            } else {
-                render_chat_conversation(frame, main_chunks[2], app);
+            match app.activity_split {
+                1 => {
+                    // 100/0 — full chat, no activity pane
+                    render_chat_conversation(frame, main_chunks[2], app);
+                }
+                2 => {
+                    // 20/80 — activity dominant
+                    let content = Layout::default()
+                        .direction(Direction::Horizontal)
+                        .constraints([Constraint::Percentage(20), Constraint::Percentage(80)])
+                        .split(main_chunks[2]);
+                    render_chat_conversation(frame, content[0], app);
+                    render_activity_log(frame, content[1], app);
+                }
+                3 => {
+                    // 0/100 — full activity
+                    render_activity_log(frame, main_chunks[2], app);
+                }
+                _ => {
+                    // 0 — 80/20 (default)
+                    let content = Layout::default()
+                        .direction(Direction::Horizontal)
+                        .constraints([Constraint::Percentage(80), Constraint::Percentage(20)])
+                        .split(main_chunks[2]);
+                    render_chat_conversation(frame, content[0], app);
+                    render_activity_log(frame, content[1], app);
+                }
             }
         }
     }
@@ -1312,7 +1331,7 @@ fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
         match app.chat_phase {
             ChatPhase::PatternSelect => "[↑↓]select [Enter]choose [Esc/Ctrl+Q]close",
             ChatPhase::Chatting => {
-                "[Tab]focus [←→]cursor [↑↓]scroll [Ctrl+A]activity [Esc]back [Ctrl+Q]close"
+                "[Tab]focus [←→]cursor [↑↓]scroll [Ctrl+W]split [Esc]back [Ctrl+Q]close"
             }
         }
     } else {

--- a/crates/jyc-core/src/command/help_handler.rs
+++ b/crates/jyc-core/src/command/help_handler.rs
@@ -1,0 +1,98 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use super::handler::{CommandContext, CommandHandler, CommandResult};
+
+/// /? command — show available commands and their descriptions.
+///
+/// Usage:
+///   /?    List all available commands with brief descriptions
+pub struct HelpCommandHandler;
+
+#[async_trait]
+impl CommandHandler for HelpCommandHandler {
+    fn name(&self) -> &str {
+        "/?"
+    }
+
+    fn description(&self) -> &str {
+        "Show available commands"
+    }
+
+    async fn execute(&self, _context: CommandContext) -> Result<CommandResult> {
+        let help = "\
+Available commands:\n\
+  /model <name>  — switch AI model\n\
+  /plan   — switch to plan mode (read-only)\n\
+  /build  — switch to build mode (full execution)\n\
+  /reset  — reset session, keep chat history\n\
+  /new    — reset session and clear chat history\n\
+  /close  — close and delete this thread\n\
+  /template [update] — apply or re-apply thread template\n\
+  /?      — show this help";
+
+        Ok(CommandResult {
+            success: true,
+            message: help.into(),
+            error: None,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn test_help_contains_commands() {
+        let ctx = CommandContext {
+            args: vec![],
+            thread_path: PathBuf::from("/tmp/test"),
+            config: Arc::new(
+                jyc_types::load_config_from_str(
+                    r#"
+[general]
+[channels.test]
+type = "email"
+[channels.test.inbound]
+host = "h"
+port = 993
+username = "u"
+password = "p"
+[channels.test.outbound]
+host = "h"
+port = 465
+username = "u"
+password = "p"
+[agent]
+enabled = true
+mode = "agent"
+"#,
+                )
+                .unwrap(),
+            ),
+            channel: "test".into(),
+            agent: None,
+            template_dir: PathBuf::from("/tmp/test/templates"),
+        };
+
+        let handler = HelpCommandHandler;
+        let result = handler.execute(ctx).await.unwrap();
+        assert!(result.success);
+        // Verify key commands are listed
+        for cmd in &[
+            "/model",
+            "/plan",
+            "/build",
+            "/reset",
+            "/new",
+            "/close",
+            "/template",
+            "/?",
+        ] {
+            assert!(result.message.contains(cmd), "help should mention {cmd}");
+        }
+    }
+}

--- a/crates/jyc-core/src/command/mod.rs
+++ b/crates/jyc-core/src/command/mod.rs
@@ -1,5 +1,6 @@
 pub mod close_handler;
 pub mod handler;
+pub mod help_handler;
 pub mod mode_handler;
 pub mod new_handler;
 pub mod registry;

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -14,6 +14,7 @@ use crate::thread_event_bus::{SimpleThreadEventBus, ThreadEventBusRef};
 use crate::agent::AgentService;
 use crate::command::close_handler::CloseCommandHandler;
 use crate::command::handler::CommandContext;
+use crate::command::help_handler::HelpCommandHandler;
 use crate::command::mode_handler::{BuildCommandHandler, PlanCommandHandler};
 use crate::command::new_handler::NewCommandHandler;
 use crate::command::registry::CommandRegistry;
@@ -1021,6 +1022,7 @@ async fn process_message(
         .unwrap_or("");
 
     let mut command_registry = CommandRegistry::new();
+    command_registry.register(Box::new(HelpCommandHandler));
     command_registry.register(Box::new(PlanCommandHandler));
     command_registry.register(Box::new(BuildCommandHandler));
     command_registry.register(Box::new(ResetCommandHandler));


### PR DESCRIPTION
Adds a `/?` command that lists all available commands with brief descriptions.

Commands listed: `/model`, `/plan`, `/build`, `/reset`, `/new`, `/close`, `/template`, `/?`