### PR TITLE
fix: show LLM thinking state and tool input in activity panel (#318)

### DIFF
--- a/crates/jyc-agent/src/agent_loop.rs
+++ b/crates/jyc-agent/src/agent_loop.rs
@@ -248,6 +248,7 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
                     } else {
                         None
                     },
+                    input: Some(truncate_str(&synthetic_args, 200)),
                     timestamp: Utc::now(),
                 },
             )
@@ -287,6 +288,18 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
             raw_context_len = raw_context.len(),
             "Agent loop iteration"
         );
+
+        // Publish LLM request started event so the activity panel shows
+        // "Thinking..." between tool execution and LLM response.
+        publish_event(
+            event_bus,
+            ThreadEvent::LLMRequestStarted {
+                thread_name: thread_name.to_string(),
+                iteration: total_iterations,
+                timestamp: Utc::now(),
+            },
+        )
+        .await;
 
         // 1. Send to LLM using raw context (preserves provider-specific fields)
         // 2. Collect the response
@@ -452,6 +465,7 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
                     } else {
                         None
                     },
+                    input: Some(truncate_str(&tool_call.arguments, 200)),
                     timestamp: Utc::now(),
                 },
             )

--- a/crates/jyc-core/src/thread_event.rs
+++ b/crates/jyc-core/src/thread_event.rs
@@ -83,7 +83,24 @@ pub enum ThreadEvent {
         duration_secs: u64,
         /// Error output preview (only set when tool failed, truncated)
         output: Option<String>,
+        /// Preview of the tool input (truncated), included so the activity
+        /// panel can show what command was run even for fast tools.
+        input: Option<String>,
         /// When the tool completed
+        timestamp: DateTime<Utc>,
+    },
+
+    /// LLM request started event.
+    ///
+    /// Sent when the agent sends a request to the LLM and is waiting
+    /// for the response. Lets the activity panel show "Thinking..." or
+    /// "Sending to LLM..." between tool execution and response.
+    LLMRequestStarted {
+        /// Name of the thread
+        thread_name: String,
+        /// Iteration number within the current agent loop run
+        iteration: usize,
+        /// When the request was sent
         timestamp: DateTime<Utc>,
     },
 
@@ -130,6 +147,7 @@ impl ThreadEvent {
             ThreadEvent::ProcessingCompleted { thread_name, .. } => thread_name,
             ThreadEvent::ToolStarted { thread_name, .. } => thread_name,
             ThreadEvent::ToolCompleted { thread_name, .. } => thread_name,
+            ThreadEvent::LLMRequestStarted { thread_name, .. } => thread_name,
             ThreadEvent::Thinking { thread_name, .. } => thread_name,
             ThreadEvent::SessionStatus { thread_name, .. } => thread_name,
         }
@@ -144,6 +162,7 @@ impl ThreadEvent {
             ThreadEvent::ProcessingCompleted { timestamp, .. } => *timestamp,
             ThreadEvent::ToolStarted { timestamp, .. } => *timestamp,
             ThreadEvent::ToolCompleted { timestamp, .. } => *timestamp,
+            ThreadEvent::LLMRequestStarted { timestamp, .. } => *timestamp,
             ThreadEvent::Thinking { timestamp, .. } => *timestamp,
             ThreadEvent::SessionStatus { timestamp, .. } => *timestamp,
         }
@@ -222,6 +241,19 @@ mod tests {
             success: true,
             duration_secs: 1,
             output: Some("hi".to_string()),
+            input: Some(r#"{"command":"ls"}"#.to_string()),
+            timestamp: ts,
+        };
+        assert_eq!(ev.thread_name(), "t1");
+        assert_eq!(ev.timestamp(), ts);
+    }
+
+    #[test]
+    fn llm_request_started_event() {
+        let ts = dummy_time();
+        let ev = ThreadEvent::LLMRequestStarted {
+            thread_name: "t1".to_string(),
+            iteration: 3,
             timestamp: ts,
         };
         assert_eq!(ev.thread_name(), "t1");

--- a/crates/jyc-inspect/src/server.rs
+++ b/crates/jyc-inspect/src/server.rs
@@ -520,6 +520,7 @@ impl ActivityTracker {
                                                                     ThreadEvent::ProcessingStarted { .. }
                                                                     | ThreadEvent::ProcessingProgress { .. }
                                                                     | ThreadEvent::ToolStarted { .. }
+                                                                    | ThreadEvent::LLMRequestStarted { .. }
                                                                 );
                                                                 let is_completed = matches!(
                                                                     &event,
@@ -706,6 +707,9 @@ fn event_to_activity(event: &ThreadEvent) -> ActivityEntry {
                 format!("Failed ({duration_secs}s)")
             }
         }
+        ThreadEvent::LLMRequestStarted { iteration, .. } => {
+            format!("Thinking... (iteration {iteration})")
+        }
         ThreadEvent::ToolStarted {
             tool_name, input, ..
         } => match input {
@@ -717,10 +721,16 @@ fn event_to_activity(event: &ThreadEvent) -> ActivityEntry {
             success,
             duration_secs,
             output,
+            input,
             ..
         } => {
             if *success {
-                format!("Tool: {tool_name} (done, {duration_secs}s)")
+                match input {
+                    Some(inp) => {
+                        format!("Tool: {tool_name} (done, {duration_secs}s) — {inp}")
+                    }
+                    None => format!("Tool: {tool_name} (done, {duration_secs}s)"),
+                }
             } else {
                 match output {
                     Some(err) => {


### PR DESCRIPTION
## Problem

Issue #318 identified two display problems in the chat pane activity panel:

1. **No "Thinking..." event**: When a message is sent to the LLM and the model is processing, there was no activity event showing this state. Users only saw tool execution events but not the LLM thinking time between tools.

2. **ToolCompleted hides the command**: For fast tools (e.g., `bash` completing in 0s), the activity panel only showed `Tool: bash (done, 0s)` without the actual command. Users care about what command was run, not just that it finished fast.

## Solution

### Change 1: Add `LLMRequestStarted` event

- **`crates/jyc-core/src/thread_event.rs`**: New `LLMRequestStarted` variant in `ThreadEvent` enum with `thread_name`, `iteration`, and `timestamp` fields.
- **`crates/jyc-agent/src/agent_loop.rs`**: Publish `LLMRequestStarted` before each `complete_with_retry()` call, so the activity panel shows "Thinking..." during LLM processing.
- **`crates/jyc-inspect/src/server.rs`**: 
  - `event_to_activity()` maps it to `"Thinking... (iteration N)"`.
  - Activity tracker treats `LLMRequestStarted` as a "processing" state (sets `is_processing = true`).

### Change 2: Include tool input in `ToolCompleted` display

- **`crates/jyc-core/src/thread_event.rs`**: Added `input: Option<String>` field to `ToolCompleted` variant.
- **`crates/jyc-agent/src/agent_loop.rs`**: Both ToolCompleted publish sites now pass the truncated tool input.
- **`crates/jyc-inspect/src/server.rs`**: `event_to_activity()` for successful `ToolCompleted` now shows the input:
  - Before: `Tool: bash (done, 0s)`
  - After: `Tool: bash (done, 0s) — {"command":"git add -A"}`

## Testing

- All existing tests pass (74 agent tests, 12 core tests, 2 inspect tests).
- Added unit tests for `LLMRequestStarted` event and updated `ToolCompleted` test to include the new `input` field.
- `cargo fmt --check` ✅
- `cargo clippy` ✅ zero warnings