### PR TITLE
feat: dashboard cancel, mode switch, and focus border improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,23 @@ All notable changes to JYC will be documented in this file.
 
 ### Added
 
+- **`/cancel` command and `Ctrl+!` dashboard shortcut.** New `/cancel` command
+  cancels the current AI processing by triggering the per-thread
+  `CancellationToken`. In the dashboard chat pane, `Ctrl+!` sends `/cancel`
+  without modifying the input buffer. The worker's `select!` loop intercepts
+  `/cancel` messages arriving during AI processing — the cancellation token fires
+  immediately, causing the agent loop to break at the next iteration. Non-cancel
+  messages arriving during processing are buffered and re-enqueued after the
+  agent finishes, preserving FIFO order.
+
+- **`Ctrl+Tab` dashboard shortcut for mode switching.** Toggles between plan
+  and build mode by sending `/plan` or `/build` as a WebSocket message, reusing
+  the existing command system for mode switching.
+
+- **Dashboard focus pane border visibility.** The focused pane's border now uses
+  `Yellow + BOLD` for better visual distinction, replacing the previous `Cyan`
+  color that was difficult to notice.
+
 - **Per-pattern filesystem access whitelist (`access.read` / `access.write`).**
   Patterns can now declare additional paths outside the thread working directory
   that the agent may read from or write to. Write paths are automatically

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -1335,7 +1335,11 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
     let title = format!(" Chat: {} ", app.chat_thread.as_deref().unwrap_or("-"));
     let mut block = Block::default().title(title).borders(Borders::ALL);
     if app.chat_focus == ChatFocus::ChatPane {
-        block = block.border_style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
+        block = block.border_style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        );
     }
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -1576,7 +1580,11 @@ fn render_activity_log_inner(
 ) {
     let mut block = Block::default().title(" Activity ").borders(Borders::ALL);
     if focused {
-        block = block.border_style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
+        block = block.border_style(
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        );
     }
 
     if selected.activity.is_empty() {

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -1282,9 +1282,7 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &App) {
     let title = format!(" Chat: {} ", app.chat_thread.as_deref().unwrap_or("-"));
     let mut block = Block::default().title(title).borders(Borders::ALL);
     if app.chat_focus == ChatFocus::ChatPane {
-        block = block.border_style(Style::default().fg(Color::Cyan));
-    } else if app.chat_scroll > 0 {
-        block = block.border_style(Style::default().fg(Color::Yellow));
+        block = block.border_style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
     }
     let inner = block.inner(area);
     frame.render_widget(block, area);
@@ -1525,9 +1523,7 @@ fn render_activity_log_inner(
 ) {
     let mut block = Block::default().title(" Activity ").borders(Borders::ALL);
     if focused {
-        block = block.border_style(Style::default().fg(Color::Cyan));
-    } else if scroll_offset > 0 {
-        block = block.border_style(Style::default().fg(Color::Yellow));
+        block = block.border_style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD));
     }
 
     if selected.activity.is_empty() {

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -316,6 +316,25 @@ impl App {
         }
     }
 
+    /// Send a raw command message via WebSocket without echoing to the chat
+    /// view or clearing the input. Used for quick keyboard shortcuts like
+    /// Ctrl+! (cancel) and Ctrl+Tab (mode switch).
+    fn send_raw_message(&mut self, text: &str) {
+        let thread = match &self.chat_thread {
+            Some(t) => t.clone(),
+            None => return,
+        };
+        let msg = serde_json::json!({
+            "type": "message",
+            "thread": thread,
+            "text": text,
+        })
+        .to_string();
+        if let Some(tx) = &self.ws_tx {
+            let _ = tx.send(msg);
+        }
+    }
+
     fn handle_ws_event(&mut self, event: WsEvent) {
         match event {
             WsEvent::Connected => {
@@ -649,6 +668,40 @@ fn handle_chat_keys(app: &mut App, key: event::KeyEvent) {
     let is_ctrl_w = key.code == KeyCode::Char('w') && key.modifiers.contains(KeyModifiers::CONTROL);
     if is_ctrl_w && app.chat_phase == ChatPhase::Chatting {
         app.activity_split = (app.activity_split + 1) % 4;
+        return;
+    }
+
+    // Ctrl+! sends /cancel to stop the current AI processing
+    let is_ctrl_bang =
+        key.code == KeyCode::Char('!') && key.modifiers.contains(KeyModifiers::CONTROL);
+    if is_ctrl_bang && app.chat_phase == ChatPhase::Chatting {
+        app.send_raw_message("/cancel");
+        app.set_status("⏹ Cancelled".to_string());
+        app.chat_awaiting_response = false;
+        return;
+    }
+
+    // Ctrl+Tab toggles between plan and build mode
+    let is_ctrl_tab = key.code == KeyCode::Tab && key.modifiers.contains(KeyModifiers::CONTROL);
+    if is_ctrl_tab && app.chat_phase == ChatPhase::Chatting {
+        let current_mode = app
+            .state
+            .as_ref()
+            .and_then(|s| {
+                let chat_name = app.chat_thread.as_deref()?;
+                s.threads.iter().find(|t| t.name == chat_name)
+            })
+            .and_then(|t| t.mode.clone())
+            .unwrap_or_else(|| "build".to_string());
+
+        if current_mode == "plan" {
+            app.send_raw_message("/build");
+            app.set_status("Switched to build mode".to_string());
+        } else {
+            app.send_raw_message("/plan");
+            app.set_status("Switched to plan mode".to_string());
+        }
+        app.chat_awaiting_response = true;
         return;
     }
 
@@ -1578,7 +1631,7 @@ fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
         match app.chat_phase {
             ChatPhase::PatternSelect => "[↑↓]select [Enter]choose [Esc/Ctrl+Q]close",
             ChatPhase::Chatting => {
-                "[Tab]focus [↑↓]scroll [PgUp/PgDn ^F/^B]page [←→]cursor [Ctrl+W]split [Esc]back [Ctrl+Q]close"
+                "[Tab]focus [↑↓]scroll [PgUp/PgDn ^F/^B]page [←→]cursor [^!]cancel [^Tab]mode [Ctrl+W]split [Esc]back [Ctrl+Q]close"
             }
         }
     } else {

--- a/crates/jyc-core/src/command/cancel_handler.rs
+++ b/crates/jyc-core/src/command/cancel_handler.rs
@@ -57,3 +57,204 @@ impl CommandHandler for CancelCommandHandler {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message_storage::MessageStorage;
+    use crate::metrics::MetricsCollector;
+    use crate::static_agent::StaticAgentService;
+    use crate::thread_manager::ThreadManager;
+    use arc_swap::ArcSwap;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+    use tokio_util::sync::CancellationToken;
+
+    fn make_thread_manager(workspace: &std::path::Path) -> Arc<ThreadManager> {
+        let storage = Arc::new(MessageStorage::new(workspace));
+        let cancel = CancellationToken::new();
+        let metrics_cancel = CancellationToken::new();
+        let (metrics, _stats, _metrics_task) = MetricsCollector::new(metrics_cancel).start();
+        let config = Arc::new(ArcSwap::from_pointee(
+            jyc_types::load_config_from_str(
+                r#"
+[general]
+[channels.test]
+type = "email"
+[channels.test.inbound]
+host = "h"
+port = 993
+username = "u"
+password = "p"
+[channels.test.outbound]
+host = "h"
+port = 465
+username = "u"
+password = "p"
+[agent]
+enabled = true
+mode = "agent"
+"#,
+            )
+            .unwrap(),
+        ));
+
+        Arc::new(ThreadManager::new_with_options(
+            1,
+            10,
+            storage,
+            // OutboundAdapter not needed for cancel tests — cancel_thread only
+            // touches thread_cancels. We use a panic-on-send stub via
+            // StaticAgentService which is sufficient.
+            Arc::new(NoopOutbound),
+            Arc::new(StaticAgentService::new("ok")),
+            cancel,
+            false,
+            workspace.join("templates"),
+            config,
+            "test".to_string(),
+            "websocket".to_string(),
+            workspace.to_path_buf(),
+            metrics,
+        ))
+    }
+
+    /// Minimal outbound adapter that does nothing — sufficient for cancel
+    /// tests which never send replies.
+    struct NoopOutbound;
+
+    #[async_trait::async_trait]
+    impl jyc_types::OutboundAdapter for NoopOutbound {
+        fn channel_type(&self) -> &str {
+            "test"
+        }
+        async fn connect(&self) -> Result<()> {
+            Ok(())
+        }
+        async fn disconnect(&self) -> Result<()> {
+            Ok(())
+        }
+        fn clean_body(&self, raw_body: &str) -> String {
+            raw_body.to_string()
+        }
+        async fn send_reply(
+            &self,
+            _original: &jyc_types::InboundMessage,
+            _reply_text: &str,
+            _thread_path: &std::path::Path,
+            _message_dir: &str,
+            _attachments: Option<&[jyc_types::OutboundAttachment]>,
+        ) -> Result<jyc_types::SendResult> {
+            Ok(jyc_types::SendResult {
+                message_id: "noop".to_string(),
+            })
+        }
+        async fn send_message(
+            &self,
+            _recipient: &str,
+            _subject: &str,
+            _body: &str,
+        ) -> Result<jyc_types::SendResult> {
+            Ok(jyc_types::SendResult {
+                message_id: "noop".to_string(),
+            })
+        }
+    }
+
+    fn test_context(thread_path: &std::path::Path) -> CommandContext {
+        CommandContext {
+            args: vec![],
+            thread_path: thread_path.to_path_buf(),
+            config: Arc::new(
+                jyc_types::load_config_from_str(
+                    r#"
+[general]
+[channels.test]
+type = "email"
+[channels.test.inbound]
+host = "h"
+port = 993
+username = "u"
+password = "p"
+[channels.test.outbound]
+host = "h"
+port = 465
+username = "u"
+password = "p"
+[agent]
+enabled = true
+mode = "agent"
+"#,
+                )
+                .unwrap(),
+            ),
+            channel: "test".into(),
+            agent: None,
+            template_dir: std::path::PathBuf::from("/tmp/test/templates"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_cancel_no_active_token_is_noop() {
+        let tmp = tempdir().unwrap();
+        let tm = make_thread_manager(tmp.path());
+
+        // No thread is processing — cancel_thread should not panic
+        tm.cancel_thread("nonexistent").await;
+    }
+
+    #[tokio::test]
+    async fn test_cancel_triggers_token() {
+        let tmp = tempdir().unwrap();
+        let tm = make_thread_manager(tmp.path());
+
+        // Manually insert a cancellation token (simulating an active worker)
+        let token = CancellationToken::new();
+        {
+            let mut cancels = tm.thread_cancels.lock().await;
+            cancels.insert("my-thread".to_string(), token.clone());
+        }
+
+        assert!(!token.is_cancelled());
+        tm.cancel_thread("my-thread").await;
+        assert!(token.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn test_cancel_handler_empty_thread_name() {
+        let tmp = tempdir().unwrap();
+        let tm = make_thread_manager(tmp.path());
+        let handler = CancelCommandHandler::new(tm);
+
+        // Use root path "/" which has no file name
+        let ctx = test_context(std::path::Path::new("/"));
+        let result = handler.execute(ctx).await.unwrap();
+        assert!(!result.success);
+        assert!(result.error.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_cancel_handler_success() {
+        let tmp = tempdir().unwrap();
+        let workspace = tmp.path();
+        let thread_dir = workspace.join("my-thread");
+        tokio::fs::create_dir_all(&thread_dir).await.unwrap();
+
+        let tm = make_thread_manager(workspace);
+
+        // Insert a token to simulate active processing
+        let token = CancellationToken::new();
+        {
+            let mut cancels = tm.thread_cancels.lock().await;
+            cancels.insert("my-thread".to_string(), token.clone());
+        }
+
+        let handler = CancelCommandHandler::new(tm.clone());
+        let ctx = test_context(&thread_dir);
+        let result = handler.execute(ctx).await.unwrap();
+
+        assert!(result.success);
+        assert!(result.message.contains("my-thread"));
+        assert!(token.is_cancelled());
+    }
+}

--- a/crates/jyc-core/src/command/cancel_handler.rs
+++ b/crates/jyc-core/src/command/cancel_handler.rs
@@ -1,0 +1,59 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use super::handler::{CommandContext, CommandHandler, CommandResult};
+use crate::thread_manager::ThreadManager;
+
+/// /cancel command — cancel the current AI processing for this thread.
+///
+/// Triggers the per-thread cancellation token, causing the agent loop to
+/// break at the next iteration check. The thread directory and queue are
+/// preserved.
+pub struct CancelCommandHandler {
+    thread_manager: Arc<ThreadManager>,
+}
+
+impl CancelCommandHandler {
+    pub fn new(thread_manager: Arc<ThreadManager>) -> Self {
+        Self { thread_manager }
+    }
+}
+
+#[async_trait]
+impl CommandHandler for CancelCommandHandler {
+    fn name(&self) -> &str {
+        "/cancel"
+    }
+
+    fn description(&self) -> &str {
+        "Cancel the current AI processing for this thread"
+    }
+
+    async fn execute(&self, context: CommandContext) -> Result<CommandResult> {
+        let thread_name = context
+            .thread_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("");
+
+        if thread_name.is_empty() {
+            return Ok(CommandResult {
+                success: false,
+                message: format!(
+                    "Failed to determine thread name from path: {:?}",
+                    context.thread_path
+                ),
+                error: Some("Thread directory name could not be extracted".into()),
+            });
+        }
+
+        self.thread_manager.cancel_thread(thread_name).await;
+
+        Ok(CommandResult {
+            success: true,
+            message: format!("AI processing cancelled for thread '{}'.", thread_name),
+            error: None,
+        })
+    }
+}

--- a/crates/jyc-core/src/command/mod.rs
+++ b/crates/jyc-core/src/command/mod.rs
@@ -1,3 +1,4 @@
+pub mod cancel_handler;
 pub mod close_handler;
 pub mod handler;
 pub mod help_handler;

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -849,6 +849,21 @@ impl ThreadManager {
         tracing::info!("All workers shut down");
     }
 
+    /// Cancel the AI processing for a thread without deleting its directory.
+    ///
+    /// Triggers the per-thread cancellation token so the agent loop breaks
+    /// at the next iteration. The worker exits, and the next message will
+    /// spawn a new worker automatically. Thread directory and queue are preserved.
+    pub async fn cancel_thread(&self, thread_name: &str) {
+        let mut cancels = self.thread_cancels.lock().await;
+        if let Some(token) = cancels.get(thread_name) {
+            token.cancel();
+            tracing::info!(thread = %thread_name, "Thread AI processing cancelled via cancel_thread");
+        } else {
+            tracing::warn!(thread = %thread_name, "cancel_thread: no cancellation token found (thread may not be processing)");
+        }
+    }
+
     /// Close and delete a thread's directory.
     ///
     /// This is channel-agnostic — all threads use the same cleanup logic.

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -1258,39 +1258,68 @@ async fn process_message(
         .await;
     });
 
-    let result = if item.live_injection {
-        // Live injection enabled: pass real queue receiver so new messages
-        // arriving during AI processing get injected into the active session.
-        agent
-            .process(
-                &message,
-                thread_name,
-                &store_result.thread_path,
-                &store_result.message_dir,
-                pending_rx,
-                thread_cancel.clone(),
-            )
-            .await?
-    } else {
-        // Live injection disabled: pass a dummy receiver that never yields.
-        // Messages stay in the real queue and are processed sequentially
-        // after the current AI call completes.
-        tracing::debug!("Live injection disabled for this pattern, using sequential processing");
-        let (_dummy_tx, mut dummy_rx) = mpsc::channel::<QueueItem>(1);
-        // Drop _dummy_tx immediately so dummy_rx.recv() returns None instantly,
-        // making the SSE select loop skip the injection arm.
-        drop(_dummy_tx);
-        agent
-            .process(
-                &message,
-                thread_name,
-                &store_result.thread_path,
-                &store_result.message_dir,
-                &mut dummy_rx,
-                thread_cancel.clone(),
-            )
-            .await?
+    // The in-process agent does not consume `pending_rx`. We monitor it
+    // ourselves for `/cancel` messages, which trigger the per-thread
+    // cancellation token and cause the agent loop to break at the next
+    // iteration. Non-cancel messages are re-enqueued so they are processed
+    // after the current AI call completes (same as before).
+    let (_dummy_tx, mut dummy_rx) = mpsc::channel::<QueueItem>(1);
+    drop(_dummy_tx);
+
+    let agent_fut = agent.process(
+        &message,
+        thread_name,
+        &store_result.thread_path,
+        &store_result.message_dir,
+        &mut dummy_rx,
+        thread_cancel.clone(),
+    );
+    tokio::pin!(agent_fut);
+
+    // Buffer non-cancel messages that arrive during AI processing.
+    // They are re-enqueued after the agent finishes, preserving FIFO order.
+    let mut buffered: Vec<QueueItem> = Vec::new();
+
+    let result = loop {
+        tokio::select! {
+            r = &mut agent_fut => {
+                break r?;
+            }
+            msg = pending_rx.recv() => match msg {
+                Some(qi) => {
+                    let text = qi.message.content.text.as_deref().unwrap_or("");
+                    if text.trim() == "/cancel" {
+                        tracing::info!(
+                            thread = %thread_name,
+                            "Cancel requested via /cancel during AI processing"
+                        );
+                        thread_cancel.cancel();
+                        // Continue loop — agent_fut will complete due to cancellation
+                    } else {
+                        // Buffer non-cancel message for re-enqueue after AI finishes
+                        buffered.push(qi);
+                    }
+                }
+                None => {
+                    // Channel closed; just wait for agent to finish
+                    break agent_fut.await?;
+                }
+            },
+        }
     };
+
+    // Re-enqueue buffered messages so they are processed after the current AI call
+    for qi in buffered {
+        thread_manager
+            .enqueue(
+                qi.message,
+                qi.thread_name,
+                qi.pattern_match,
+                qi.attachment_config,
+                qi.live_injection,
+            )
+            .await;
+    }
 
     // Stop the delivery watcher
     delivery_cancel.cancel();

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -856,7 +856,7 @@ impl ThreadManager {
     /// at the next iteration. The worker exits, and the next message will
     /// spawn a new worker automatically. Thread directory and queue are preserved.
     pub async fn cancel_thread(&self, thread_name: &str) {
-        let mut cancels = self.thread_cancels.lock().await;
+        let cancels = self.thread_cancels.lock().await;
         if let Some(token) = cancels.get(thread_name) {
             token.cancel();
             tracing::info!(thread = %thread_name, "Thread AI processing cancelled via cancel_thread");

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -12,6 +12,7 @@ use crate::thread_event::ThreadEvent;
 use crate::thread_event_bus::{SimpleThreadEventBus, ThreadEventBusRef};
 
 use crate::agent::AgentService;
+use crate::command::cancel_handler::CancelCommandHandler;
 use crate::command::close_handler::CloseCommandHandler;
 use crate::command::handler::CommandContext;
 use crate::command::help_handler::HelpCommandHandler;
@@ -1089,6 +1090,7 @@ async fn process_message(
     command_registry.register(Box::new(NewCommandHandler));
     command_registry.register(Box::new(TemplateCommandHandler));
     command_registry.register(Box::new(CloseCommandHandler::new(thread_manager.clone())));
+    command_registry.register(Box::new(CancelCommandHandler::new(thread_manager.clone())));
 
     let cmd_context = CommandContext {
         args: vec![],


### PR DESCRIPTION
## Summary

Three improvements to the dashboard chat pane:

1. **Focus pane border color** — Changed from `Cyan` to `Yellow + BOLD` for better visibility. Removed scroll-state color change.

2. **`/cancel` command + `Ctrl+!` shortcut** — New `/cancel` command that cancels the AI processing for the current thread. During AI processing, the worker monitors `pending_rx` via `tokio::select!` — when `/cancel` arrives, it triggers the per-thread `CancellationToken`, causing the agent loop to break at the next iteration. `Ctrl+!` in the dashboard sends `/cancel` via WebSocket.

3. **`Ctrl+Tab` mode switch** — Toggles between plan/build mode by sending `/plan` or `/build` via WebSocket, reusing the existing command system.

## Files Changed

- `crates/jyc-cli/src/cli/dashboard.rs` — border color, `Ctrl+!`/`Ctrl+Tab` shortcuts, `send_raw_message()`
- `crates/jyc-core/src/command/cancel_handler.rs` — new `/cancel` command handler
- `crates/jyc-core/src/command/mod.rs` — module registration
- `crates/jyc-core/src/thread_manager.rs` — `cancel_thread()` method, `pending_rx` monitoring during AI processing
- `CHANGELOG.md`

## Verification

- `cargo check` ✅
- `cargo fmt --check` ✅
- `cargo clippy --workspace -- -D warnings` ✅