### PR TITLE
fix: use Ctrl+C for cancel and Shift+Tab for mode switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,16 +25,16 @@ All notable changes to JYC will be documented in this file.
 
 ### Added
 
-- **`/cancel` command and `Ctrl+!` dashboard shortcut.** New `/cancel` command
+- **`/cancel` command and `Ctrl+C` dashboard shortcut.** New `/cancel` command
   cancels the current AI processing by triggering the per-thread
-  `CancellationToken`. In the dashboard chat pane, `Ctrl+!` sends `/cancel`
+  `CancellationToken`. In the dashboard chat pane, `Ctrl+C` sends `/cancel`
   without modifying the input buffer. The worker's `select!` loop intercepts
   `/cancel` messages arriving during AI processing — the cancellation token fires
   immediately, causing the agent loop to break at the next iteration. Non-cancel
   messages arriving during processing are buffered and re-enqueued after the
   agent finishes, preserving FIFO order.
 
-- **`Ctrl+Tab` dashboard shortcut for mode switching.** Toggles between plan
+- **`Shift+Tab` dashboard shortcut for mode switching.** Toggles between plan
   and build mode by sending `/plan` or `/build` as a WebSocket message, reusing
   the existing command system for mode switching.
 

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -318,7 +318,7 @@ impl App {
 
     /// Send a raw command message via WebSocket without echoing to the chat
     /// view or clearing the input. Used for quick keyboard shortcuts like
-    /// Ctrl+! (cancel) and Ctrl+Tab (mode switch).
+    /// Ctrl+C (cancel) and Shift+Tab (mode switch).
     fn send_raw_message(&mut self, text: &str) {
         let thread = match &self.chat_thread {
             Some(t) => t.clone(),
@@ -671,19 +671,18 @@ fn handle_chat_keys(app: &mut App, key: event::KeyEvent) {
         return;
     }
 
-    // Ctrl+! sends /cancel to stop the current AI processing
-    let is_ctrl_bang =
-        key.code == KeyCode::Char('!') && key.modifiers.contains(KeyModifiers::CONTROL);
-    if is_ctrl_bang && app.chat_phase == ChatPhase::Chatting {
+    // Ctrl+C sends /cancel to stop the current AI processing
+    let is_ctrl_c = key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL);
+    if is_ctrl_c && app.chat_phase == ChatPhase::Chatting {
         app.send_raw_message("/cancel");
         app.set_status("⏹ Cancelled".to_string());
         app.chat_awaiting_response = false;
         return;
     }
 
-    // Ctrl+Tab toggles between plan and build mode
-    let is_ctrl_tab = key.code == KeyCode::Tab && key.modifiers.contains(KeyModifiers::CONTROL);
-    if is_ctrl_tab && app.chat_phase == ChatPhase::Chatting {
+    // Shift+Tab toggles between plan and build mode
+    let is_shift_tab = key.code == KeyCode::BackTab;
+    if is_shift_tab && app.chat_phase == ChatPhase::Chatting {
         let current_mode = app
             .state
             .as_ref()
@@ -1639,7 +1638,7 @@ fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
         match app.chat_phase {
             ChatPhase::PatternSelect => "[↑↓]select [Enter]choose [Esc/Ctrl+Q]close",
             ChatPhase::Chatting => {
-                "[Tab]focus [↑↓]scroll [PgUp/PgDn ^F/^B]page [←→]cursor [^!]cancel [^Tab]mode [Ctrl+W]split [Esc]back [Ctrl+Q]close"
+                "[Tab]focus [↑↓]scroll [PgUp/PgDn ^F/^B]page [←→]cursor [^C]cancel [⇧Tab]mode [Ctrl+W]split [Esc]back [Ctrl+Q]close"
             }
         }
     } else {

--- a/crates/jyc-inspect/src/server.rs
+++ b/crates/jyc-inspect/src/server.rs
@@ -485,7 +485,8 @@ impl ActivityTracker {
                 }
             }
 
-            let mut subscribed: HashSet<(String, String)> = HashSet::new();
+            let subscribed: Arc<Mutex<HashSet<(String, String)>>> =
+                Arc::new(Mutex::new(HashSet::new()));
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(2));
 
             loop {
@@ -498,17 +499,25 @@ impl ActivityTracker {
                             let threads = tm.list_threads().await;
                             for thread in threads {
                                 let key = (channel.clone(), thread.name.clone());
-                                if subscribed.contains(&key) {
-                                    continue;
+                                {
+                                    let sub = subscribed.lock().await;
+                                    if sub.contains(&key) {
+                                        continue;
+                                    }
                                 }
                                 if let Some(bus) = tm.get_event_bus(&thread.name).await
                                     && let Ok(mut rx) = bus.subscribe().await {
-                                        subscribed.insert(key.clone());
+                                        {
+                                            let mut sub = subscribed.lock().await;
+                                            sub.insert(key.clone());
+                                        }
                                         let map = activity_map.clone();
                                         let name = thread.name.clone();
                                         let channel_for_task = channel.clone();
                                         let thread_path = workspace_dir.map(|d| d.join(&name));
                                         let cancel_inner = cancel.clone();
+                                        let subscribed_clone = subscribed.clone();
+                                        let key_clone = key.clone();
                                         tokio::spawn(async move {
                                             loop {
                                                 tokio::select! {
@@ -559,7 +568,15 @@ impl ActivityTracker {
                                                                     state.has_error = true;
                                                                 }
                                                             }
-                                                            None => break,
+                                                            None => {
+                                                                // Event bus was replaced (e.g., after /cancel
+                                                                // caused worker restart). Remove from subscribed
+                                                                // so the next interval tick re-subscribes to the
+                                                                // new event bus.
+                                                                let mut sub = subscribed_clone.lock().await;
+                                                                sub.remove(&key_clone);
+                                                                break;
+                                                            }
                                                         }
                                                     }
                                                     _ = cancel_inner.cancelled() => break,


### PR DESCRIPTION
Ctrl+! and Ctrl+Tab are intercepted by most terminal emulators and never reach the application. This PR switches to reliable keybindings:

- `Ctrl+C` → cancel AI processing (sends `/cancel`)
- `Shift+Tab` → toggle plan/build mode (sends `/plan` or `/build`)

Ctrl+C works in raw mode (crossterm disables SIGINT conversion), and Shift+Tab (BackTab) is universally supported by all terminals.