### PR TITLE
feat: implement /model command for listing and switching AI models

### DIFF
--- a/crates/jyc-core/src/command/mod.rs
+++ b/crates/jyc-core/src/command/mod.rs
@@ -2,6 +2,7 @@ pub mod close_handler;
 pub mod handler;
 pub mod help_handler;
 pub mod mode_handler;
+pub mod model_handler;
 pub mod new_handler;
 pub mod registry;
 pub mod reset_handler;

--- a/crates/jyc-core/src/command/model_handler.rs
+++ b/crates/jyc-core/src/command/model_handler.rs
@@ -1,0 +1,326 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use super::handler::{CommandContext, CommandHandler, CommandResult};
+
+/// /model command — switch AI model for this thread.
+///
+/// Usage:
+///   /model              List all available models
+///   /model <provider/model-id>  Switch to the specified model
+///   /model reset        Reset to default model from config
+pub struct ModelCommandHandler;
+
+#[async_trait]
+impl CommandHandler for ModelCommandHandler {
+    fn name(&self) -> &str {
+        "/model"
+    }
+
+    fn description(&self) -> &str {
+        "Switch AI model or list available models"
+    }
+
+    async fn execute(&self, context: CommandContext) -> Result<CommandResult> {
+        let jyc_dir = context.thread_path.join(".jyc");
+        tokio::fs::create_dir_all(&jyc_dir).await?;
+
+        let providers = &context.config.agent.providers;
+
+        if context.args.is_empty() {
+            // /model — list all available models
+            if providers.is_empty() {
+                return Ok(CommandResult {
+                    success: true,
+                    message: "/model: no models configured".into(),
+                    error: None,
+                });
+            }
+
+            let mut lines = vec!["Available models:".to_string()];
+            for (provider_name, provider_def) in providers {
+                if provider_def.models.is_empty() {
+                    lines.push(format!("  {provider_name}/*  (no specific models listed)"));
+                } else {
+                    for model_id in provider_def.models.keys() {
+                        lines.push(format!("  {provider_name}/{model_id}"));
+                    }
+                }
+            }
+
+            Ok(CommandResult {
+                success: true,
+                message: lines.join("\n"),
+                error: None,
+            })
+        } else if context.args.len() == 1 && context.args[0] == "reset" {
+            // /model reset — remove override, restore default
+            let override_path = jyc_dir.join("model-override");
+
+            if override_path.exists() {
+                tokio::fs::remove_file(&override_path).await?;
+                Ok(CommandResult {
+                    success: true,
+                    message: "/model: reset to default model".into(),
+                    error: None,
+                })
+            } else {
+                Ok(CommandResult {
+                    success: true,
+                    message: "/model: already using default model".into(),
+                    error: None,
+                })
+            }
+        } else {
+            // /model <provider/model-id> — switch model
+            let model_id = context.args[0].clone();
+
+            // Validate format: must be "provider/model-id"
+            match model_id.split_once('/') {
+                Some((provider_name, model_name))
+                    if !provider_name.is_empty() && !model_name.is_empty() =>
+                {
+                    // Validate provider exists
+                    let Some(provider_def) = providers.get(provider_name) else {
+                        let available: Vec<&str> = providers.keys().map(|s| s.as_str()).collect();
+                        return Ok(CommandResult {
+                            success: false,
+                            message: format!("/model: unknown provider '{provider_name}'"),
+                            error: Some(format!(
+                                "Provider '{provider_name}' not found. Available: {available:?}"
+                            )),
+                        });
+                    };
+
+                    // Validate model exists (if provider has specific models)
+                    if !provider_def.models.is_empty()
+                        && !provider_def.models.contains_key(model_name)
+                    {
+                        let available: Vec<&str> =
+                            provider_def.models.keys().map(|s| s.as_str()).collect();
+                        return Ok(CommandResult {
+                            success: false,
+                            message: format!(
+                                "/model: unknown model '{model_name}' for provider '{provider_name}'"
+                            ),
+                            error: Some(format!(
+                                "Model '{model_name}' not found in provider '{provider_name}'. Available: {available:?}"
+                            )),
+                        });
+                    }
+
+                    // Write override file
+                    let override_path = jyc_dir.join("model-override");
+                    tokio::fs::write(&override_path, &model_id).await?;
+
+                    Ok(CommandResult {
+                        success: true,
+                        message: format!("/model: switched to {model_id}"),
+                        error: None,
+                    })
+                }
+                _ => Ok(CommandResult {
+                    success: false,
+                    message: format!("/model: invalid format '{model_id}'"),
+                    error: Some(
+                        "Expected 'provider/model-id' (e.g., 'anthropic/claude-opus-4-6')".into(),
+                    ),
+                }),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+
+    fn test_context(thread_path: &Path) -> CommandContext {
+        CommandContext {
+            args: vec![],
+            thread_path: thread_path.to_path_buf(),
+            config: Arc::new(
+                jyc_types::load_config_from_str(
+                    r#"
+[general]
+[channels.test]
+type = "email"
+[channels.test.inbound]
+host = "h"
+port = 993
+username = "u"
+password = "p"
+[channels.test.outbound]
+host = "h"
+port = 465
+username = "u"
+password = "p"
+[agent]
+enabled = true
+mode = "agent"
+
+[agent.providers.deepseek]
+type = "openai-compatible"
+base_url = "https://api.deepseek.com"
+api_key_env = "DEEPSEEK_API_KEY"
+
+[agent.providers.deepseek.models.deepseek-chat]
+context_window = 64000
+
+[agent.providers.deepseek.models.deepseek-reasoner]
+context_window = 64000
+
+[agent.providers.anthropic]
+type = "anthropic"
+base_url = "https://api.anthropic.com/v1"
+api_key_env = "ANTHROPIC_API_KEY"
+
+[agent.providers.anthropic.models.claude-opus-4-6]
+context_window = 200000
+"#,
+                )
+                .unwrap(),
+            ),
+            channel: "test".into(),
+            agent: None,
+            template_dir: PathBuf::from("/tmp/test/templates"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_list_models() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut ctx = test_context(tmp.path());
+        ctx.args = vec![];
+        let handler = ModelCommandHandler;
+        let result = handler.execute(ctx).await.unwrap();
+        assert!(result.success);
+        assert!(result.message.contains("Available models:"));
+        assert!(result.message.contains("deepseek/deepseek-chat"));
+        assert!(result.message.contains("deepseek/deepseek-reasoner"));
+        assert!(result.message.contains("anthropic/claude-opus-4-6"));
+    }
+
+    #[tokio::test]
+    async fn test_list_models_empty_providers() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ctx = CommandContext {
+            args: vec![],
+            thread_path: tmp.path().to_path_buf(),
+            config: Arc::new(
+                jyc_types::load_config_from_str(
+                    r#"
+[general]
+[channels.test]
+type = "email"
+[channels.test.inbound]
+host = "h"
+port = 993
+username = "u"
+password = "p"
+[channels.test.outbound]
+host = "h"
+port = 465
+username = "u"
+password = "p"
+[agent]
+enabled = true
+mode = "agent"
+"#,
+                )
+                .unwrap(),
+            ),
+            channel: "test".into(),
+            agent: None,
+            template_dir: PathBuf::from("/tmp/test/templates"),
+        };
+        let handler = ModelCommandHandler;
+        let result = handler.execute(ctx).await.unwrap();
+        assert!(result.success);
+        assert!(result.message.contains("no models configured"));
+    }
+
+    #[tokio::test]
+    async fn test_switch_model() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut ctx = test_context(tmp.path());
+        ctx.args = vec!["deepseek/deepseek-chat".into()];
+        let handler = ModelCommandHandler;
+        let result = handler.execute(ctx).await.unwrap();
+        assert!(result.success);
+        assert!(
+            result
+                .message
+                .contains("switched to deepseek/deepseek-chat")
+        );
+
+        let content = tokio::fs::read_to_string(tmp.path().join(".jyc/model-override"))
+            .await
+            .unwrap();
+        assert_eq!(content, "deepseek/deepseek-chat");
+    }
+
+    #[tokio::test]
+    async fn test_reset_model() {
+        let tmp = tempfile::tempdir().unwrap();
+        let jyc_dir = tmp.path().join(".jyc");
+        tokio::fs::create_dir_all(&jyc_dir).await.unwrap();
+        tokio::fs::write(jyc_dir.join("model-override"), "deepseek/deepseek-chat\n")
+            .await
+            .unwrap();
+
+        let mut ctx = test_context(tmp.path());
+        ctx.args = vec!["reset".into()];
+        let handler = ModelCommandHandler;
+        let result = handler.execute(ctx).await.unwrap();
+        assert!(result.success);
+        assert!(result.message.contains("reset to default model"));
+        assert!(!jyc_dir.join("model-override").exists());
+    }
+
+    #[tokio::test]
+    async fn test_reset_model_no_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut ctx = test_context(tmp.path());
+        ctx.args = vec!["reset".into()];
+        let handler = ModelCommandHandler;
+        let result = handler.execute(ctx).await.unwrap();
+        assert!(result.success);
+        assert!(result.message.contains("already using default"));
+    }
+
+    #[tokio::test]
+    async fn test_invalid_model_format() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut ctx = test_context(tmp.path());
+        ctx.args = vec!["invalid-format".into()];
+        let handler = ModelCommandHandler;
+        let result = handler.execute(ctx).await.unwrap();
+        assert!(!result.success);
+        assert!(result.message.contains("invalid format"));
+    }
+
+    #[tokio::test]
+    async fn test_unknown_provider() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut ctx = test_context(tmp.path());
+        ctx.args = vec!["openai/gpt-5".into()];
+        let handler = ModelCommandHandler;
+        let result = handler.execute(ctx).await.unwrap();
+        assert!(!result.success);
+        assert!(result.message.contains("unknown provider"));
+    }
+
+    #[tokio::test]
+    async fn test_unknown_model() {
+        let tmp = tempfile::tempdir().unwrap();
+        let mut ctx = test_context(tmp.path());
+        ctx.args = vec!["deepseek/non-existent-model".into()];
+        let handler = ModelCommandHandler;
+        let result = handler.execute(ctx).await.unwrap();
+        assert!(!result.success);
+        assert!(result.message.contains("unknown model"));
+    }
+}

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -16,6 +16,7 @@ use crate::command::close_handler::CloseCommandHandler;
 use crate::command::handler::CommandContext;
 use crate::command::help_handler::HelpCommandHandler;
 use crate::command::mode_handler::{BuildCommandHandler, PlanCommandHandler};
+use crate::command::model_handler::ModelCommandHandler;
 use crate::command::new_handler::NewCommandHandler;
 use crate::command::registry::CommandRegistry;
 use crate::command::reset_handler::ResetCommandHandler;
@@ -1023,6 +1024,7 @@ async fn process_message(
 
     let mut command_registry = CommandRegistry::new();
     command_registry.register(Box::new(HelpCommandHandler));
+    command_registry.register(Box::new(ModelCommandHandler));
     command_registry.register(Box::new(PlanCommandHandler));
     command_registry.register(Box::new(BuildCommandHandler));
     command_registry.register(Box::new(ResetCommandHandler));


### PR DESCRIPTION
## Summary

Implements the `/model` command (issue #306) for listing available models and switching the AI model per thread.

## Changes

- **New**: `crates/jyc-core/src/command/model_handler.rs` — `ModelCommandHandler` implementing `CommandHandler`
- **Edit**: `crates/jyc-core/src/command/mod.rs` — add module declaration
- **Edit**: `crates/jyc-core/src/thread_manager.rs` — import and register handler

## Usage

| Command | Behavior |
|---|---|
| `/model` | List all available models from `[agent.providers]` config |
| `/model <provider/model-id>` | Switch model, writes `.jyc/model-override` |
| `/model reset` | Remove override, restore default model |

## Validation

- Validates provider exists in config
- Validates model exists in provider (if provider lists specific models)
- Validates `provider/model-id` format

## Testing

- 7 new unit tests: list, switch, reset, reset-no-override, invalid format, unknown provider, unknown model
- Full test suite: 167/167 passing
- `cargo check` zero warnings

Closes #306