### PR TITLE
fix: add [SUCCESS]/[ERROR] prefix to OpenAI-compat tool results (#280)

### DIFF
--- a/crates/jyc-agent/src/provider/openai_compat.rs
+++ b/crates/jyc-agent/src/provider/openai_compat.rs
@@ -235,12 +235,17 @@ impl Provider for OpenAiCompatProvider {
         &self,
         tool_call_id: &str,
         content: &str,
-        _is_error: bool,
+        is_error: bool,
     ) -> serde_json::Value {
+        let labeled = if is_error {
+            format!("[ERROR] {content}")
+        } else {
+            format!("[SUCCESS] {content}")
+        };
         serde_json::json!({
             "role": "tool",
             "tool_call_id": tool_call_id,
-            "content": content,
+            "content": labeled,
         })
     }
 
@@ -910,5 +915,46 @@ mod tests {
 
         assert_eq!(state.tool_calls.len(), 1);
         assert_eq!(state.tool_calls[0].arguments, r#"{"command":"ls"}"#);
+    }
+
+    #[test]
+    fn format_tool_result_prefixed_with_success() {
+        let provider = OpenAiCompatProvider::new(
+            "https://api.example.com",
+            "test",
+            Some("k"),
+            None,
+            false,
+            None,
+        )
+        .unwrap();
+        let result =
+            provider.format_tool_result("id1", "Command completed with exit code 0", false);
+        let content = result["content"].as_str().unwrap();
+        assert!(
+            content.starts_with("[SUCCESS] "),
+            "expected [SUCCESS] prefix, got: {content}"
+        );
+        assert!(content.contains("Command completed with exit code 0"));
+    }
+
+    #[test]
+    fn format_tool_result_prefixed_with_error() {
+        let provider = OpenAiCompatProvider::new(
+            "https://api.example.com",
+            "test",
+            Some("k"),
+            None,
+            false,
+            None,
+        )
+        .unwrap();
+        let result = provider.format_tool_result("id1", "something failed", true);
+        let content = result["content"].as_str().unwrap();
+        assert!(
+            content.starts_with("[ERROR] "),
+            "expected [ERROR] prefix, got: {content}"
+        );
+        assert!(content.contains("something failed"));
     }
 }


### PR DESCRIPTION
## Problem
GLM-5.2 via Ark repeatedly called the same tool even after successful execution (`gh pr edit 273 --remove-label ready-for-review`).

## Root Cause
The OpenAI-compatible provider's `format_tool_result` discarded the `is_error` parameter (`_is_error`). Tool results were sent as bare text — for silently-succeeding commands like `gh pr edit --remove-label`, the result was just `"Command completed with exit code 0"`. GLM-5.2's weaker text comprehension couldn't reliably parse this as success, causing a repeating tool-call loop.

Note: the Anthropic provider already preserves `is_error` via its native `is_error` field. This fix brings the OpenAI-compat path to equivalent clarity.

## Fix
`format_tool_result` now prefixes content with `[SUCCESS]` or `[ERROR]` based on `is_error`, giving all OpenAI-compatible models (DeepSeek, GPT, GLM-5.2, etc.) an explicit structured signal.

## Changes
- **1 file**, +48 / -2 lines
- 2 new unit tests covering both success and error paths