### PR TITLE
feat: websocket channel multi-thread support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,16 @@ All notable changes to JYC will be documented in this file.
   messaging, and multi-client broadcast via `tokio::sync::broadcast`. (#284,
   #285)
 
+### Changed
+
+- **WebSocket channel now supports multiple threads per channel.** Thread names
+  are derived from the client's `thread` field in WebSocket messages (e.g.,
+  `{"type":"message","thread":"general","text":"hello"}`). When `thread` is
+  non-empty, it is used as the thread name; when empty, it falls back to the
+  channel name for backward compatibility. This enables separate conversation
+  contexts and workspace directories for different threads within the same
+  websocket channel.
+
 ### Removed
 
 - **Local TUI channel and `jyc local` CLI command.** The standalone `local`

--- a/crates/jyc-channels/src/websocket/inbound.rs
+++ b/crates/jyc-channels/src/websocket/inbound.rs
@@ -34,12 +34,17 @@ impl ChannelMatcher for WebsocketMatcher {
 
     fn derive_thread_name(
         &self,
-        _message: &InboundMessage,
+        message: &InboundMessage,
         _patterns: &[ChannelPattern],
         _pattern_match: Option<&PatternMatch>,
     ) -> String {
-        // Each websocket channel has exactly one thread named after the channel.
-        self.channel_name.clone()
+        // Use the thread name specified by the client (e.g. from the WebSocket
+        // protocol's `thread` field). Fall back to the channel name when empty.
+        if message.topic.is_empty() {
+            self.channel_name.clone()
+        } else {
+            message.topic.clone()
+        }
     }
 
     fn match_message(

--- a/crates/jyc-channels/src/websocket/inbound.rs
+++ b/crates/jyc-channels/src/websocket/inbound.rs
@@ -448,9 +448,18 @@ mod tests {
     }
 
     #[test]
-    fn test_derive_thread_name() {
+    fn test_derive_thread_name_uses_topic() {
         let matcher = WebsocketMatcher::new("my-ws".to_string());
         let msg = create_test_message();
+        let name = matcher.derive_thread_name(&msg, &[], None);
+        assert_eq!(name, "Test");
+    }
+
+    #[test]
+    fn test_derive_thread_name_empty_topic_fallback() {
+        let matcher = WebsocketMatcher::new("my-ws".to_string());
+        let mut msg = create_test_message();
+        msg.topic = String::new();
         let name = matcher.derive_thread_name(&msg, &[], None);
         assert_eq!(name, "my-ws");
     }

--- a/crates/jyc-channels/tests/websocket_integration_test.rs
+++ b/crates/jyc-channels/tests/websocket_integration_test.rs
@@ -149,6 +149,27 @@ async fn test_websocket_adapter_start_and_handle() {
     assert_eq!(received.content.text.as_ref().unwrap(), message_text);
     assert_eq!(received.sender, "user");
 
+    // Send a second message to a different thread to verify multi-thread routing
+    let second_text = "Hello to coding thread";
+    let second_msg = format!(
+        r#"{{"type":"message","thread":"coding","text":"{}"}}"#,
+        second_text
+    );
+    write
+        .send(tokio_tungstenite::tungstenite::Message::Text(second_msg))
+        .await
+        .unwrap();
+
+    let received2 = tokio::time::timeout(tokio::time::Duration::from_secs(5), msg_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(received2.channel, "test-ws");
+    assert_eq!(received2.topic, "coding");
+    assert_eq!(received2.content.text.as_ref().unwrap(), second_text);
+    assert_eq!(received2.sender, "user");
+
     // Close connection
     let _ = write
         .send(tokio_tungstenite::tungstenite::Message::Close(None))

--- a/docs/channels/websocket.md
+++ b/docs/channels/websocket.md
@@ -190,11 +190,14 @@ All connected dashboard clients receive broadcast replies via `tokio::sync::broa
 
 ## Thread Naming
 
-Each websocket channel has exactly one thread per pattern:
+WebSocket thread names are derived from the `thread` field in client messages:
 
+```json
+{"type":"message","thread":"general","text":"hello"}
+{"type":"subscribe","thread":"general"}
 ```
-thread_name = "{channel_name}"   # e.g., "my_ws"
-```
+
+When a message's `thread` field is non-empty, it is used as the thread name. When empty, the thread name falls back to the channel name (e.g., `my_ws`).
 
 Workspace files are stored under:
 
@@ -230,7 +233,7 @@ The full resolution chain for websocket channels (highest to lowest priority):
 | Setup complexity | High | High | Medium | Low |
 | Real-time | Polling | Webhook/WebSocket | WebSocket | Instant |
 | Multi-client | No | No | No | Yes |
-| Workspace isolation | Per-thread | Per-thread | Per-thread | Per-channel |
+| Workspace isolation | Per-thread | Per-thread | Per-thread | Per-thread |
 
 ## Workspace Layout
 


### PR DESCRIPTION
## Summary

WebSocket channel now supports multiple threads per channel, derived from the client-provided `thread` field in WebSocket messages.

## Changes

- **`derive_thread_name`** now uses `message.topic` (populated from client's `thread` field) when non-empty, falling back to channel name for backward compatibility.
- Added unit tests covering both non-empty topic and empty-topic fallback scenarios.
- Added integration test verifying messages to different `thread` values are correctly routed with corresponding `topic`.
- Updated `docs/channels/websocket.md` to reflect multi-thread naming and workspace isolation.
- Updated `CHANGELOG.md` with unreleased entry.

## Backward Compatibility

Existing dashboard behavior is unchanged: when `thread` equals the channel name (current default), routing is identical to before.

## Verification

- `cargo fmt --check` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test -p jyc-channels websocket` — 34 unit + 2 integration tests pass ✅