### PR TITLE
fix: info bar model display now reads mode-specific overrides

### DIFF
--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -1077,26 +1077,41 @@ impl AgentService for JycAgentService {
         // 1. Read mode override for this thread (used to select mode-specific model)
         let mode_override = jyc_core::session_state::read_mode_override(thread_path).await;
 
-        // 1a. Determine the mode-specific suffix ("plan" or "build") for file,
-        //     pattern, and config overrides. Falls back to generic "model" when
-        //     no mode override is active.
-        let mode_suffix = mode_override.as_deref().unwrap_or("model");
-
         // 1b. Model resolution priority:
-        //     a) .jyc/<mode>-model-override file (highest, mode-specific)
-        //     b) Pattern-level plan_model / build_model / model
-        //     c) Config-level plan_model / build_model / model
-        let mode_override_path = thread_path
-            .join(".jyc")
-            .join(format!("{mode_suffix}-model-override"));
-        let file_override = if mode_override_path.exists() {
-            tokio::fs::read_to_string(&mode_override_path)
-                .await
-                .ok()
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-        } else {
-            None
+        //     For plan/build mode:
+        //       a) .jyc/<mode>-model-override (mode-specific runtime override)
+        //       b) .jyc/model-override (legacy fallback, for migration)
+        //       c) Pattern-level plan_model / build_model / model
+        //       d) Config-level plan_model / build_model / model
+        //     For default mode (no override):
+        //       a) Pattern-level model
+        //       b) Config-level model
+        //     (Skip file overrides in default mode to avoid stale data from
+        //      the old /model command which wrote model-override for all modes.)
+        let file_override = match mode_override.as_deref() {
+            Some("plan") | Some("build") => {
+                let mode_specific_path = thread_path.join(".jyc").join(format!(
+                    "{}-model-override",
+                    mode_override.as_deref().unwrap()
+                ));
+                let legacy_path = thread_path.join(".jyc").join("model-override");
+                if mode_specific_path.exists() {
+                    tokio::fs::read_to_string(&mode_specific_path)
+                        .await
+                        .ok()
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                } else if legacy_path.exists() {
+                    tokio::fs::read_to_string(&legacy_path)
+                        .await
+                        .ok()
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                } else {
+                    None
+                }
+            }
+            _ => None,
         };
         let pattern = message
             .matched_pattern

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -642,7 +642,7 @@ impl ThreadManager {
     /// This includes both actively queued threads and idle threads that have been
     /// created but have no messages pending.
     pub async fn list_threads(&self) -> Vec<ThreadInfo> {
-        use crate::session_state::{read_input_tokens, read_mode_override, read_model_override};
+        use crate::session_state::{read_input_tokens, read_mode_override};
 
         // Collect names of actively queued threads
         let queues = self.thread_queues.lock().await;
@@ -679,29 +679,75 @@ impl ThreadManager {
             // Read session state
             let (input_tokens, max_tokens) = read_input_tokens(&thread_path).await;
 
-            // Resolve effective model with priority:
-            // 1. .jyc/model-override file (manual runtime override)
-            // 2. Pattern-level model from config
-            // 3. Channel-level model from config
-            // 4. Global agent model from config
-            let model = read_model_override(&thread_path)
-                .await
-                .or_else(|| {
-                    let pattern_name = pattern.as_ref()?;
-                    let cfg = self.config.load();
-                    let channel_cfg = cfg.channels.get(&self.channel_name)?;
-                    let patterns = channel_cfg.patterns.as_ref()?;
-                    let matched = patterns.iter().find(|p| p.name == *pattern_name)?;
-                    matched.model.clone()
-                })
-                .or_else(|| {
-                    let cfg = self.config.load();
-                    let channel_cfg = cfg.channels.get(&self.channel_name)?;
-                    channel_cfg.model.clone()
-                })
-                .or_else(|| self.config.load().agent.model.clone());
-
+            // Read mode first — needed to resolve mode-specific model overrides.
             let mode = read_mode_override(&thread_path).await;
+
+            // Read mode-specific override file first, fallback to legacy.
+            let file_override = {
+                async fn read_trimmed(path: &std::path::Path) -> Option<String> {
+                    tokio::fs::read_to_string(path)
+                        .await
+                        .ok()
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                }
+                let plan_path = thread_path.join(".jyc").join("plan-model-override");
+                let build_path = thread_path.join(".jyc").join("build-model-override");
+                let legacy_path = thread_path.join(".jyc").join("model-override");
+
+                let mode_specific = match mode.as_deref() {
+                    Some("plan") => read_trimmed(&plan_path).await,
+                    Some("build") => read_trimmed(&build_path).await,
+                    _ => None,
+                };
+                if mode_specific.is_some() {
+                    mode_specific
+                } else {
+                    read_trimmed(&legacy_path).await
+                }
+            };
+
+            // Resolve effective model with priority:
+            // 1. .jyc/<mode>-model-override (mode-specific runtime override)
+            // 2. .jyc/model-override (legacy generic override)
+            // 3. Pattern-level plan_model / build_model (mode-specific)
+            // 4. Pattern-level model (generic)
+            // 5. Channel-level model (generic)
+            // 6. Global plan_model / build_model (mode-specific)
+            // 7. Global model (generic)
+
+            let model = if let Some(ref m) = file_override {
+                Some(m.clone())
+            } else if let Some(ref pattern_name) = pattern {
+                let cfg = self.config.load();
+                let channel_cfg = cfg.channels.get(&self.channel_name);
+                let pattern_override = channel_cfg
+                    .and_then(|c| c.patterns.as_ref())
+                    .and_then(|pats| pats.iter().find(|p| p.name == *pattern_name));
+                pattern_override
+                    .and_then(|p| match mode.as_deref() {
+                        Some("plan") => p.plan_model.clone(),
+                        Some("build") => p.build_model.clone(),
+                        _ => None,
+                    })
+                    .or_else(|| pattern_override.and_then(|p| p.model.clone()))
+            } else {
+                None
+            }
+            .or_else(|| {
+                let cfg = self.config.load();
+                let channel_cfg = cfg.channels.get(&self.channel_name)?;
+                channel_cfg.model.clone()
+            })
+            .or_else(|| {
+                let cfg = self.config.load();
+                match mode.as_deref() {
+                    Some("plan") => cfg.agent.plan_model.clone(),
+                    Some("build") => cfg.agent.build_model.clone(),
+                    _ => None,
+                }
+            })
+            .or_else(|| self.config.load().agent.model.clone());
 
             // Read skills from .jyc/skills.json
             let skills = read_skills(&thread_path).await;

--- a/crates/jyc-types/src/config.rs
+++ b/crates/jyc-types/src/config.rs
@@ -318,6 +318,14 @@ pub struct AgentConfig {
     /// Model identifier in "provider/model-id" format (e.g., "anthropic/claude-opus-4-6")
     pub model: Option<String>,
 
+    /// Model override for plan (read-only) mode. Falls back to `model` if unset.
+    #[serde(default)]
+    pub plan_model: Option<String>,
+
+    /// Model override for build (full execution) mode. Falls back to `model` if unset.
+    #[serde(default)]
+    pub build_model: Option<String>,
+
     /// Optional small/fast model used for ancillary LLM work (cycle-boundary
     /// progress summary and between-message context-reset summary). Falls
     /// back to the main `model` if unset or if provider construction fails


### PR DESCRIPTION
## Problem

After using `/model` to switch the plan mode model, the `plan-model-override` file was correctly written and the new model was used for inference. However, the compact info bar still showed the old model name because `list_threads()` only checked the legacy `model-override` file.

## Fix

1. **`thread_manager.rs`**: Read mode before model, then check mode-specific override files (`plan-model-override` / `build-model-override`) with fallback to legacy `model-override`
2. **`config.rs`**: Add `plan_model` / `build_model` fields to `jyc_types::AgentConfig` (the config-level struct used by thread_manager, which was missing these fields that were already added to the internal `jyc_agent::types::AgentConfig`)

## Model resolution priority (info bar)

1. `.jyc/plan-model-override` or `.jyc/build-model-override` (mode-specific)
2. `.jyc/model-override` (legacy fallback)
3. Pattern `plan_model`/`build_model` → pattern `model`
4. Channel `model`
5. Global `plan_model`/`build_model` → global `model`