### PR TITLE
fix: activity display and stream_options for token usage

### DIFF
--- a/crates/jyc-agent/src/provider/openai_compat.rs
+++ b/crates/jyc-agent/src/provider/openai_compat.rs
@@ -123,6 +123,7 @@ impl Provider for OpenAiCompatProvider {
         let mut body = serde_json::json!({
             "model": &self.model,
             "stream": true,
+            "stream_options": {"include_usage": true},
             "messages": api_messages,
         });
 
@@ -312,6 +313,7 @@ impl Provider for OpenAiCompatProvider {
         let mut body = serde_json::json!({
             "model": &self.model,
             "stream": true,
+            "stream_options": {"include_usage": true},
             "messages": api_messages,
         });
 

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -522,7 +522,7 @@ pub async fn run(args: &DashboardArgs) -> Result<()> {
 }
 
 /// Format elapsed time from an RFC 3339 timestamp to now.
-/// Returns a string like "(15s)" or "(2m)" or "" if parsing fails.
+/// Returns a string like "15s" or "2m" or "" if parsing fails.
 fn format_elapsed(timestamp: &Option<String>) -> String {
     let ts = match timestamp {
         Some(t) => t,
@@ -538,9 +538,9 @@ fn format_elapsed(timestamp: &Option<String>) -> String {
         return String::new();
     }
     if secs < 60 {
-        format!("({secs}s)")
+        format!("{secs}s")
     } else {
-        format!("({}m)", secs / 60)
+        format!("{}m", secs / 60)
     }
 }
 
@@ -1281,13 +1281,22 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
                     ),
                 ]));
             } else {
-                for a in recent.iter().rev() {
-                    // Compute elapsed time from the activity's timestamp
-                    let elapsed = format_elapsed(&a.timestamp);
-                    let label = if elapsed.is_empty() {
-                        format!("⏳ {}", a.text)
+                let total = recent.len();
+                for (idx, a) in recent.iter().rev().enumerate() {
+                    let is_last = idx == total - 1;
+                    let elapsed = if is_last {
+                        format_elapsed(&a.timestamp)
                     } else {
-                        format!("⏳ {} ({})", a.text, elapsed)
+                        String::new()
+                    };
+                    let label = if is_last {
+                        if elapsed.is_empty() {
+                            format!("⏳ {}", a.text)
+                        } else {
+                            format!("⏳ {} {}", a.text, elapsed)
+                        }
+                    } else {
+                        format!("  {}", a.text)
                     };
                     all_lines.push(Line::from(vec![
                         Span::raw("  "),


### PR DESCRIPTION
## Changes

### 1. Activity display fixes (dashboard.rs)
- **Hourglass only on last line**: Only the most recent activity entry shows the ⏳ prefix; earlier entries show plain text
- **Elapsed time only on last line**: Removes duplicate elapsed time from non-last entries
- **Remove double parentheses**: Elapsed time now shows `15s` instead of `((15s))`

### 2. Token usage fix (openai_compat.rs)
- Add `stream_options: {"include_usage": true}` to both `complete()` and `complete_raw()` requests
- This enables usage info in streaming responses from providers like Ark (GLM-5.2) and Kimi that don't include it by default
- DeepSeek already worked because it includes usage in stream without this option