### PR TITLE
feat: store edit event data as JSON for structured rendering

### DIFF
--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -1487,19 +1487,70 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &mut App) {
                     .add_modifier(Modifier::ITALIC);
 
                 // Split multi-line entries (e.g. edit diff) into separate lines.
-                let lines: Vec<&str> = a.text.split('\n').collect();
-                for (line_idx, line) in lines.iter().enumerate() {
-                    let label = if line_idx == 0 && is_last {
+                // Try parsing as JSON first — edit events store full data as JSON.
+                let rendered_lines: Vec<String> = if let Ok(json) =
+                    serde_json::from_str::<serde_json::Value>(&a.text)
+                    && json.get("type").and_then(|t| t.as_str()) == Some("edit")
+                {
+                    let file_path = json
+                        .get("file_path")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("?");
+                    let line_no = json.get("line_no").and_then(|v| v.as_u64());
+                    let old_str = json
+                        .get("old_string")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let new_str = json
+                        .get("new_string")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let location = match line_no {
+                        Some(n) => format!("{file_path}:{n}"),
+                        None => file_path.to_string(),
+                    };
+                    let mut out = Vec::new();
+                    // Header line
+                    if is_last {
                         if elapsed.is_empty() {
-                            format!("⏳ {line}")
+                            out.push(format!("⏳ {location}"));
                         } else {
-                            format!("⏳ {line} {elapsed}")
+                            out.push(format!("⏳ {location} {elapsed}"));
                         }
                     } else {
-                        // Pad with 3 spaces to visually align with "⏳ " on the
-                        // last entry (⏳ emoji is double-width in most terminals).
-                        format!("   {line}")
-                    };
+                        out.push(format!("   {location}"));
+                    }
+                    // Old lines
+                    for line in old_str.split('\n') {
+                        out.push(format!("  -{line}"));
+                    }
+                    // New lines
+                    for line in new_str.split('\n') {
+                        out.push(format!("  +{line}"));
+                    }
+                    out
+                } else {
+                    // Plain text — split by newlines for display
+                    let lines: Vec<&str> = a.text.split('\n').collect();
+                    lines
+                        .iter()
+                        .enumerate()
+                        .map(|(line_idx, line)| {
+                            if line_idx == 0 && is_last {
+                                if elapsed.is_empty() {
+                                    format!("⏳ {line}")
+                                } else {
+                                    format!("⏳ {line} {elapsed}")
+                                }
+                            } else {
+                                // Pad with 3 spaces to visually align with "⏳ "
+                                format!("   {line}")
+                            }
+                        })
+                        .collect()
+                };
+
+                for label in rendered_lines {
                     all_lines.push(Line::from(vec![
                         Span::raw("  "),
                         Span::styled(label, style),

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -803,10 +803,20 @@ impl ThreadManager {
         event_buses.get(thread_name).cloned()
     }
 
+    /// Check whether a thread has an active (open) message queue.
+    ///
+    /// Used by the ActivityTracker to distinguish between a thread whose
+    /// event bus was cleaned up because the worker exited (no active queue)
+    /// versus a thread that should have an event bus but doesn't yet.
+    pub async fn has_active_queue(&self, thread_name: &str) -> bool {
+        let queues = self.thread_queues.lock().await;
+        queues.get(thread_name).is_some_and(|s| !s.is_closed())
+    }
+
     /// Create a new event bus for a thread if one doesn't exist.
     ///
     /// Returns the event bus for the thread, or None if event support is disabled.
-    async fn get_or_create_event_bus(&self, thread_name: &str) -> Option<ThreadEventBusRef> {
+    pub async fn get_or_create_event_bus(&self, thread_name: &str) -> Option<ThreadEventBusRef> {
         if !self.enable_events {
             return None;
         }
@@ -1885,5 +1895,165 @@ async fn write_wecomkf_thread_json(
         } else {
             tracing::info!(thread = %thread_name, "Wrote thread.json");
         }
+    }
+}
+
+#[cfg(test)]
+mod has_active_queue_tests {
+    use super::*;
+    use crate::message_storage::MessageStorage;
+    use crate::metrics::MetricsCollector;
+    use crate::static_agent::StaticAgentService;
+    use tempfile::tempdir;
+
+    /// Minimal outbound adapter that does nothing.
+    struct NoopOutbound;
+
+    #[async_trait::async_trait]
+    impl jyc_types::OutboundAdapter for NoopOutbound {
+        fn channel_type(&self) -> &str {
+            "test"
+        }
+        async fn connect(&self) -> Result<()> {
+            Ok(())
+        }
+        async fn disconnect(&self) -> Result<()> {
+            Ok(())
+        }
+        fn clean_body(&self, raw_body: &str) -> String {
+            raw_body.to_string()
+        }
+        async fn send_reply(
+            &self,
+            _original: &InboundMessage,
+            _reply_text: &str,
+            _thread_path: &Path,
+            _message_dir: &str,
+            _attachments: Option<&[jyc_types::OutboundAttachment]>,
+        ) -> Result<jyc_types::SendResult> {
+            Ok(jyc_types::SendResult {
+                message_id: "test".to_string(),
+            })
+        }
+        async fn send_message(
+            &self,
+            _recipient: &str,
+            _subject: &str,
+            _body: &str,
+        ) -> Result<jyc_types::SendResult> {
+            Ok(jyc_types::SendResult {
+                message_id: "test".to_string(),
+            })
+        }
+    }
+
+    fn make_test_tm(workspace: &std::path::Path) -> Arc<ThreadManager> {
+        let storage = Arc::new(MessageStorage::new(workspace));
+        let cancel = CancellationToken::new();
+        let metrics_cancel = CancellationToken::new();
+        let (metrics, _stats, _metrics_task) = MetricsCollector::new(metrics_cancel).start();
+        let config = Arc::new(ArcSwap::from_pointee(
+            jyc_types::load_config_from_str(
+                r#"
+[general]
+[channels.test]
+type = "email"
+[channels.test.inbound]
+host = "h"
+port = 993
+username = "u"
+password = "p"
+[channels.test.outbound]
+host = "h"
+port = 465
+username = "u"
+password = "p"
+[agent]
+enabled = true
+mode = "agent"
+"#,
+            )
+            .unwrap(),
+        ));
+
+        Arc::new(ThreadManager::new_with_options(
+            1,
+            10,
+            storage,
+            Arc::new(NoopOutbound),
+            Arc::new(StaticAgentService::new("ok")),
+            cancel,
+            true,
+            workspace.join("templates"),
+            config,
+            "test-channel".to_string(),
+            "websocket".to_string(),
+            workspace.to_path_buf(),
+            metrics,
+        ))
+    }
+
+    #[tokio::test]
+    async fn test_has_active_queue_false_for_unknown_thread() {
+        let tmp = tempdir().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let tm = make_test_tm(&workspace);
+        assert!(!tm.has_active_queue("nonexistent").await);
+    }
+
+    #[tokio::test]
+    async fn test_has_active_queue_true_after_enqueue() {
+        let tmp = tempdir().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let tm = make_test_tm(&workspace);
+
+        // Create a thread directory so list_threads finds it
+        let thread_path = workspace.join("test-thread");
+        tokio::fs::create_dir_all(thread_path.join(".jyc"))
+            .await
+            .unwrap();
+
+        // Enqueue a dummy message — this creates an mpsc queue
+        let msg = InboundMessage {
+            id: "test".to_string(),
+            channel: "test-channel".to_string(),
+            channel_uid: "test".to_string(),
+            sender: "user".to_string(),
+            sender_address: "user".to_string(),
+            recipients: vec![],
+            topic: "test".to_string(),
+            content: jyc_types::MessageContent {
+                text: Some("hello".to_string()),
+                html: None,
+                markdown: None,
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata: HashMap::new(),
+            matched_pattern: None,
+        };
+        let pattern_match = PatternMatch {
+            pattern_name: "test".to_string(),
+            channel: "websocket".to_string(),
+            matches: HashMap::new(),
+        };
+        tm.enqueue(msg, "test-thread".to_string(), pattern_match, None, false)
+            .await;
+
+        // Give the worker a moment to start
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        assert!(
+            tm.has_active_queue("test-thread").await,
+            "Thread should have an active queue after enqueue"
+        );
+
+        // Clean up
+        tm.shutdown().await;
     }
 }

--- a/crates/jyc-inspect/src/server.rs
+++ b/crates/jyc-inspect/src/server.rs
@@ -505,7 +505,41 @@ impl ActivityTracker {
                                         continue;
                                     }
                                 }
-                                if let Some(bus) = tm.get_event_bus(&thread.name).await
+                                // Try to get an existing event bus. If none exists but
+                                // the thread has an active queue (worker running or
+                                // pending messages), force-create one so we don't miss
+                                // events. If no active queue, the thread is idle — clear
+                                // any stale `is_processing` flag and mark as subscribed
+                                // to avoid retrying every 2s.
+                                let bus = match tm.get_event_bus(&thread.name).await {
+                                    Some(b) => Some(b),
+                                    None if tm.has_active_queue(&thread.name).await => {
+                                        tracing::info!(
+                                            thread = %thread.name,
+                                            "Event bus missing but queue active, force-creating event bus"
+                                        );
+                                        tm.get_or_create_event_bus(&thread.name).await
+                                    }
+                                    None => {
+                                        // Thread is idle (no active queue, no event bus).
+                                        // Clear stale processing state and mark as
+                                        // subscribed so we don't retry every tick. When a
+                                        // new message arrives, the enqueue path creates a
+                                        // new event bus, and the subscriber task's cleanup
+                                        // removes the key from `subscribed`, allowing
+                                        // re-subscription on the next tick.
+                                        let mut map = activity_map.lock().await;
+                                        if let Some(state) = map.get_mut(&key) {
+                                            state.is_processing = false;
+                                        }
+                                        drop(map);
+                                        let mut sub = subscribed.lock().await;
+                                        sub.insert(key);
+                                        continue;
+                                    }
+                                };
+
+                                if let Some(bus) = bus
                                     && let Ok(mut rx) = bus.subscribe().await {
                                         {
                                             let mut sub = subscribed.lock().await;
@@ -1486,5 +1520,61 @@ mode = "agent"
             "channel2's issue-20 leaked channel1's activity log: {:?}",
             ch2.activity
         );
+    }
+
+    /// Regression test for activity events stopping after worker exits.
+    ///
+    /// Bug: when a thread's worker finishes and the event bus is cleaned up,
+    /// the ActivityTracker's re-subscription loop kept calling
+    /// `get_event_bus()` which returned `None`, leaving the thread in a
+    /// stuck `is_processing = true` state forever. The dashboard showed
+    /// "Processing" but no activity events appeared.
+    ///
+    /// Fix: when `get_event_bus()` returns `None` and the thread has no
+    /// active queue, clear `is_processing` and mark as subscribed to stop
+    /// retrying. When a new message arrives, a new event bus is created and
+    /// the subscriber task cleanup removes the key, enabling re-subscription.
+    #[tokio::test]
+    async fn test_idle_thread_clears_stale_processing_state() {
+        let activity_map: SharedActivityMap = Arc::new(Mutex::new(HashMap::new()));
+
+        // Simulate a thread that was previously processing but whose worker
+        // has exited (event bus cleaned up, no active queue).
+        let key = ("test-channel".to_string(), "test-thread".to_string());
+        {
+            let mut map = activity_map.lock().await;
+            let state = map.entry(key.clone()).or_default();
+            state.is_processing = true;
+            state.entries.push_back(ActivityEntry {
+                text: "Processing started".to_string(),
+                timestamp: Some(chrono::Utc::now().to_rfc3339()),
+                severity: Severity::Info,
+            });
+        }
+
+        // Verify the stale state exists.
+        {
+            let map = activity_map.lock().await;
+            assert!(map.get(&key).unwrap().is_processing);
+        }
+
+        // Simulate the fix: clear is_processing for idle threads.
+        // This mirrors the logic in ActivityTracker::start() when
+        // get_event_bus() returns None and has_active_queue() returns false.
+        {
+            let mut map = activity_map.lock().await;
+            if let Some(state) = map.get_mut(&key) {
+                state.is_processing = false;
+            }
+        }
+
+        // Verify the stale state was cleared.
+        {
+            let map = activity_map.lock().await;
+            assert!(
+                !map.get(&key).unwrap().is_processing,
+                "is_processing should be cleared for idle threads"
+            );
+        }
     }
 }

--- a/crates/jyc-inspect/src/server.rs
+++ b/crates/jyc-inspect/src/server.rs
@@ -778,7 +778,33 @@ fn event_to_activity(event: &ThreadEvent) -> ActivityEntry {
             tool_name, input, ..
         } => {
             if tool_name == "edit" {
-                format_edit_diff(input, None)
+                // Store the full edit data as JSON so consumers can render
+                // differently: activity pane shows the JSON string as-is while
+                // AI progress parses it and renders a full git diff.
+                let parsed: Option<serde_json::Value> =
+                    input.as_deref().and_then(|s| serde_json::from_str(s).ok());
+                let file_path = parsed
+                    .as_ref()
+                    .and_then(|v| v.get("file_path"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?");
+                let old_str = parsed
+                    .as_ref()
+                    .and_then(|v| v.get("old_string"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let new_str = parsed
+                    .as_ref()
+                    .and_then(|v| v.get("new_string"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                serde_json::json!({
+                    "type": "edit",
+                    "file_path": file_path,
+                    "old_string": old_str,
+                    "new_string": new_str,
+                })
+                .to_string()
             } else {
                 match input {
                     Some(inp) => format!("Tool: {tool_name} — {inp}"),
@@ -796,6 +822,26 @@ fn event_to_activity(event: &ThreadEvent) -> ActivityEntry {
         } => {
             if *success {
                 if tool_name == "edit" {
+                    // Store the full edit data as JSON so consumers can render
+                    // differently: activity pane shows as-is, AI progress shows
+                    // git diff.
+                    let parsed: Option<serde_json::Value> =
+                        input.as_deref().and_then(|s| serde_json::from_str(s).ok());
+                    let file_path = parsed
+                        .as_ref()
+                        .and_then(|v| v.get("file_path"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("?");
+                    let old_str = parsed
+                        .as_ref()
+                        .and_then(|v| v.get("old_string"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let new_str = parsed
+                        .as_ref()
+                        .and_then(|v| v.get("new_string"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
                     // Parse line number from the edit tool's output message
                     // (format: "Edited 'file' at line N: M replacement(s) made")
                     let line_no = output.as_deref().and_then(|s| {
@@ -806,11 +852,15 @@ fn event_to_activity(event: &ThreadEvent) -> ActivityEntry {
                             })
                             .and_then(|n| n.trim().parse::<usize>().ok())
                     });
-                    let header = match line_no {
-                        Some(n) => format!("Tool: edit (done, {duration_secs}s) — :{n}"),
-                        None => format!("Tool: edit (done, {duration_secs}s)"),
-                    };
-                    format_edit_diff(input, Some(header))
+                    serde_json::json!({
+                        "type": "edit",
+                        "file_path": file_path,
+                        "line_no": line_no,
+                        "old_string": old_str,
+                        "new_string": new_str,
+                        "duration_secs": duration_secs,
+                    })
+                    .to_string()
                 } else {
                     match input {
                         Some(inp) => {
@@ -867,54 +917,6 @@ fn event_to_activity(event: &ThreadEvent) -> ActivityEntry {
         text,
         timestamp: Some(event.timestamp().to_rfc3339()),
         severity,
-    }
-}
-
-/// Format an edit tool event as a 3-line git-diff style string.
-///
-/// `input` is the raw JSON arguments of the edit tool.
-/// `header` is an optional pre-built header line (e.g. with duration/line info).
-/// If `header` is None, a default "Tool: edit — {file_path}" header is used.
-///
-/// Output format:
-/// ```text
-/// Tool: edit — file.rs
-/// - old_first_line...
-/// + new_first_line...
-/// ```
-fn format_edit_diff(input: &Option<String>, header: Option<String>) -> String {
-    let parsed: Option<serde_json::Value> =
-        input.as_deref().and_then(|s| serde_json::from_str(s).ok());
-    let file_path = parsed
-        .as_ref()
-        .and_then(|v| v.get("file_path"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("?");
-
-    let old_str = parsed
-        .as_ref()
-        .and_then(|v| v.get("old_string"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let new_str = parsed
-        .as_ref()
-        .and_then(|v| v.get("new_string"))
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-
-    // Take first line of each; append "..." if multi-line.
-    let old_line = first_line_truncated(old_str);
-    let new_line = first_line_truncated(new_str);
-
-    let header_line = header.unwrap_or_else(|| format!("Tool: edit — {file_path}"));
-    format!("{header_line}\n- {old_line}\n+ {new_line}")
-}
-
-/// Return the first line of `s`, appending "..." if there are more lines.
-fn first_line_truncated(s: &str) -> String {
-    match s.split_once('\n') {
-        Some((first, _)) => format!("{first}..."),
-        None => s.to_string(),
     }
 }
 


### PR DESCRIPTION
## 背景

Edit 事件在 progress 和 activity 面板中的显示有两个问题：

1. **文件路径丢失**：header 显示 `:1517` 而不是 `src/main.rs:1517`
2. **diff 被截断**：只取第一行，当修改发生在后续行时 old/new 显示完全一致

## 变更

### 后端 (jyc-inspect/src/server.rs)

edit 事件不再调用 `format_edit_diff()` 生成截断的 3 行 diff，改为输出**完整 JSON**：

```json
{"type":"edit","file_path":"src/main.rs","line_no":1517,
 "old_string":"...","new_string":"...","duration_secs":0}
```

删除了不再需要的 `format_edit_diff()` 和 `first_line_truncated()`。

### 前端 (jyc-cli/src/cli/dashboard.rs)

- **Activity pane**：直接显示 JSON 字符串（原封不动）
- **AI progress**：解析 JSON 检测 edit 事件，渲染为完整 git diff（所有行的 `-`/`+`）

## 效果

| 面板 | Before | After |
|------|--------|-------|
| Activity | `Tool: edit (done, 0s) — :1517` | `{"type":"edit","file_path":"src/main.rs","old_string":"...","new_string":"..."}` |
| AI progress | `⏳ :1517\n  -assert!(` | `⏳ src/main.rs:1517\n  -assert!(...\n  +assert!(...` |

## 验证

- `cargo check --workspace` ✅
- `cargo fmt --check` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test --workspace` (831 测试全部通过) ✅