### PR TITLE
fix: treat None mode as build mode everywhere

### DIFF
--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -1088,30 +1088,30 @@ impl AgentService for JycAgentService {
         //       b) Config-level model
         //     (Skip file overrides in default mode to avoid stale data from
         //      the old /model command which wrote model-override for all modes.)
-        let file_override = match mode_override.as_deref() {
-            Some("plan") | Some("build") => {
-                let mode_specific_path = thread_path.join(".jyc").join(format!(
-                    "{}-model-override",
-                    mode_override.as_deref().unwrap()
-                ));
-                let legacy_path = thread_path.join(".jyc").join("model-override");
-                if mode_specific_path.exists() {
-                    tokio::fs::read_to_string(&mode_specific_path)
-                        .await
-                        .ok()
-                        .map(|s| s.trim().to_string())
-                        .filter(|s| !s.is_empty())
-                } else if legacy_path.exists() {
-                    tokio::fs::read_to_string(&legacy_path)
-                        .await
-                        .ok()
-                        .map(|s| s.trim().to_string())
-                        .filter(|s| !s.is_empty())
-                } else {
-                    None
-                }
+        let file_override = {
+            let mode_suffix = match mode_override.as_deref() {
+                Some("plan") => "plan",
+                _ => "build", // default = build mode
+            };
+            let mode_specific_path = thread_path
+                .join(".jyc")
+                .join(format!("{mode_suffix}-model-override"));
+            let legacy_path = thread_path.join(".jyc").join("model-override");
+            if mode_specific_path.exists() {
+                tokio::fs::read_to_string(&mode_specific_path)
+                    .await
+                    .ok()
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+            } else if legacy_path.exists() {
+                tokio::fs::read_to_string(&legacy_path)
+                    .await
+                    .ok()
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+            } else {
+                None
             }
-            _ => None,
         };
         let pattern = message
             .matched_pattern
@@ -1121,15 +1121,13 @@ impl AgentService for JycAgentService {
         let pattern_override = pattern
             .and_then(|p| match mode_override.as_deref() {
                 Some("plan") => p.plan_model.as_deref(),
-                Some("build") => p.build_model.as_deref(),
-                _ => None,
+                _ => p.build_model.as_deref(), // default = build
             })
             .or_else(|| pattern.and_then(|p| p.model.as_deref()));
         // Config: try mode-specific field first, then generic model
         let config_override = match mode_override.as_deref() {
             Some("plan") => self.config.plan_model.as_deref(),
-            Some("build") => self.config.build_model.as_deref(),
-            _ => None,
+            _ => self.config.build_model.as_deref(), // default = build
         }
         .or(self.config.model.as_deref());
         let model_override = file_override

--- a/crates/jyc-core/src/command/model_handler.rs
+++ b/crates/jyc-core/src/command/model_handler.rs
@@ -123,7 +123,7 @@ impl CommandHandler for ModelCommandHandler {
                     let filename = match current_mode.as_deref() {
                         Some("plan") => "plan-model-override",
                         Some("build") => "build-model-override",
-                        _ => "model-override",
+                        _ => "build-model-override", // None = default build mode
                     };
                     let override_path = jyc_dir.join(filename);
                     tokio::fs::write(&override_path, &model_id).await?;
@@ -271,7 +271,7 @@ mode = "agent"
                 .contains("switched to deepseek/deepseek-chat")
         );
 
-        let content = tokio::fs::read_to_string(tmp.path().join(".jyc/model-override"))
+        let content = tokio::fs::read_to_string(tmp.path().join(".jyc/build-model-override"))
             .await
             .unwrap();
         assert_eq!(content, "deepseek/deepseek-chat");
@@ -282,9 +282,12 @@ mode = "agent"
         let tmp = tempfile::tempdir().unwrap();
         let jyc_dir = tmp.path().join(".jyc");
         tokio::fs::create_dir_all(&jyc_dir).await.unwrap();
-        tokio::fs::write(jyc_dir.join("model-override"), "deepseek/deepseek-chat\n")
-            .await
-            .unwrap();
+        tokio::fs::write(
+            jyc_dir.join("build-model-override"),
+            "deepseek/deepseek-chat\n",
+        )
+        .await
+        .unwrap();
 
         let mut ctx = test_context(tmp.path());
         ctx.args = vec!["reset".into()];
@@ -292,7 +295,7 @@ mode = "agent"
         let result = handler.execute(ctx).await.unwrap();
         assert!(result.success);
         assert!(result.message.contains("reset to default model"));
-        assert!(!jyc_dir.join("model-override").exists());
+        assert!(!jyc_dir.join("build-model-override").exists());
     }
 
     #[tokio::test]

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -697,8 +697,7 @@ impl ThreadManager {
 
                 let mode_specific = match mode.as_deref() {
                     Some("plan") => read_trimmed(&plan_path).await,
-                    Some("build") => read_trimmed(&build_path).await,
-                    _ => None,
+                    _ => read_trimmed(&build_path).await, // None = build mode
                 };
                 if mode_specific.is_some() {
                     mode_specific
@@ -727,8 +726,7 @@ impl ThreadManager {
                 pattern_override
                     .and_then(|p| match mode.as_deref() {
                         Some("plan") => p.plan_model.clone(),
-                        Some("build") => p.build_model.clone(),
-                        _ => None,
+                        _ => p.build_model.clone(), // None = build mode
                     })
                     .or_else(|| pattern_override.and_then(|p| p.model.clone()))
             } else {
@@ -743,8 +741,7 @@ impl ThreadManager {
                 let cfg = self.config.load();
                 match mode.as_deref() {
                     Some("plan") => cfg.agent.plan_model.clone(),
-                    Some("build") => cfg.agent.build_model.clone(),
-                    _ => None,
+                    _ => cfg.agent.build_model.clone(), // None = build mode
                 }
             })
             .or_else(|| self.config.load().agent.model.clone());


### PR DESCRIPTION
## Problem

When no explicit mode override exists (default = build mode), the code treated it as a separate "None" state that:
1. `/model` wrote to legacy `model-override` instead of `build-model-override`
2. `service.rs` skipped all file overrides and config mode-specific models (used only generic `model`)
3. `thread_manager.rs` (info bar) also skipped mode-specific models

This caused plan-mode model overrides to either leak or not work in build mode.

## Fix

Treat `None` mode as `build` mode in all three places:

| File | Change |
|------|--------|
| `model_handler.rs` | `_ => "build-model-override"` (was `"model-override"`) |
| `service.rs` | `_ => build_model / build-model-override` (was `None => skip`) |
| `thread_manager.rs` | `_ => build_path / build_model` (was `None => skip`) |

## Tests
- `test_switch_model`: now checks `build-model-override` instead of `model-override`
- `test_reset_model`: writes to `build-model-override` instead of `model-override`
- All 11 model_handler tests pass