### PR TITLE
fix: activity tracker panic recovery + WS connection status indicator

### DIFF
--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -89,6 +89,7 @@ struct App {
     activity_split: u8,
     ws_tx: Option<tokio::sync::mpsc::UnboundedSender<String>>,
     ws_rx: tokio::sync::mpsc::UnboundedReceiver<WsEvent>,
+    ws_connected: bool,
 }
 
 impl App {
@@ -115,6 +116,7 @@ impl App {
             activity_split: 0,
             ws_tx: None,
             ws_rx,
+            ws_connected: false,
         }
     }
 
@@ -184,6 +186,7 @@ impl App {
         self.chat_scroll = 0;
         self.activity_scroll = 0;
         self.activity_split = 0;
+        self.ws_connected = false;
 
         let (cmd_tx, cmd_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
         let (event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel::<WsEvent>();
@@ -198,6 +201,7 @@ impl App {
     fn close_chat(&mut self) {
         self.chat_visible = false;
         self.chat_phase = ChatPhase::PatternSelect;
+        self.ws_connected = false;
         if let Some(tx) = self.ws_tx.take() {
             // Best-effort disconnect signal
             let _ = tx.send("{\"type\":\"disconnect\"}".to_string());
@@ -338,6 +342,7 @@ impl App {
     fn handle_ws_event(&mut self, event: WsEvent) {
         match event {
             WsEvent::Connected => {
+                self.ws_connected = true;
                 // Request pattern list on connect
                 let list_msg = serde_json::json!({"type": "list_patterns"}).to_string();
                 if let Some(tx) = &self.ws_tx {
@@ -358,6 +363,7 @@ impl App {
                 }
             }
             WsEvent::Disconnected => {
+                self.ws_connected = false;
                 self.set_status("WebSocket disconnected".to_string());
             }
             WsEvent::Message(text) => {
@@ -1676,10 +1682,20 @@ fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
         ))
     };
 
-    let bar = Paragraph::new(Line::from(vec![
-        Span::raw(format!(" {help_text}  ")),
-        status_part,
-    ]))
+    let bar = Paragraph::new(Line::from({
+        let mut spans = vec![Span::raw(" ")];
+        if app.chat_visible {
+            if app.ws_connected {
+                spans.push(Span::styled("●", Style::default().fg(Color::Green)));
+            } else {
+                spans.push(Span::styled("●", Style::default().fg(Color::Red)));
+            }
+            spans.push(Span::raw(" "));
+        }
+        spans.push(Span::raw(format!("{help_text}  ")));
+        spans.push(status_part);
+        spans
+    }))
     .style(Style::default().bg(Color::DarkGray).fg(Color::White));
 
     frame.render_widget(bar, area);

--- a/crates/jyc-inspect/src/server.rs
+++ b/crates/jyc-inspect/src/server.rs
@@ -519,68 +519,81 @@ impl ActivityTracker {
                                         let subscribed_clone = subscribed.clone();
                                         let key_clone = key.clone();
                                         tokio::spawn(async move {
-                                            loop {
-                                                tokio::select! {
-                                                    event = rx.recv() => {
-                                                        match event {
-                                                            Some(event) => {
-                                                                let is_processing = matches!(
-                                                                    &event,
-                                                                    ThreadEvent::ProcessingStarted { .. }
-                                                                    | ThreadEvent::ProcessingProgress { .. }
-                                                                    | ThreadEvent::ToolStarted { .. }
-                                                                    | ThreadEvent::LLMRequestStarted { .. }
-                                                                );
-                                                                let is_completed = matches!(
-                                                                    &event,
-                                                                    ThreadEvent::ProcessingCompleted { .. }
-                                                                );
-                                                                let entry = event_to_activity(&event);
-                                                                let is_error = entry.severity == Severity::Error;
-                                                                let is_progress =
-                                                                    matches!(&event, ThreadEvent::ProcessingProgress { .. });
-                                                                if let Some(ref path) = thread_path
-                                                                    && let Err(e) = ActivityLogStore::append(path, &entry) {
-                                                                        tracing::warn!(error = %e, thread = %name, "Failed to persist activity entry");
+                                            use futures_util::FutureExt;
+                                            use std::panic::AssertUnwindSafe;
+
+                                            let result = AssertUnwindSafe(async {
+                                                loop {
+                                                    tokio::select! {
+                                                        event = rx.recv() => {
+                                                            match event {
+                                                                Some(event) => {
+                                                                    let is_processing = matches!(
+                                                                        &event,
+                                                                        ThreadEvent::ProcessingStarted { .. }
+                                                                        | ThreadEvent::ProcessingProgress { .. }
+                                                                        | ThreadEvent::ToolStarted { .. }
+                                                                        | ThreadEvent::LLMRequestStarted { .. }
+                                                                    );
+                                                                    let is_completed = matches!(
+                                                                        &event,
+                                                                        ThreadEvent::ProcessingCompleted { .. }
+                                                                    );
+                                                                    let entry = event_to_activity(&event);
+                                                                    let is_error = entry.severity == Severity::Error;
+                                                                    let is_progress =
+                                                                        matches!(&event, ThreadEvent::ProcessingProgress { .. });
+                                                                    if let Some(ref path) = thread_path
+                                                                        && let Err(e) = ActivityLogStore::append(path, &entry) {
+                                                                            tracing::warn!(error = %e, thread = %name, "Failed to persist activity entry");
+                                                                        }
+                                                                    let mut map = map.lock().await;
+                                                                    let state = map
+                                                                        .entry((channel_for_task.clone(), name.clone()))
+                                                                        .or_default();
+                                                                    // ProcessingProgress is a heartbeat, not a discrete
+                                                                    // activity. Persist it to disk but skip the in-memory
+                                                                    // activity log so it doesn't crowd out ToolStarted /
+                                                                    // ToolCompleted entries that show the actual tool name.
+                                                                    if !is_progress {
+                                                                        state.entries.push_back(entry);
+                                                                        if state.entries.len() > MAX_ACTIVITY_ENTRIES {
+                                                                            state.entries.pop_front();
+                                                                        }
                                                                     }
-                                                                let mut map = map.lock().await;
-                                                                let state = map
-                                                                    .entry((channel_for_task.clone(), name.clone()))
-                                                                    .or_default();
-                                                                // ProcessingProgress is a heartbeat, not a discrete
-                                                                // activity. Persist it to disk but skip the in-memory
-                                                                // activity log so it doesn't crowd out ToolStarted /
-                                                                // ToolCompleted entries that show the actual tool name.
-                                                                if !is_progress {
-                                                                    state.entries.push_back(entry);
-                                                                    if state.entries.len() > MAX_ACTIVITY_ENTRIES {
-                                                                        state.entries.pop_front();
+                                                                    state.last_active_at = Some(event.timestamp());
+                                                                    if is_processing {
+                                                                        state.is_processing = true;
+                                                                        state.has_error = false;
+                                                                    } else if is_completed {
+                                                                        state.is_processing = false;
+                                                                    }
+                                                                    if is_error {
+                                                                        state.has_error = true;
                                                                     }
                                                                 }
-                                                                state.last_active_at = Some(event.timestamp());
-                                                                if is_processing {
-                                                                    state.is_processing = true;
-                                                                    state.has_error = false;
-                                                                } else if is_completed {
-                                                                    state.is_processing = false;
-                                                                }
-                                                                if is_error {
-                                                                    state.has_error = true;
-                                                                }
-                                                            }
-                                                            None => {
-                                                                // Event bus was replaced (e.g., after /cancel
-                                                                // caused worker restart). Remove from subscribed
-                                                                // so the next interval tick re-subscribes to the
-                                                                // new event bus.
-                                                                let mut sub = subscribed_clone.lock().await;
-                                                                sub.remove(&key_clone);
-                                                                break;
+                                                                None => break,
                                                             }
                                                         }
+                                                        _ = cancel_inner.cancelled() => break,
                                                     }
-                                                    _ = cancel_inner.cancelled() => break,
                                                 }
+                                            }).catch_unwind().await;
+
+                                            // Always clean up subscribed on exit — whether normal
+                                            // (event bus replaced, cancel) or panic. Without this,
+                                            // the key stays in `subscribed` forever and the thread
+                                            // is never re-subscribed, causing activity events to
+                                            // silently stop appearing in the dashboard.
+                                            let mut sub = subscribed_clone.lock().await;
+                                            sub.remove(&key_clone);
+
+                                            if let Err(panic) = result {
+                                                tracing::error!(
+                                                    thread = %name,
+                                                    panic = ?panic,
+                                                    "Activity tracker task panicked; will re-subscribe on next interval"
+                                                );
                                             }
                                         });
                                     }


### PR DESCRIPTION
## Summary

Two fixes for dashboard activity tracking reliability:

### 1. ActivityTracker panic recovery (jyc-inspect/src/server.rs)

**Problem:** When the per-thread activity listener task panicked (e.g. poisoned mutex), it died silently. The `subscribed` set still contained the thread's key (only the `None` branch removed it), so the 2-second interval tick would skip it forever — activity events permanently stopped for that thread.

**Fix:** Wrap the listener loop body with `catch_unwind`. Move the `subscribed.remove()` cleanup to run unconditionally after the loop exits — whether normal (event bus replaced, cancel) or panic. On panic, log the error so it's visible in journalctl, then the next interval tick re-subscribes.

### 2. WebSocket connection status indicator (jyc-cli/src/cli/dashboard.rs)

**Problem:** No visible indication of WebSocket connection state. Users couldn't tell if the dashboard was disconnected from the inspect server.

**Fix:** Added `ws_connected: bool` field to `App`, updated on `WsEvent::Connected/Disconnected`. Status bar shows 🟢 (green ●) when connected, 🔴 (red ●) when disconnected, only visible in chat mode.

## Test Plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` — all 723 tests pass
- [ ] Manual: verify green/red indicator appears in status bar
- [ ] Manual: verify activity resumes after simulated panic