### PR TITLE
fix: inject BUILD mode tag in prompts to prevent stale PLAN mode inheritance

### DIFF
--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -483,6 +483,20 @@ impl JycAgentService {
                  You are in PLAN MODE.\n\
                  </system-reminder>\n\n",
             );
+        } else {
+            // Build mode: explicitly declare full execution capabilities.
+            // Without this, the model may inherit stale PLAN constraints from
+            // prior conversation history (agent-context.json).
+            prompt.push_str(
+                "<system-reminder>\n\
+                 You are in BUILD MODE (full execution). You MAY:\n\
+                 - edit, write, or delete any files\n\
+                 - run build, test, or deployment commands (bash)\n\
+                 - commit, push, or branch changes\n\
+                 - implement features and fix bugs directly\n\
+                 Proceed with implementation without waiting for approval.\n\
+                 </system-reminder>\n\n",
+            );
         }
 
         prompt
@@ -566,6 +580,17 @@ impl JycAgentService {
             prompt.push_str("<mode>\n");
             prompt.push_str("Current mode: PLAN (read-only). ");
             prompt.push_str("Use only read/search/analyze tools. Do NOT edit/write/commit.\n");
+            prompt.push_str("</mode>\n");
+        } else {
+            // Build mode: explicitly declare full execution capabilities so the
+            // model does not mistakenly inherit stale PLAN constraints from
+            // prior conversation history (agent-context.json).
+            prompt.push('\n');
+            prompt.push_str("<mode>\n");
+            prompt.push_str("Current mode: BUILD (full execution). ");
+            prompt.push_str(
+                "You may use all tools including edit, write, bash, commit, and deploy.\n",
+            );
             prompt.push_str("</mode>\n");
         }
 

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -1986,4 +1986,43 @@ mod tests {
             assert_eq!(skills.len(), 2);
         });
     }
+
+    #[test]
+    fn build_user_prompt_injects_build_mode_tag() {
+        let svc = service_with_skills(vec![], None, None);
+        let message = InboundMessage {
+            id: "test-id".into(),
+            channel: "test".into(),
+            channel_uid: "uid".into(),
+            sender: "test-sender".into(),
+            sender_address: "test@example.com".into(),
+            recipients: vec![],
+            topic: "test".into(),
+            content: jyc_types::MessageContent {
+                text: Some("hello world".into()),
+                ..Default::default()
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata: Default::default(),
+            matched_pattern: None,
+        };
+
+        // Plan mode: should inject PLAN tag
+        let plan_prompt = svc.build_user_prompt_text(&message, Some("plan"));
+        assert!(
+            plan_prompt.contains("Current mode: PLAN (read-only)"),
+            "plan mode prompt should contain PLAN tag, got: {plan_prompt}"
+        );
+
+        // Build mode (None = no override): should inject BUILD tag
+        let build_prompt = svc.build_user_prompt_text(&message, None);
+        assert!(
+            build_prompt.contains("Current mode: BUILD (full execution)"),
+            "build mode prompt should contain BUILD tag, got: {build_prompt}"
+        );
+    }
 }

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -1081,17 +1081,10 @@ fn render_compact_info(frame: &mut Frame, area: Rect, app: &App) {
         }
         if t.status == ThreadStatus::Processing {
             spans.push(Span::raw(" | "));
-            if let Some(latest) = t.activity.first() {
-                spans.push(Span::styled(
-                    format!("⏳ {}", latest.text),
-                    Style::default().fg(Color::Yellow),
-                ));
-            } else {
-                spans.push(Span::styled(
-                    "⏳ AI thinking...",
-                    Style::default().fg(Color::Yellow),
-                ));
-            }
+            spans.push(Span::styled(
+                "⏳ AI thinking...",
+                Style::default().fg(Color::Yellow),
+            ));
         }
         Line::from(spans)
     } else {
@@ -1191,15 +1184,19 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
     if let Some(ref state) = app.state
         && let Some(chat_name) = &app.chat_thread
     {
-        let is_processing = state
-            .threads
-            .iter()
-            .any(|t| t.name == *chat_name && t.status == ThreadStatus::Processing);
-        if is_processing {
+        let chat_thread = state.threads.iter().find(|t| t.name == *chat_name);
+        if let Some(ct) = chat_thread
+            && ct.status == ThreadStatus::Processing
+        {
+            let status_text = ct
+                .activity
+                .last()
+                .map(|a| format!("⏳ {}", a.text))
+                .unwrap_or_else(|| "⏳ AI is thinking...".to_string());
             all_lines.push(Line::from(vec![
                 Span::raw("  "),
                 Span::styled(
-                    "⏳ AI is thinking...",
+                    status_text,
                     Style::default()
                         .fg(Color::Yellow)
                         .add_modifier(Modifier::ITALIC),


### PR DESCRIPTION
## Problem

When `/build` deletes the `.jyc/mode-override` file, the agent had no explicit BUILD mode declaration in either the system prompt or user prompt. Meanwhile, prior plan-mode messages stored in `agent-context.json` still carried `<mode>Current mode: PLAN</mode>` tags. The model saw these stale tags in the conversation history with no counter-declaration, and concluded it was still in plan mode.

## Root Cause

Both `build_system_prompt()` and `build_user_prompt_text()` only had:

```rust
if mode_override == Some("plan") {
    // inject PLAN mode tags
}
```

There was no `else` branch to declare BUILD mode. When `read_mode_override()` returned `None` (build mode), no mode tag was injected at all, leaving the model to infer mode from stale prior context.

## Fix

Added `else` branches to both functions that inject an explicit BUILD mode declaration:

- **System prompt**: `<system-reminder>You are in BUILD MODE (full execution). You MAY: edit, write, run build/test/deploy commands, commit/push, implement features...</system-reminder>`
- **User prompt**: `<mode>Current mode: BUILD (full execution). You may use all tools including edit, write, bash, commit, and deploy.</mode>`

This ensures every message explicitly declares the current mode, preventing stale plan constraints from prior conversation history from being misinterpreted.

## Changes

- `crates/jyc-agent/src/service.rs`: 25 insertions