### PR TITLE
feat: show latest activity event in chat pane compact info bar

### DIFF
--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -1081,10 +1081,17 @@ fn render_compact_info(frame: &mut Frame, area: Rect, app: &App) {
         }
         if t.status == ThreadStatus::Processing {
             spans.push(Span::raw(" | "));
-            spans.push(Span::styled(
-                "⏳ AI thinking...",
-                Style::default().fg(Color::Yellow),
-            ));
+            if let Some(latest) = t.activity.first() {
+                spans.push(Span::styled(
+                    format!("⏳ {}", latest.text),
+                    Style::default().fg(Color::Yellow),
+                ));
+            } else {
+                spans.push(Span::styled(
+                    "⏳ AI thinking...",
+                    Style::default().fg(Color::Yellow),
+                ));
+            }
         }
         Line::from(spans)
     } else {


### PR DESCRIPTION
## Summary

When a thread is in **Processing** state, the compact info bar at the bottom of the chat pane now shows the **latest activity event text** instead of a generic "⏳ AI thinking..." message. This lets users see what the AI is doing at a glance.

## Before
```
⏳ AI thinking...
```

## After
```
⏳ Tool running (bash)
⏳ Reading file...
```

Falls back to "⏳ AI thinking..." when no activity events have been recorded yet.

## Changes
- `crates/jyc-cli/src/cli/dashboard.rs` — 1 edit: check `t.activity.first()` before rendering the status span

## Testing
- `cargo fmt -- --check` ✅
- `cargo check` zero warnings ✅