### PR TITLE
feat: per-mode model selection with plan_model/build_model (#322)

### DIFF
--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -1074,13 +1074,23 @@ impl AgentService for JycAgentService {
             "Processing message with in-process agent"
         );
 
-        // 1. Read model override with priority:
-        //    a) .jyc/model-override file (highest priority, manual runtime override)
-        //    b) Pattern-level model (from matched pattern config)
-        //    c) Config-level model (from self.config.model, i.e. global or channel-level)
-        let model_override_path = thread_path.join(".jyc").join("model-override");
-        let file_override = if model_override_path.exists() {
-            tokio::fs::read_to_string(&model_override_path)
+        // 1. Read mode override for this thread (used to select mode-specific model)
+        let mode_override = jyc_core::session_state::read_mode_override(thread_path).await;
+
+        // 1a. Determine the mode-specific suffix ("plan" or "build") for file,
+        //     pattern, and config overrides. Falls back to generic "model" when
+        //     no mode override is active.
+        let mode_suffix = mode_override.as_deref().unwrap_or("model");
+
+        // 1b. Model resolution priority:
+        //     a) .jyc/<mode>-model-override file (highest, mode-specific)
+        //     b) Pattern-level plan_model / build_model / model
+        //     c) Config-level plan_model / build_model / model
+        let mode_override_path = thread_path
+            .join(".jyc")
+            .join(format!("{mode_suffix}-model-override"));
+        let file_override = if mode_override_path.exists() {
+            tokio::fs::read_to_string(&mode_override_path)
                 .await
                 .ok()
                 .map(|s| s.trim().to_string())
@@ -1088,15 +1098,29 @@ impl AgentService for JycAgentService {
         } else {
             None
         };
-        let pattern_override = message
+        let pattern = message
             .matched_pattern
             .as_deref()
-            .and_then(|name| self.patterns.iter().find(|p| p.name == name))
-            .and_then(|p| p.model.as_deref());
+            .and_then(|name| self.patterns.iter().find(|p| p.name == name));
+        // Pattern: try mode-specific field first, then generic model
+        let pattern_override = pattern
+            .and_then(|p| match mode_override.as_deref() {
+                Some("plan") => p.plan_model.as_deref(),
+                Some("build") => p.build_model.as_deref(),
+                _ => None,
+            })
+            .or_else(|| pattern.and_then(|p| p.model.as_deref()));
+        // Config: try mode-specific field first, then generic model
+        let config_override = match mode_override.as_deref() {
+            Some("plan") => self.config.plan_model.as_deref(),
+            Some("build") => self.config.build_model.as_deref(),
+            _ => None,
+        }
+        .or(self.config.model.as_deref());
         let model_override = file_override
             .clone()
             .or_else(|| pattern_override.map(|s| s.to_string()))
-            .or_else(|| self.config.model.clone());
+            .or_else(|| config_override.map(|s| s.to_string()));
 
         // 2. Create provider
         let provider = self

--- a/crates/jyc-agent/src/types.rs
+++ b/crates/jyc-agent/src/types.rs
@@ -239,6 +239,12 @@ pub struct VisionConfig {
 pub struct AgentConfig {
     /// Default model in "provider/model-id" format
     pub model: Option<String>,
+    /// Model override for plan (read-only) mode. Falls back to `model` if unset.
+    #[serde(default)]
+    pub plan_model: Option<String>,
+    /// Model override for build (full execution) mode. Falls back to `model` if unset.
+    #[serde(default)]
+    pub build_model: Option<String>,
     /// Optional small/fast model used for ancillary LLM work — currently:
     /// - cycle-boundary progress summary (in `agent_loop`)
     /// - between-messages context reset summary (in `session::summarize_context`)
@@ -263,6 +269,8 @@ impl Default for AgentConfig {
     fn default() -> Self {
         Self {
             model: None,
+            plan_model: None,
+            build_model: None,
             small_model: None,
             providers: std::collections::HashMap::new(),
             max_iterations: default_max_iterations(),

--- a/crates/jyc-channels/src/wecom_bot/inbound.rs
+++ b/crates/jyc-channels/src/wecom_bot/inbound.rs
@@ -662,17 +662,7 @@ mod tests {
             thread_prefix: None,
             role: None,
             live_injection: true,
-            repo_group: None,
-            inject_inbound_images: false,
-            model: None,
-            small_model: None,
-            mcps: None,
-            disabled_tools: None,
-            disabled_builtin_tools: None,
-            disabled_mcp_servers: None,
-            skills: None,
-            disabled_skills: None,
-            access: None,
+            ..Default::default()
         };
 
         let matcher = WecomBotMatcher;

--- a/crates/jyc-cli/src/cli/agent_builder.rs
+++ b/crates/jyc-cli/src/cli/agent_builder.rs
@@ -104,6 +104,8 @@ pub fn build_agent_service(
                 .collect();
 
             let agent_cfg = jyc_agent::types::AgentConfig {
+                plan_model: None,
+                build_model: None,
                 model,
                 small_model: effective_small_model.clone(),
                 providers,

--- a/crates/jyc-core/src/command/model_handler.rs
+++ b/crates/jyc-core/src/command/model_handler.rs
@@ -338,4 +338,81 @@ mode = "agent"
         assert!(!result.success);
         assert!(result.message.contains("unknown model"));
     }
+
+    #[tokio::test]
+    async fn test_switch_model_in_plan_mode_writes_plan_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let jyc_dir = tmp.path().join(".jyc");
+        tokio::fs::create_dir_all(&jyc_dir).await.unwrap();
+        // Simulate plan mode
+        tokio::fs::write(jyc_dir.join("mode-override"), "plan\n")
+            .await
+            .unwrap();
+
+        let mut ctx = test_context(tmp.path());
+        ctx.args = vec!["deepseek/deepseek-reasoner".into()];
+        let handler = ModelCommandHandler;
+        let result = handler.execute(ctx).await.unwrap();
+        assert!(result.success);
+
+        // Should write to plan-model-override, not model-override
+        assert!(jyc_dir.join("plan-model-override").exists());
+        assert!(!jyc_dir.join("model-override").exists());
+        let content = tokio::fs::read_to_string(jyc_dir.join("plan-model-override"))
+            .await
+            .unwrap();
+        assert_eq!(content, "deepseek/deepseek-reasoner");
+    }
+
+    #[tokio::test]
+    async fn test_switch_model_in_build_mode_writes_build_override() {
+        let tmp = tempfile::tempdir().unwrap();
+        let jyc_dir = tmp.path().join(".jyc");
+        tokio::fs::create_dir_all(&jyc_dir).await.unwrap();
+        // Simulate build mode
+        tokio::fs::write(jyc_dir.join("mode-override"), "build\n")
+            .await
+            .unwrap();
+
+        let mut ctx = test_context(tmp.path());
+        ctx.args = vec!["deepseek/deepseek-chat".into()];
+        let handler = ModelCommandHandler;
+        let result = handler.execute(ctx).await.unwrap();
+        assert!(result.success);
+
+        // Should write to build-model-override
+        assert!(jyc_dir.join("build-model-override").exists());
+        assert!(!jyc_dir.join("model-override").exists());
+        let content = tokio::fs::read_to_string(jyc_dir.join("build-model-override"))
+            .await
+            .unwrap();
+        assert_eq!(content, "deepseek/deepseek-chat");
+    }
+
+    #[tokio::test]
+    async fn test_reset_clears_all_mode_overrides() {
+        let tmp = tempfile::tempdir().unwrap();
+        let jyc_dir = tmp.path().join(".jyc");
+        tokio::fs::create_dir_all(&jyc_dir).await.unwrap();
+        tokio::fs::write(jyc_dir.join("plan-model-override"), "deepseek/some\n")
+            .await
+            .unwrap();
+        tokio::fs::write(jyc_dir.join("build-model-override"), "ark/glm\n")
+            .await
+            .unwrap();
+        tokio::fs::write(jyc_dir.join("model-override"), "legacy-model\n")
+            .await
+            .unwrap();
+
+        let mut ctx = test_context(tmp.path());
+        ctx.args = vec!["reset".into()];
+        let handler = ModelCommandHandler;
+        let result = handler.execute(ctx).await.unwrap();
+        assert!(result.success);
+        assert!(result.message.contains("reset to default model"));
+
+        assert!(!jyc_dir.join("plan-model-override").exists());
+        assert!(!jyc_dir.join("build-model-override").exists());
+        assert!(!jyc_dir.join("model-override").exists());
+    }
 }

--- a/crates/jyc-core/src/command/model_handler.rs
+++ b/crates/jyc-core/src/command/model_handler.rs
@@ -27,6 +27,9 @@ impl CommandHandler for ModelCommandHandler {
 
         let providers = &context.config.agent.providers;
 
+        // Read current mode to determine which override file to use.
+        let current_mode = crate::session_state::read_mode_override(&context.thread_path).await;
+
         if context.args.is_empty() {
             // /model — list all available models
             if providers.is_empty() {
@@ -54,11 +57,18 @@ impl CommandHandler for ModelCommandHandler {
                 error: None,
             })
         } else if context.args.len() == 1 && context.args[0] == "reset" {
-            // /model reset — remove override, restore default
-            let override_path = jyc_dir.join("model-override");
-
-            if override_path.exists() {
-                tokio::fs::remove_file(&override_path).await?;
+            // /model reset — remove mode-specific and legacy overrides
+            let plan_path = jyc_dir.join("plan-model-override");
+            let build_path = jyc_dir.join("build-model-override");
+            let legacy_path = jyc_dir.join("model-override");
+            let mut removed = false;
+            for path in [&plan_path, &build_path, &legacy_path] {
+                if path.exists() {
+                    tokio::fs::remove_file(path).await?;
+                    removed = true;
+                }
+            }
+            if removed {
                 Ok(CommandResult {
                     success: true,
                     message: "/model: reset to default model".into(),
@@ -109,8 +119,13 @@ impl CommandHandler for ModelCommandHandler {
                         });
                     }
 
-                    // Write override file
-                    let override_path = jyc_dir.join("model-override");
+                    // Write mode-specific override file
+                    let filename = match current_mode.as_deref() {
+                        Some("plan") => "plan-model-override",
+                        Some("build") => "build-model-override",
+                        _ => "model-override",
+                    };
+                    let override_path = jyc_dir.join(filename);
                     tokio::fs::write(&override_path, &model_id).await?;
 
                     Ok(CommandResult {

--- a/crates/jyc-types/src/channel.rs
+++ b/crates/jyc-types/src/channel.rs
@@ -347,6 +347,12 @@ pub struct ChannelPattern {
     /// but below the runtime `.jyc/model-override` file.
     #[serde(default)]
     pub model: Option<String>,
+    /// Override model for plan (read-only) mode. Falls back to `model` if unset.
+    #[serde(default)]
+    pub plan_model: Option<String>,
+    /// Override model for build (full execution) mode. Falls back to `model` if unset.
+    #[serde(default)]
+    pub build_model: Option<String>,
     /// Override small_model for this pattern's thread.
     /// Takes priority over channel-level small_model and global [agent].small_model,
     /// but below the runtime `.jyc/model-override` file.
@@ -458,6 +464,8 @@ impl Default for ChannelPattern {
             repo_group: None,
             inject_inbound_images: false,
             model: None,
+            plan_model: None,
+            build_model: None,
             small_model: None,
             mcps: None,
             disabled_tools: None,


### PR DESCRIPTION
Adds per-mode (plan/build) model configuration at agent and pattern level. The /model command now writes mode-specific override files.

## Changes
1. New config fields: plan_model and build_model in AgentConfig and ChannelPattern
2. /model command writes mode-specific override (plan-model-override or build-model-override)
3. /model reset clears both mode-specific and legacy override files
4. Model resolution checks mode-specific overrides first:
   .jyc/<mode>-model-override > pattern.<mode>_model > pattern.model > config.<mode>_model > config.model