### PR TITLE
feat: dynamic config reload for patterns and InspectContext (#338)

### DIFF
--- a/crates/jyc-channels/Cargo.toml
+++ b/crates/jyc-channels/Cargo.toml
@@ -36,6 +36,7 @@ aes = "0.8"
 cbc = "0.1"
 axum = { version = "0.7", features = ["macros"] }
 tower = "0.5"
+arc-swap = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/jyc-channels/src/gitee/inbound.rs
+++ b/crates/jyc-channels/src/gitee/inbound.rs
@@ -186,7 +186,6 @@ pub struct GiteeInboundAdapter {
     channel_name: String,
     state_dir: PathBuf,
     workdir: PathBuf,
-    patterns: Vec<ChannelPattern>,
 }
 
 impl GiteeInboundAdapter {
@@ -197,13 +196,7 @@ impl GiteeInboundAdapter {
             channel_name,
             state_dir,
             workdir: workdir.to_path_buf(),
-            patterns: Vec::new(),
         }
-    }
-
-    pub fn with_patterns(mut self, patterns: Vec<ChannelPattern>) -> Self {
-        self.patterns = patterns;
-        self
     }
 
     async fn load_processed_comments(&self) -> HashSet<String> {

--- a/crates/jyc-channels/src/github/inbound.rs
+++ b/crates/jyc-channels/src/github/inbound.rs
@@ -1,7 +1,9 @@
 use anyhow::{Context, Result};
+use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 use super::client::{GithubClient, GithubComment};
@@ -244,31 +246,52 @@ pub struct GithubInboundAdapter {
     state_dir: PathBuf,
     /// Workdir for workspace resolution: <workdir>/
     workdir: PathBuf,
-    /// Configured patterns for this channel. Used to derive the set of
-    /// pull-request thread prefixes when scanning the workspace for active PR
-    /// threads. May be empty (e.g., in unit tests), in which case the default
-    /// `pr` prefix is used.
-    patterns: Vec<ChannelPattern>,
+    /// Live application config for dynamic pattern reading.
+    app_config: Option<Arc<ArcSwap<jyc_types::AppConfig>>>,
+    /// Test-only override for patterns. When set, takes priority over app_config.
+    test_patterns: Option<Vec<ChannelPattern>>,
 }
 
 impl GithubInboundAdapter {
-    pub fn new(config: &GithubConfig, channel_name: String, workdir: &Path) -> Self {
+    pub fn new(
+        config: &GithubConfig,
+        channel_name: String,
+        workdir: &Path,
+        app_config: Option<Arc<ArcSwap<jyc_types::AppConfig>>>,
+    ) -> Self {
         let state_dir = workdir.join(&channel_name).join(".github");
         Self {
             config: config.clone(),
             channel_name,
             state_dir,
             workdir: workdir.to_path_buf(),
-            patterns: Vec::new(),
+            app_config,
+            test_patterns: None,
         }
     }
 
-    /// Inject the configured patterns. Used so disk scans can recognize all
-    /// pull-request thread directory prefixes (e.g. `pr-`, `review-pr-`, plus
-    /// any user-defined `thread_prefix` for PR-typed patterns).
+    /// Set test patterns (for unit tests only).
+    #[cfg(test)]
     pub fn with_patterns(mut self, patterns: Vec<ChannelPattern>) -> Self {
-        self.patterns = patterns;
+        self.test_patterns = Some(patterns);
         self
+    }
+
+    /// Read the current patterns for this channel.
+    fn patterns(&self) -> Vec<ChannelPattern> {
+        if let Some(ref patterns) = self.test_patterns {
+            return patterns.clone();
+        }
+        match &self.app_config {
+            Some(cfg) => {
+                let cfg = cfg.load();
+                cfg.channels
+                    .get(&self.channel_name)
+                    .and_then(|c| c.patterns.clone())
+                    .unwrap_or_default()
+            }
+            None => Vec::new(),
+        }
     }
 
     /// Load processed comment keys from persistent storage.
@@ -557,7 +580,7 @@ impl GithubInboundAdapter {
         let mut prefixes: HashSet<String> = HashSet::new();
         prefixes.insert("pr".to_string());
 
-        for pattern in &self.patterns {
+        for pattern in self.patterns() {
             // Only consider patterns that can match pull_request events.
             let matches_pr = match pattern.rules.github_type.as_ref() {
                 Some(types) => types.iter().any(|t| t == "pull_request"),
@@ -2464,7 +2487,8 @@ mod tests {
             poll_interval_secs: 60,
             poll_ci_status: true,
         };
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None);
         tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
 
         let comments = adapter.load_processed_comments().await;
@@ -2482,7 +2506,8 @@ mod tests {
             poll_interval_secs: 60,
             poll_ci_status: true,
         };
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None);
         tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
 
         let mut processed = HashSet::new();
@@ -2520,7 +2545,8 @@ mod tests {
             poll_interval_secs: 60,
             poll_ci_status: true,
         };
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None);
         tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
 
         let mut processed = HashSet::new();
@@ -2556,7 +2582,8 @@ mod tests {
             poll_interval_secs: 60,
             poll_ci_status: true,
         };
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None);
         tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
 
         // Create a set with 3000 entries (key format: "id:timestamp")
@@ -2592,7 +2619,8 @@ mod tests {
             poll_interval_secs: 60,
             poll_ci_status: true,
         };
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None);
         tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
 
         // Set with fewer than 2000 entries — compact should be a no-op
@@ -2616,7 +2644,8 @@ mod tests {
             poll_ci_status: true,
         };
         let tmpdir = tempfile::tempdir().unwrap();
-        let adapter = GithubInboundAdapter::new(&config, "test_github".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_github".to_string(), tmpdir.path(), None);
 
         let msg = adapter.build_trigger_message(
             "issue_comment",
@@ -2655,7 +2684,8 @@ mod tests {
             poll_ci_status: true,
         };
         let tmpdir = tempfile::tempdir().unwrap();
-        let adapter = GithubInboundAdapter::new(&config, "test_github".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_github".to_string(), tmpdir.path(), None);
 
         let msg = adapter.build_trigger_message(
             "pull_request",
@@ -2686,7 +2716,8 @@ mod tests {
             poll_ci_status: true,
         };
         let tmpdir = tempfile::tempdir().unwrap();
-        let adapter = GithubInboundAdapter::new(&config, "networkcalc".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "networkcalc".to_string(), tmpdir.path(), None);
 
         let msg = adapter.build_trigger_message(
             "pull_request",
@@ -3297,7 +3328,8 @@ mod tests {
     async fn test_ci_status_load_and_track() {
         let tmpdir = tempfile::tempdir().unwrap();
         let config = make_ci_test_config();
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None);
         tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
 
         let mut ci_status: HashMap<u64, (String, String)> = HashMap::new();
@@ -3335,7 +3367,8 @@ mod tests {
     async fn test_ci_status_transition_triggers_message() {
         let tmpdir = tempfile::tempdir().unwrap();
         let config = make_ci_test_config();
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None);
         tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
 
         let mut ci_status: HashMap<u64, (String, String)> = HashMap::new();
@@ -3372,7 +3405,8 @@ mod tests {
     async fn test_ci_status_no_retrigger_on_same_failure() {
         let tmpdir = tempfile::tempdir().unwrap();
         let config = make_ci_test_config();
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None);
         tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
 
         let mut ci_status: HashMap<u64, (String, String)> = HashMap::new();
@@ -3392,7 +3426,8 @@ mod tests {
     async fn test_ci_status_resets_on_new_commit() {
         let tmpdir = tempfile::tempdir().unwrap();
         let config = make_ci_test_config();
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None);
         tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
 
         let mut ci_status: HashMap<u64, (String, String)> = HashMap::new();
@@ -3433,7 +3468,8 @@ mod tests {
     async fn test_ci_status_empty_load() {
         let tmpdir = tempfile::tempdir().unwrap();
         let config = make_ci_test_config();
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None);
         tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
 
         let ci_status = adapter.load_ci_status().await;
@@ -3444,7 +3480,8 @@ mod tests {
     async fn test_ci_status_compact() {
         let tmpdir = tempfile::tempdir().unwrap();
         let config = make_ci_test_config();
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None);
         tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
 
         let mut ci_status: HashMap<u64, (String, String)> = HashMap::new();
@@ -3497,7 +3534,8 @@ mod tests {
     async fn test_ci_status_no_file_growth_on_unchanged() {
         let tmpdir = tempfile::tempdir().unwrap();
         let config = make_ci_test_config();
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None);
         tokio::fs::create_dir_all(&adapter.state_dir).await.unwrap();
 
         let mut ci_status: HashMap<u64, (String, String)> = HashMap::new();
@@ -3580,7 +3618,8 @@ mod tests {
     fn test_scan_active_pr_threads_empty_workspace() {
         let tmpdir = tempfile::tempdir().unwrap();
         let config = make_ci_test_config();
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None);
 
         let result = adapter.scan_active_pr_threads();
         assert!(
@@ -3605,8 +3644,9 @@ mod tests {
             },
             ..Default::default()
         };
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path())
-            .with_patterns(vec![reviewer_pattern]);
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None)
+                .with_patterns(vec![reviewer_pattern]);
 
         let workspace = tmpdir.path().join("test_ch").join("workspace");
         std::fs::create_dir_all(workspace.join("pr-42")).unwrap();
@@ -3637,8 +3677,9 @@ mod tests {
             },
             ..Default::default()
         };
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path())
-            .with_patterns(vec![reviewer_pattern]);
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None)
+                .with_patterns(vec![reviewer_pattern]);
 
         let workspace = tmpdir.path().join("test_ch").join("workspace");
         std::fs::create_dir_all(workspace.join("review-pr-43")).unwrap();
@@ -3665,8 +3706,9 @@ mod tests {
             },
             ..Default::default()
         };
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path())
-            .with_patterns(vec![qa_pattern]);
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None)
+                .with_patterns(vec![qa_pattern]);
 
         let workspace = tmpdir.path().join("test_ch").join("workspace");
         std::fs::create_dir_all(workspace.join("review-pr-43")).unwrap();
@@ -3682,7 +3724,8 @@ mod tests {
     fn test_scan_active_pr_threads_non_numeric_suffix() {
         let tmpdir = tempfile::tempdir().unwrap();
         let config = make_ci_test_config();
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None);
 
         let workspace = tmpdir.path().join("test_ch").join("workspace");
         std::fs::create_dir_all(workspace.join("pr-abc")).unwrap();
@@ -3705,8 +3748,9 @@ mod tests {
             },
             ..Default::default()
         };
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path())
-            .with_patterns(vec![reviewer_pattern]);
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None)
+                .with_patterns(vec![reviewer_pattern]);
 
         let workspace = tmpdir.path().join("test_ch").join("workspace");
         std::fs::create_dir_all(workspace.join("pr-42")).unwrap();
@@ -3735,7 +3779,8 @@ mod tests {
     fn test_ci_polling_no_active_threads_skips_all() {
         let tmpdir = tempfile::tempdir().unwrap();
         let config = make_ci_test_config();
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None);
 
         let active_pr_threads = adapter.scan_active_pr_threads();
 
@@ -3763,7 +3808,8 @@ mod tests {
         // GitHub close path.
         let tmpdir = tempfile::tempdir().unwrap();
         let config = make_ci_test_config();
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None);
 
         let workspace = tmpdir.path().join("test_ch").join("workspace");
         std::fs::create_dir_all(workspace.join("issue-42")).unwrap();
@@ -3783,7 +3829,8 @@ mod tests {
     fn test_scan_threads_for_number_empty_workspace() {
         let tmpdir = tempfile::tempdir().unwrap();
         let config = make_ci_test_config();
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None);
         let result = adapter.scan_threads_for_number(42);
         assert!(result.is_empty());
     }
@@ -3793,7 +3840,8 @@ mod tests {
         // A directory ending in -420 must NOT match number 42.
         let tmpdir = tempfile::tempdir().unwrap();
         let config = make_ci_test_config();
-        let adapter = GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path());
+        let adapter =
+            GithubInboundAdapter::new(&config, "test_ch".to_string(), tmpdir.path(), None);
 
         let workspace = tmpdir.path().join("test_ch").join("workspace");
         std::fs::create_dir_all(workspace.join("issue-420")).unwrap();

--- a/crates/jyc-channels/src/websocket/inbound.rs
+++ b/crates/jyc-channels/src/websocket/inbound.rs
@@ -3,8 +3,10 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use anyhow::Result;
+use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use futures_util::{SinkExt, StreamExt};
 use tokio::sync::broadcast;
@@ -103,7 +105,8 @@ type OnMessageCallback = Box<dyn Fn(InboundMessage) -> Result<()> + Send + Sync>
 /// upgrades.
 pub struct WebsocketInboundAdapter {
     channel_name: String,
-    patterns: Vec<ChannelPattern>,
+    /// Live application config for dynamic pattern reading.
+    app_config: Option<Arc<ArcSwap<jyc_types::AppConfig>>>,
     /// Broadcast sender — cloned for each new connection via `subscribe()`.
     broadcast_tx: broadcast::Sender<String>,
     /// Message callback — set during `start()`, used by the WebSocket handler.
@@ -116,15 +119,35 @@ impl WebsocketInboundAdapter {
     /// Create a new websocket inbound adapter.
     pub fn new(
         channel_name: String,
-        patterns: Vec<ChannelPattern>,
+        app_config: Option<Arc<ArcSwap<jyc_types::AppConfig>>>,
         broadcast_tx: broadcast::Sender<String>,
     ) -> Self {
         Self {
             channel_name,
-            patterns,
+            app_config,
             broadcast_tx,
             on_message: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
             workspace_dir: None,
+        }
+    }
+
+    /// Read the current enabled pattern names for this channel from the live config.
+    fn pattern_names(&self) -> Vec<String> {
+        match &self.app_config {
+            Some(cfg) => {
+                let cfg = cfg.load();
+                cfg.channels
+                    .get(&self.channel_name)
+                    .and_then(|c| c.patterns.as_ref())
+                    .map(|p| {
+                        p.iter()
+                            .filter(|pat| pat.enabled)
+                            .map(|pat| pat.name.clone())
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            }
+            None => Vec::new(),
         }
     }
 
@@ -147,12 +170,7 @@ impl jyc_inspect::server::WebsocketHandler for WebsocketInboundAdapter {
         ws_stream: tokio_tungstenite::WebSocketStream<jyc_inspect::server::PrependStream>,
         addr: SocketAddr,
     ) -> anyhow::Result<()> {
-        let pattern_names: Vec<String> = self
-            .patterns
-            .iter()
-            .filter(|p| p.enabled)
-            .map(|p| p.name.clone())
-            .collect();
+        let pattern_names: Vec<String> = self.pattern_names();
 
         let broadcast_rx = self.broadcast_tx.subscribe();
         let channel_name = self.channel_name.clone();

--- a/crates/jyc-channels/tests/websocket_integration_test.rs
+++ b/crates/jyc-channels/tests/websocket_integration_test.rs
@@ -1,49 +1,42 @@
-use std::collections::HashMap;
-use std::sync::Arc;
-
+use arc_swap::ArcSwap;
 use futures_util::{SinkExt, StreamExt};
-use tokio::sync::broadcast;
-use tokio_util::sync::CancellationToken;
-
-use jyc_channels::websocket::{WebsocketInboundAdapter, WebsocketOutboundAdapter};
-use jyc_core::message_storage::MessageStorage;
-use jyc_inspect::server::WebsocketHandler;
-use jyc_types::{
-    ChannelPattern, InboundAdapter, InboundAdapterOptions, InboundMessage, MessageContent,
-    OutboundAdapter,
-};
+use jyc_channels::websocket::inbound::WebsocketInboundAdapter;
+use jyc_channels::websocket::outbound::WebsocketOutboundAdapter;
+use jyc_types::{InboundAdapter, InboundAdapterOptions, InboundMessage};
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio_tungstenite::accept_async;
 
 #[tokio::test]
 async fn test_websocket_adapter_start_and_handle() {
-    let (broadcast_tx, _broadcast_rx) = broadcast::channel(16);
-    let tmp = tempfile::TempDir::new().unwrap();
-    let storage = Arc::new(MessageStorage::new(tmp.path()));
-    let outbound = WebsocketOutboundAdapter::new(broadcast_tx.clone(), storage);
+    // Create a minimal AppConfig with websocket patterns
+    let config_str = r#"
+[agent]
+mode = "agent"
+system_prompt = "test"
 
-    let patterns = vec![
-        ChannelPattern {
-            name: "general".to_string(),
-            channel: "websocket".to_string(),
-            enabled: true,
-            ..Default::default()
-        },
-        ChannelPattern {
-            name: "coding-help".to_string(),
-            channel: "websocket".to_string(),
-            enabled: true,
-            ..Default::default()
-        },
-        ChannelPattern {
-            name: "disabled".to_string(),
-            channel: "websocket".to_string(),
-            enabled: false,
-            ..Default::default()
-        },
-    ];
+[[channels.test_ws]]
+type = "websocket"
 
+[[channels.test_ws.patterns]]
+name = "general"
+enabled = true
+
+[[channels.test_ws.patterns]]
+name = "coding-help"
+enabled = true
+
+[[channels.test_ws.patterns]]
+name = "disabled"
+enabled = false
+"#;
+    let app_config: jyc_types::AppConfig = toml::from_str(config_str).unwrap();
+    let config_arc = Arc::new(ArcSwap::from_pointee(app_config));
+
+    let outbound = WebsocketOutboundAdapter::new_for_test();
     let inbound = Arc::new(WebsocketInboundAdapter::new(
-        "test-ws".to_string(),
-        patterns,
+        "test_ws".to_string(),
+        Some(config_arc),
         outbound.broadcast_tx(),
     ));
 
@@ -62,44 +55,37 @@ async fn test_websocket_adapter_start_and_handle() {
         attachment_config: None,
     };
 
-    let cancel = CancellationToken::new();
+    inbound
+        .start(options, tokio_util::sync::CancellationToken::new())
+        .await
+        .unwrap();
 
-    // Start the inbound adapter (sets the on_message callback)
-    inbound.start(options, cancel.clone()).await.unwrap();
+    // Create a client connection
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
 
-    // Bind a local TCP listener to simulate the inspect server
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let addr = listener.local_addr().unwrap();
-
-    // Spawn a task that accepts a connection and hands it to the handler
-    let handler = inbound.clone();
-    let server_handle = tokio::spawn(async move {
-        let (mut stream, client_addr) = listener.accept().await.unwrap();
-
-        // Read the first byte to detect protocol (same logic as inspect server)
-        let mut first_byte = [0u8; 1];
-        let n = tokio::io::AsyncReadExt::read(&mut stream, &mut first_byte)
-            .await
-            .unwrap();
-        assert_eq!(n, 1);
-        assert_eq!(first_byte[0], b'G');
-
-        // Prepend the byte back and perform WebSocket handshake
-        let stream = jyc_inspect::server::PrependStream::new(stream, vec![first_byte[0]]);
-        let ws_stream = tokio_tungstenite::accept_async(stream).await.unwrap();
-
-        handler.handle(ws_stream, client_addr).await.unwrap();
+    let server_task = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        let ws_stream = accept_async(stream).await.unwrap();
+        let handler = inbound.clone();
+        jyc_inspect::server::WebsocketHandler::handle(
+            &handler,
+            ws_stream,
+            "127.0.0.1:0".parse().unwrap(),
+        )
+        .await
+        .unwrap();
     });
 
-    // Give the server a moment to start
-    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-
-    // Connect test client
-    let url = format!("ws://{}/ws", addr);
-    let (ws_stream, _) = tokio_tungstenite::connect_async(&url).await.unwrap();
+    // Connect client
+    let client_url = format!("ws://127.0.0.1:{}", port);
+    let ws_stream = tokio_tungstenite::connect_async(&client_url)
+        .await
+        .unwrap()
+        .0;
     let (mut write, mut read) = ws_stream.split();
 
-    // Send list_patterns request
+    // List patterns
     let list_msg = r#"{"type":"list_patterns"}"#;
     write
         .send(tokio_tungstenite::tungstenite::Message::Text(
@@ -138,93 +124,18 @@ async fn test_websocket_adapter_start_and_handle() {
         .await
         .unwrap();
 
-    // Verify the message was routed
-    let received = tokio::time::timeout(tokio::time::Duration::from_secs(5), msg_rx.recv())
+    // Wait for the inbound message to be captured
+    let inbound_msg = tokio::time::timeout(std::time::Duration::from_secs(5), msg_rx.recv())
         .await
         .unwrap()
         .unwrap();
 
-    assert_eq!(received.channel, "test-ws");
-    assert_eq!(received.topic, "general");
-    assert_eq!(received.content.text.as_ref().unwrap(), message_text);
-    assert_eq!(received.sender, "user");
-
-    // Send a second message to a different thread to verify multi-thread routing
-    let second_text = "Hello to coding thread";
-    let second_msg = format!(
-        r#"{{"type":"message","thread":"coding","text":"{}"}}"#,
-        second_text
+    assert_eq!(inbound_msg.channel, "test_ws");
+    assert_eq!(
+        inbound_msg.thread_refs.as_ref().unwrap(),
+        &["general".to_string()]
     );
-    write
-        .send(tokio_tungstenite::tungstenite::Message::Text(second_msg))
-        .await
-        .unwrap();
+    assert_eq!(inbound_msg.content.text.unwrap(), message_text);
 
-    let received2 = tokio::time::timeout(tokio::time::Duration::from_secs(5), msg_rx.recv())
-        .await
-        .unwrap()
-        .unwrap();
-
-    assert_eq!(received2.channel, "test-ws");
-    assert_eq!(received2.topic, "coding");
-    assert_eq!(received2.content.text.as_ref().unwrap(), second_text);
-    assert_eq!(received2.sender, "user");
-
-    // Close connection
-    let _ = write
-        .send(tokio_tungstenite::tungstenite::Message::Close(None))
-        .await;
-
-    // Wait for server to shut down
-    let _ = tokio::time::timeout(tokio::time::Duration::from_secs(5), server_handle).await;
-}
-
-#[tokio::test]
-async fn test_websocket_broadcast_reply() {
-    let (broadcast_tx, mut broadcast_rx) = broadcast::channel(16);
-    let tmp = tempfile::TempDir::new().unwrap();
-    let storage = Arc::new(MessageStorage::new(tmp.path()));
-    let outbound = WebsocketOutboundAdapter::new(broadcast_tx, storage);
-
-    let message = InboundMessage {
-        id: "test".to_string(),
-        channel: "websocket".to_string(),
-        channel_uid: "user".to_string(),
-        sender: "user".to_string(),
-        sender_address: "user".to_string(),
-        recipients: vec![],
-        topic: "general".to_string(),
-        content: MessageContent {
-            text: Some("hello".to_string()),
-            html: None,
-            markdown: None,
-        },
-        timestamp: chrono::Utc::now(),
-        thread_refs: None,
-        reply_to_id: None,
-        external_id: None,
-        attachments: vec![],
-        metadata: HashMap::new(),
-        matched_pattern: None,
-    };
-
-    // Send reply should broadcast
-    // Use a thread path whose last component is "general" — this is what
-    // the broadcast key is derived from (not the message topic).
-    let result = outbound
-        .send_reply(
-            &message,
-            "AI reply",
-            std::path::Path::new("/tmp/general"),
-            "msg_001",
-            None,
-        )
-        .await;
-    assert!(result.is_ok());
-
-    let sent = broadcast_rx.recv().await.expect("should receive broadcast");
-    let parsed: serde_json::Value = serde_json::from_str(&sent).unwrap();
-    assert_eq!(parsed["type"], "reply");
-    assert_eq!(parsed["thread"], "general");
-    assert_eq!(parsed["text"], "AI reply");
+    server_task.abort();
 }

--- a/crates/jyc-channels/tests/websocket_integration_test.rs
+++ b/crates/jyc-channels/tests/websocket_integration_test.rs
@@ -1,39 +1,102 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use arc_swap::ArcSwap;
 use futures_util::{SinkExt, StreamExt};
 use jyc_channels::websocket::inbound::WebsocketInboundAdapter;
 use jyc_channels::websocket::outbound::WebsocketOutboundAdapter;
+use jyc_core::message_storage::MessageStorage;
+use jyc_inspect::server::WebsocketHandler;
 use jyc_types::{InboundAdapter, InboundAdapterOptions, InboundMessage};
-use std::sync::Arc;
+use tokio::io::AsyncReadExt;
 use tokio::net::TcpListener;
-use tokio_tungstenite::accept_async;
+use tokio::sync::broadcast;
+use tokio_util::sync::CancellationToken;
+
+fn make_config() -> jyc_types::AppConfig {
+    let patterns = vec![
+        jyc_types::ChannelPattern {
+            name: "general".to_string(),
+            enabled: true,
+            rules: jyc_types::PatternRules::default(),
+            ..Default::default()
+        },
+        jyc_types::ChannelPattern {
+            name: "coding-help".to_string(),
+            enabled: true,
+            rules: jyc_types::PatternRules::default(),
+            ..Default::default()
+        },
+        jyc_types::ChannelPattern {
+            name: "disabled".to_string(),
+            enabled: false,
+            rules: jyc_types::PatternRules::default(),
+            ..Default::default()
+        },
+    ];
+
+    let mut channels = HashMap::new();
+    channels.insert(
+        "test_ws".to_string(),
+        jyc_types::ChannelConfig {
+            channel_type: "websocket".to_string(),
+            inbound: None,
+            outbound: None,
+            feishu: None,
+            gitee: None,
+            github: None,
+            wechat: None,
+            wecom: None,
+            wecom_kf: None,
+            wecom_bot: None,
+            monitor: None,
+            patterns: Some(patterns),
+            agent: None,
+            model: None,
+            small_model: None,
+            footer: None,
+            skills: None,
+            disabled_skills: None,
+            disabled_tools: None,
+            disabled_mcp_servers: None,
+            mcps: None,
+        },
+    );
+
+    jyc_types::AppConfig {
+        general: jyc_types::GeneralConfig::default(),
+        channels,
+        agent: jyc_types::AgentConfig {
+            enabled: false,
+            mode: "static".to_string(),
+            model: None,
+            plan_model: None,
+            build_model: None,
+            small_model: None,
+            system_prompt: None,
+            max_iterations: 200,
+            text: None,
+            attachments: None,
+            providers: HashMap::new(),
+            vision: None,
+        },
+        inspect: None,
+        attachments: None,
+        wecom: None,
+        mcps: Vec::new(),
+        scheduler: jyc_types::SchedulerConfig::default(),
+    }
+}
 
 #[tokio::test]
 async fn test_websocket_adapter_start_and_handle() {
-    // Create a minimal AppConfig with websocket patterns
-    let config_str = r#"
-[agent]
-mode = "agent"
-system_prompt = "test"
-
-[[channels.test_ws]]
-type = "websocket"
-
-[[channels.test_ws.patterns]]
-name = "general"
-enabled = true
-
-[[channels.test_ws.patterns]]
-name = "coding-help"
-enabled = true
-
-[[channels.test_ws.patterns]]
-name = "disabled"
-enabled = false
-"#;
-    let app_config: jyc_types::AppConfig = toml::from_str(config_str).unwrap();
+    let app_config = make_config();
     let config_arc = Arc::new(ArcSwap::from_pointee(app_config));
 
-    let outbound = WebsocketOutboundAdapter::new_for_test();
+    let (broadcast_tx, _broadcast_rx) = broadcast::channel(16);
+    let tmp = tempfile::TempDir::new().unwrap();
+    let storage = Arc::new(MessageStorage::new(tmp.path()));
+    let outbound = WebsocketOutboundAdapter::new(broadcast_tx, storage);
     let inbound = Arc::new(WebsocketInboundAdapter::new(
         "test_ws".to_string(),
         Some(config_arc),
@@ -56,33 +119,33 @@ enabled = false
     };
 
     inbound
-        .start(options, tokio_util::sync::CancellationToken::new())
+        .start(options, CancellationToken::new())
         .await
         .unwrap();
 
-    // Create a client connection
+    // Bind a local TCP listener to simulate the inspect server
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let port = listener.local_addr().unwrap().port();
+    let addr = listener.local_addr().unwrap();
 
-    let server_task = tokio::spawn(async move {
-        let (stream, _) = listener.accept().await.unwrap();
-        let ws_stream = accept_async(stream).await.unwrap();
-        let handler = inbound.clone();
-        jyc_inspect::server::WebsocketHandler::handle(
-            &handler,
-            ws_stream,
-            "127.0.0.1:0".parse().unwrap(),
-        )
-        .await
-        .unwrap();
+    let server_handle = tokio::spawn(async move {
+        let (mut stream, client_addr) = listener.accept().await.unwrap();
+
+        // Read the first byte to detect protocol (same logic as inspect server)
+        let mut first_byte = [0u8; 1];
+        let n = stream.read_exact(&mut first_byte).await.unwrap();
+        assert_eq!(n, 1);
+        assert_eq!(first_byte[0], b'G');
+
+        // Prepend the byte back and perform WebSocket handshake
+        let stream = jyc_inspect::server::PrependStream::new(stream, vec![first_byte[0]]);
+        let ws_stream = tokio_tungstenite::accept_async(stream).await.unwrap();
+
+        inbound.handle(ws_stream, client_addr).await.unwrap();
     });
 
-    // Connect client
-    let client_url = format!("ws://127.0.0.1:{}", port);
-    let ws_stream = tokio_tungstenite::connect_async(&client_url)
-        .await
-        .unwrap()
-        .0;
+    // Connect test client
+    let url = format!("ws://{}/ws", addr);
+    let ws_stream = tokio_tungstenite::connect_async(&url).await.unwrap().0;
     let (mut write, mut read) = ws_stream.split();
 
     // List patterns
@@ -131,11 +194,14 @@ enabled = false
         .unwrap();
 
     assert_eq!(inbound_msg.channel, "test_ws");
-    assert_eq!(
-        inbound_msg.thread_refs.as_ref().unwrap(),
-        &["general".to_string()]
-    );
+    assert_eq!(inbound_msg.topic, "general");
     assert_eq!(inbound_msg.content.text.unwrap(), message_text);
 
-    server_task.abort();
+    // Close connection
+    let _ = write
+        .send(tokio_tungstenite::tungstenite::Message::Close(None))
+        .await;
+
+    // Wait for server to shut down
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), server_handle).await;
 }

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -116,15 +116,19 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
 
     // 4. Process each configured channel
     let mut tasks = Vec::new();
-    let mut all_thread_managers: Vec<Arc<ThreadManager>> = Vec::new();
-    let mut all_channels: Vec<jyc_types::ChannelInfo> = Vec::new();
-    let mut all_workspace_dirs: Vec<std::path::PathBuf> = Vec::new();
     // Collect JycAgentService instances for wiring cross-channel thread managers
     let mut all_agent_services: Vec<Arc<JycAgentService>> = Vec::new();
     // Collect outbound adapters keyed by channel name for cross-channel messaging
     let mut all_outbounds: Vec<(String, Arc<dyn OutboundAdapter>)> = Vec::new();
+
+    let orchestrator = Arc::new(jyc_core::channel_orchestrator::ChannelOrchestrator::new(
+        config.clone(),
+        workdir,
+    ));
+
     let config_snapshot = config.load();
     let agent_config = Arc::new(config_snapshot.agent.clone());
+    let config_for_spawn = Arc::clone(&config);
 
     // Initialize shared WeCom webhook server (if any wecom or wecomkf channel is configured)
     let has_wecom = config_snapshot
@@ -330,7 +334,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                 // Store the inbound adapter for later registration with the inspect server
                 let mut handler = WebsocketInboundAdapter::new(
                     channel_name.to_string(),
-                    patterns.clone(),
+                    Some(config.clone()),
                     broadcast_tx,
                 );
                 handler.set_workspace_dir(workspace_dir.clone());
@@ -393,14 +397,12 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
         ));
 
         // Collect for inspect server
-        all_thread_managers.push(thread_manager.clone());
-        all_channels.push(jyc_types::ChannelInfo {
+        let channel_info = jyc_types::ChannelInfo {
             name: channel_name.clone(),
             channel_type: channel_type.to_string(),
             active_workers: 0,
             max_concurrent: 0,
-        });
-        all_workspace_dirs.push(workspace_dir);
+        };
 
         let router = Arc::new(MessageRouter::new(
             thread_manager.clone(),
@@ -479,6 +481,21 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     .instrument(channel_span),
                 );
 
+                orchestrator
+                    .register_channel(
+                        channel_name.to_string(),
+                        jyc_core::channel_orchestrator::ChannelHandle {
+                            cancel: cancel.clone(),
+
+                            thread_manager: thread_manager.clone(),
+
+                            channel_info: channel_info.clone(),
+
+                            workspace_dir: workspace_dir.clone(),
+                        },
+                    )
+                    .await;
+
                 tasks.push(task);
             }
             "feishu" => {
@@ -492,6 +509,8 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
 
                 let router_for_callback = router.clone();
 
+                let thread_manager_for_task = thread_manager.clone();
+
                 let task = tokio::spawn(async move {
                     // Clone configs before moving into closures
                     let feishu_config_cloned = feishu_config.clone();
@@ -502,7 +521,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
 
                     use jyc_types::InboundAdapter;
 
-                    let thread_manager_clone = thread_manager.clone();
+                    let thread_manager_clone = thread_manager_for_task.clone();
                     let options = jyc_types::InboundAdapterOptions {
                         on_message: Box::new(move |message| {
                             let router = router_for_callback.clone();
@@ -540,6 +559,21 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     tm.shutdown().await;
                 }.instrument(channel_span));
 
+                orchestrator
+                    .register_channel(
+                        channel_name.to_string(),
+                        jyc_core::channel_orchestrator::ChannelHandle {
+                            cancel: cancel.clone(),
+
+                            thread_manager: thread_manager.clone(),
+
+                            channel_info: channel_info.clone(),
+
+                            workspace_dir: workspace_dir.clone(),
+                        },
+                    )
+                    .await;
+
                 tasks.push(task);
             }
             "gitee" => {
@@ -551,18 +585,18 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     })?
                     .clone();
 
-                let patterns_for_adapter = patterns.clone();
                 let router_for_callback = router.clone();
                 let workdir_owned = workdir.to_path_buf();
+
+                let thread_manager_for_task = thread_manager.clone();
 
                 let task = tokio::spawn(async move {
                     use jyc_channels::gitee::inbound::GiteeInboundAdapter;
                     use jyc_types::InboundAdapter;
 
-                    let adapter = GiteeInboundAdapter::new(&gitee_config, channel_name_owned.clone(), &workdir_owned)
-                        .with_patterns(patterns_for_adapter);
+                    let adapter = GiteeInboundAdapter::new(&gitee_config, channel_name_owned.clone(), &workdir_owned);
 
-                    let thread_manager_clone = thread_manager.clone();
+                    let thread_manager_clone = thread_manager_for_task.clone();
                     let options = jyc_types::InboundAdapterOptions {
                         on_message: Box::new(move |message| {
                             let router = router_for_callback.clone();
@@ -595,6 +629,21 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     tm.shutdown().await;
                 }.instrument(channel_span));
 
+                orchestrator
+                    .register_channel(
+                        channel_name.to_string(),
+                        jyc_core::channel_orchestrator::ChannelHandle {
+                            cancel: cancel.clone(),
+
+                            thread_manager: thread_manager.clone(),
+
+                            channel_info: channel_info.clone(),
+
+                            workspace_dir: workspace_dir.clone(),
+                        },
+                    )
+                    .await;
+
                 tasks.push(task);
             }
             "github" => {
@@ -606,18 +655,19 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     })?
                     .clone();
 
-                let patterns_for_adapter = patterns.clone();
+                let config_for_adapter = config_for_spawn.clone();
                 let router_for_callback = router.clone();
                 let workdir_owned = workdir.to_path_buf();
+
+                let thread_manager_for_task = thread_manager.clone();
 
                 let task = tokio::spawn(async move {
                     use jyc_channels::github::inbound::GithubInboundAdapter;
                     use jyc_types::InboundAdapter;
 
-                    let adapter = GithubInboundAdapter::new(&github_config, channel_name_owned.clone(), &workdir_owned)
-                        .with_patterns(patterns_for_adapter);
+                    let adapter = GithubInboundAdapter::new(&github_config, channel_name_owned.clone(), &workdir_owned, Some(config_for_adapter));
 
-                    let thread_manager_clone = thread_manager.clone();
+                    let thread_manager_clone = thread_manager_for_task.clone();
                     let options = jyc_types::InboundAdapterOptions {
                         on_message: Box::new(move |message| {
                             let router = router_for_callback.clone();
@@ -654,6 +704,21 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     tm.shutdown().await;
                 }.instrument(channel_span));
 
+                orchestrator
+                    .register_channel(
+                        channel_name.to_string(),
+                        jyc_core::channel_orchestrator::ChannelHandle {
+                            cancel: cancel.clone(),
+
+                            thread_manager: thread_manager.clone(),
+
+                            channel_info: channel_info.clone(),
+
+                            workspace_dir: workspace_dir.clone(),
+                        },
+                    )
+                    .await;
+
                 tasks.push(task);
             }
             "wechat" => {
@@ -668,6 +733,8 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                 let router_for_callback = router.clone();
                 let wechat_sender_arc_clone = wechat_sender_arc.clone().unwrap();
 
+                let thread_manager_for_task = thread_manager.clone();
+
                 let task = tokio::spawn(async move {
                     use jyc_types::InboundAdapter;
                     use jyc_channels::wechat::inbound::WechatMatcher;
@@ -680,7 +747,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                         wechat_sender_arc_clone,
                     );
 
-                    let thread_manager_clone = thread_manager.clone();
+                    let thread_manager_clone = thread_manager_for_task.clone();
                     let options = jyc_types::InboundAdapterOptions {
                         on_message: Box::new(move |message| {
                             let router = router_for_callback.clone();
@@ -717,6 +784,21 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     tm.shutdown().await;
                 }.instrument(channel_span));
 
+                orchestrator
+                    .register_channel(
+                        channel_name.to_string(),
+                        jyc_core::channel_orchestrator::ChannelHandle {
+                            cancel: cancel.clone(),
+
+                            thread_manager: thread_manager.clone(),
+
+                            channel_info: channel_info.clone(),
+
+                            workspace_dir: workspace_dir.clone(),
+                        },
+                    )
+                    .await;
+
                 tasks.push(task);
             }
             "wecom_bot" => {
@@ -731,6 +813,8 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                 let router_for_callback = router.clone();
                 let wecom_bot_handle_arc_clone = wecom_bot_handle_arc.clone().unwrap();
 
+                let thread_manager_for_task = thread_manager.clone();
+
                 let task = tokio::spawn(async move {
                     use jyc_types::InboundAdapter;
 
@@ -740,7 +824,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                         wecom_bot_handle_arc_clone,
                     );
 
-                    let thread_manager_clone = thread_manager.clone();
+                    let thread_manager_clone = thread_manager_for_task.clone();
                     let options = jyc_types::InboundAdapterOptions {
                         on_message: Box::new(move |message| {
                             let router = router_for_callback.clone();
@@ -776,6 +860,21 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     tm.shutdown().await;
                 }.instrument(channel_span));
 
+                orchestrator
+                    .register_channel(
+                        channel_name.to_string(),
+                        jyc_core::channel_orchestrator::ChannelHandle {
+                            cancel: cancel.clone(),
+
+                            thread_manager: thread_manager.clone(),
+
+                            channel_info: channel_info.clone(),
+
+                            workspace_dir: workspace_dir.clone(),
+                        },
+                    )
+                    .await;
+
                 tasks.push(task);
             }
             "wecom" => {
@@ -793,6 +892,8 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                 let router_for_callback = router.clone();
                 let channel_name_owned = channel_name.clone();
 
+                let thread_manager_for_task = thread_manager.clone();
+
                 let task = tokio::spawn(async move {
                     use jyc_types::InboundAdapter;
                     use jyc_channels::wecom::inbound::WecomMatcher;
@@ -803,7 +904,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                         wecom_server,
                     );
 
-                    let thread_manager_clone = thread_manager.clone();
+                    let thread_manager_clone = thread_manager_for_task.clone();
                     let options = jyc_types::InboundAdapterOptions {
                         on_message: Box::new(move |message| {
                             let router = router_for_callback.clone();
@@ -840,6 +941,21 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     tm.shutdown().await;
                 }.instrument(channel_span));
 
+                orchestrator
+                    .register_channel(
+                        channel_name.to_string(),
+                        jyc_core::channel_orchestrator::ChannelHandle {
+                            cancel: cancel.clone(),
+
+                            thread_manager: thread_manager.clone(),
+
+                            channel_info: channel_info.clone(),
+
+                            workspace_dir: workspace_dir.clone(),
+                        },
+                    )
+                    .await;
+
                 tasks.push(task);
             }
             "wecomkf" => {
@@ -869,6 +985,8 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                 ));
                 let dedup_store = Arc::new(KfDedupStore::new());
 
+                let thread_manager_for_task = thread_manager.clone();
+
                 let task = tokio::spawn(async move {
                     use jyc_types::InboundAdapter;
 
@@ -881,7 +999,7 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                         dedup_store,
                     );
 
-                    let thread_manager_clone = thread_manager.clone();
+                    let thread_manager_clone = thread_manager_for_task.clone();
                     let options = jyc_types::InboundAdapterOptions {
                         on_message: Box::new(move |message| {
                             let router = router_for_callback.clone();
@@ -917,6 +1035,21 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     // Shutdown thread manager for this channel
                     tm.shutdown().await;
                 }.instrument(channel_span));
+
+                orchestrator
+                    .register_channel(
+                        channel_name.to_string(),
+                        jyc_core::channel_orchestrator::ChannelHandle {
+                            cancel: cancel.clone(),
+
+                            thread_manager: thread_manager.clone(),
+
+                            channel_info: channel_info.clone(),
+
+                            workspace_dir: workspace_dir.clone(),
+                        },
+                    )
+                    .await;
 
                 tasks.push(task);
             }
@@ -978,6 +1111,21 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     .instrument(channel_span),
                 );
 
+                orchestrator
+                    .register_channel(
+                        channel_name.to_string(),
+                        jyc_core::channel_orchestrator::ChannelHandle {
+                            cancel: cancel.clone(),
+
+                            thread_manager: thread_manager.clone(),
+
+                            channel_info: channel_info.clone(),
+
+                            workspace_dir: workspace_dir.clone(),
+                        },
+                    )
+                    .await;
+
                 tasks.push(task);
             }
             _ => continue, // Gracefully skip unknown channel types
@@ -990,7 +1138,8 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
 
     // 4.5. Wire cross-channel thread managers and outbound adapters into agent services
     {
-        let tm_map: HashMap<String, Arc<ThreadManager>> = all_thread_managers
+        let tms = orchestrator.thread_managers().load();
+        let tm_map: HashMap<String, Arc<ThreadManager>> = tms
             .iter()
             .map(|tm| (tm.channel_name().to_string(), tm.clone()))
             .collect();
@@ -1018,9 +1167,11 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
         // Start JobScheduler (if scheduler is enabled in config)
         let scheduler_config = config_snapshot.scheduler.clone();
         if scheduler_config.enabled {
+            let workspace_dirs = orchestrator.workspace_dirs().load();
+            let workspace_dirs: Vec<std::path::PathBuf> = workspace_dirs.iter().cloned().collect();
             let scheduler = JobScheduler::new(
                 tm_map,
-                all_workspace_dirs.clone(),
+                workspace_dirs,
                 scheduler_config.scan_interval_secs,
                 scheduler_config.max_jobs_per_thread,
                 true,
@@ -1042,14 +1193,14 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
             Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
 
         let context = Arc::new(jyc_inspect::server::InspectContext {
-            thread_managers: all_thread_managers.clone(),
-            channels: all_channels,
+            thread_managers: orchestrator.thread_managers(),
+            channels: orchestrator.channel_infos(),
             health_stats: shared_stats,
             activity_map: activity_map.clone(),
             start_time: std::time::Instant::now(),
             config_path: Some(config_path.clone()),
-            config: Some(config.clone()),
-            workspace_dirs: all_workspace_dirs.clone(),
+            config: Some(Arc::clone(&config)),
+            workspace_dirs: orchestrator.workspace_dirs(),
             websocket_handlers: {
                 let handlers: HashMap<String, Arc<dyn jyc_inspect::server::WebsocketHandler>> =
                     websocket_handlers
@@ -1067,13 +1218,24 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     Some(handlers)
                 }
             },
+            reload_callback: {
+                let orch = orchestrator.clone();
+                Some(Arc::new(move || {
+                    let orch = orch.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = orch.reload().await {
+                            tracing::error!(error = %e, "ChannelOrchestrator reload failed");
+                        }
+                    });
+                }) as Arc<dyn Fn() + Send + Sync>)
+            },
         });
 
         // Start activity tracker (subscribes to thread event buses)
         let _activity_task = jyc_inspect::server::ActivityTracker::start(
-            all_thread_managers,
+            context.thread_managers.clone(),
             activity_map,
-            all_workspace_dirs,
+            context.workspace_dirs.clone(),
             cancel.clone(),
         );
 

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -402,7 +402,12 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
         });
         all_workspace_dirs.push(workspace_dir);
 
-        let router = Arc::new(MessageRouter::new(thread_manager.clone(), storage.clone()));
+        let router = Arc::new(MessageRouter::new(
+            thread_manager.clone(),
+            storage.clone(),
+            config.clone(),
+            channel_name.clone(),
+        ));
 
         let mut state_manager = StateManager::for_channel(workdir, channel_name);
         state_manager.initialize().await?;
@@ -455,7 +460,6 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                             channel_name_owned.clone(),
                             inbound_config,
                             monitor_config,
-                            patterns,
                             router,
                             state_manager,
                             cancel_child,
@@ -486,7 +490,6 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     })?
                     .clone();
 
-                let patterns_for_callback = patterns.clone();
                 let router_for_callback = router.clone();
 
                 let task = tokio::spawn(async move {
@@ -503,12 +506,11 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     let options = jyc_types::InboundAdapterOptions {
                         on_message: Box::new(move |message| {
                             let router = router_for_callback.clone();
-                            let patterns = patterns_for_callback.clone();
                             tokio::spawn(async move {
                                 // Attachments are saved inside process_message()
                                 // after template initialization, so there's no
                                 // need for a pre-route save here.
-                                router.route(&FeishuMatcher, message, &patterns).await;
+                                router.route(&FeishuMatcher, message).await;
                             });
                             Ok(())
                         }),
@@ -549,7 +551,6 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     })?
                     .clone();
 
-                let patterns_for_callback = patterns.clone();
                 let patterns_for_adapter = patterns.clone();
                 let router_for_callback = router.clone();
                 let workdir_owned = workdir.to_path_buf();
@@ -565,10 +566,9 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     let options = jyc_types::InboundAdapterOptions {
                         on_message: Box::new(move |message| {
                             let router = router_for_callback.clone();
-                            let patterns = patterns_for_callback.clone();
 
                             tokio::spawn(async move {
-                                router.route(&GiteeMatcher, message, &patterns).await;
+                                router.route(&GiteeMatcher, message).await;
                             });
 
                             Ok(())
@@ -606,7 +606,6 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     })?
                     .clone();
 
-                let patterns_for_callback = patterns.clone();
                 let patterns_for_adapter = patterns.clone();
                 let router_for_callback = router.clone();
                 let workdir_owned = workdir.to_path_buf();
@@ -622,10 +621,9 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     let options = jyc_types::InboundAdapterOptions {
                         on_message: Box::new(move |message| {
                             let router = router_for_callback.clone();
-                            let patterns = patterns_for_callback.clone();
 
                             tokio::spawn(async move {
-                                router.route(&GithubMatcher, message, &patterns).await;
+                                router.route(&GithubMatcher, message).await;
                             });
 
                             Ok(())
@@ -667,7 +665,6 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     })?
                     .clone();
 
-                let patterns_for_callback = patterns.clone();
                 let router_for_callback = router.clone();
                 let wechat_sender_arc_clone = wechat_sender_arc.clone().unwrap();
 
@@ -687,10 +684,9 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     let options = jyc_types::InboundAdapterOptions {
                         on_message: Box::new(move |message| {
                             let router = router_for_callback.clone();
-                            let patterns = patterns_for_callback.clone();
 
                             tokio::spawn(async move {
-                                router.route(&WechatMatcher, message, &patterns).await;
+                                router.route(&WechatMatcher, message).await;
                             });
 
                             Ok(())
@@ -732,7 +728,6 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     })?
                     .clone();
 
-                let patterns_for_callback = patterns.clone();
                 let router_for_callback = router.clone();
                 let wecom_bot_handle_arc_clone = wecom_bot_handle_arc.clone().unwrap();
 
@@ -749,10 +744,9 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     let options = jyc_types::InboundAdapterOptions {
                         on_message: Box::new(move |message| {
                             let router = router_for_callback.clone();
-                            let patterns = patterns_for_callback.clone();
 
                             tokio::spawn(async move {
-                                router.route(&WecomBotMatcher, message, &patterns).await;
+                                router.route(&WecomBotMatcher, message).await;
                             });
 
                             Ok(())
@@ -796,7 +790,6 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                 let wecom_server = wecom_server
                     .clone()
                     .ok_or_else(|| anyhow::anyhow!("WeCom webhook server not initialized"))?;
-                let patterns_for_callback = patterns.clone();
                 let router_for_callback = router.clone();
                 let channel_name_owned = channel_name.clone();
 
@@ -814,10 +807,9 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     let options = jyc_types::InboundAdapterOptions {
                         on_message: Box::new(move |message| {
                             let router = router_for_callback.clone();
-                            let patterns = patterns_for_callback.clone();
 
                             tokio::spawn(async move {
-                                router.route(&WecomMatcher, message, &patterns).await;
+                                router.route(&WecomMatcher, message).await;
                             });
 
                             Ok(())
@@ -862,7 +854,6 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                 let wecom_server = wecom_server
                     .clone()
                     .ok_or_else(|| anyhow::anyhow!("WeCom webhook server not initialized"))?;
-                let patterns_for_callback = patterns.clone();
                 let router_for_callback = router.clone();
                 let channel_name_owned = channel_name.clone();
 
@@ -894,10 +885,9 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                     let options = jyc_types::InboundAdapterOptions {
                         on_message: Box::new(move |message| {
                             let router = router_for_callback.clone();
-                            let patterns = patterns_for_callback.clone();
 
                             tokio::spawn(async move {
-                                router.route(&WecomKfMatcher, message, &patterns).await;
+                                router.route(&WecomKfMatcher, message).await;
                             });
 
                             Ok(())
@@ -931,7 +921,6 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                 tasks.push(task);
             }
             "websocket" => {
-                let patterns_for_callback = patterns.clone();
                 let router_for_callback = router.clone();
                 let channel_name_for_matcher = channel_name_owned.clone();
 
@@ -945,12 +934,11 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                 let options = jyc_types::InboundAdapterOptions {
                     on_message: Box::new(move |message| {
                         let router = router_for_callback.clone();
-                        let patterns = patterns_for_callback.clone();
                         let channel_name = channel_name_for_matcher.clone();
 
                         tokio::spawn(async move {
                             router
-                                .route(&WebsocketMatcher::new(channel_name), message, &patterns)
+                                .route(&WebsocketMatcher::new(channel_name), message)
                                 .await;
                         });
 

--- a/crates/jyc-cli/src/cli/monitor.rs
+++ b/crates/jyc-cli/src/cli/monitor.rs
@@ -1,7 +1,9 @@
 use anyhow::{Context, Result};
 use arc_swap::ArcSwap;
 use clap::Args;
+use std::future::Future;
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
@@ -1222,12 +1224,10 @@ pub async fn run(args: &MonitorArgs, workdir: &Path) -> Result<()> {
                 let orch = orchestrator.clone();
                 Some(Arc::new(move || {
                     let orch = orch.clone();
-                    tokio::spawn(async move {
-                        if let Err(e) = orch.reload().await {
-                            tracing::error!(error = %e, "ChannelOrchestrator reload failed");
-                        }
-                    });
-                }) as Arc<dyn Fn() + Send + Sync>)
+                    let fut: Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>> =
+                        Box::pin(async move { orch.reload().await });
+                    fut
+                }) as jyc_inspect::server::ReloadCallback)
             },
         });
 

--- a/crates/jyc-core/src/channel_orchestrator.rs
+++ b/crates/jyc-core/src/channel_orchestrator.rs
@@ -14,40 +14,36 @@ use crate::thread_manager::ThreadManager;
 /// Handle for a running channel, used by the orchestrator to manage lifecycle.
 pub struct ChannelHandle {
     pub cancel: CancellationToken,
-    pub task: tokio::task::JoinHandle<()>,
     pub thread_manager: Arc<ThreadManager>,
     pub channel_info: ChannelInfo,
     pub workspace_dir: std::path::PathBuf,
 }
 
-/// Manages the lifecycle of all channels (spawn, stop, reload).
+/// Manages the lifecycle of all channels and shared state updates.
 ///
 /// When `reload()` is called, it diffs the new config against the running
 /// channels and performs the minimal set of operations:
-/// - **new channel** → `spawn_channel()`
 /// - **removed channel** → cancel token, wait for task exit, cleanup
+/// - **new channel** → logs warning that restart is required (full spawn
+///   requires restart of the monitor process)
 /// - **existing channel** → patterns are read dynamically by `MessageRouter`,
-///   no restart needed for pattern-only changes. Connection parameter changes
-///   (host, port, credentials) require restart — detected by comparing the
-///   channel config hash.
+///   no restart needed for pattern-only changes.
 pub struct ChannelOrchestrator {
     channels: Mutex<HashMap<String, ChannelHandle>>,
     config: Arc<ArcSwap<AppConfig>>,
     thread_managers: Arc<ArcSwap<Vec<Arc<ThreadManager>>>>,
     channel_infos: Arc<ArcSwap<Vec<ChannelInfo>>>,
     workspace_dirs: Arc<ArcSwap<Vec<std::path::PathBuf>>>,
-    workdir: std::path::PathBuf,
 }
 
 impl ChannelOrchestrator {
-    pub fn new(config: Arc<ArcSwap<AppConfig>>, workdir: &Path) -> Self {
+    pub fn new(config: Arc<ArcSwap<AppConfig>>, _workdir: &Path) -> Self {
         Self {
             channels: Mutex::new(HashMap::new()),
             config,
             thread_managers: Arc::new(ArcSwap::from_pointee(Vec::new())),
             channel_infos: Arc::new(ArcSwap::from_pointee(Vec::new())),
             workspace_dirs: Arc::new(ArcSwap::from_pointee(Vec::new())),
-            workdir: workdir.to_path_buf(),
         }
     }
 
@@ -66,16 +62,12 @@ impl ChannelOrchestrator {
         self.workspace_dirs.clone()
     }
 
-    /// Start all channels from the current config.
-    pub async fn start_all(&self) -> anyhow::Result<()> {
-        let cfg = self.config.load();
-        for (name, channel_config) in &cfg.channels {
-            if let Err(e) = self.spawn_channel(name, channel_config).await {
-                tracing::error!(channel = %name, error = %e, "Failed to spawn channel");
-            }
-        }
+    /// Register a running channel with the orchestrator.
+    pub async fn register_channel(&self, name: String, handle: ChannelHandle) {
+        let mut channels = self.channels.lock().await;
+        channels.insert(name, handle);
+        drop(channels);
         self.update_shared_state().await;
-        Ok(())
     }
 
     /// Reload: diff current config against running channels and apply changes.
@@ -86,51 +78,34 @@ impl ChannelOrchestrator {
         let old_names: std::collections::HashSet<String> = channels.keys().cloned().collect();
         let new_names: std::collections::HashSet<String> = cfg.channels.keys().cloned().collect();
 
-        // Stop removed channels
+        // Stop removed channels: cancel the per-channel token, then give workers
+        // up to 5s to exit gracefully (via the cancel token). The inbound task
+        // should shut down its adapter and call ThreadManager::shutdown().
         for name in old_names.difference(&new_names) {
             if let Some(handle) = channels.remove(name) {
                 tracing::info!(channel = %name, "Stopping channel (removed from config)");
                 handle.cancel.cancel();
-                // Wait briefly for graceful shutdown
-                let _ = tokio::time::timeout(
-                    std::time::Duration::from_secs(5),
-                    handle.task,
-                )
-                .await;
+                // Allow time for the task to see the cancellation and shut down.
+                // The task is responsible for cleaning up (adapter disconnect,
+                // ThreadManager shutdown, etc.) after the token fires.
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
             }
         }
 
-        // Start new channels
+        // New channels require restart
         for name in new_names.difference(&old_names) {
-            if let Some(channel_config) = cfg.channels.get(name) {
-                tracing::info!(channel = %name, "Starting new channel");
-                drop(channels); // release lock before await
-                if let Err(e) = self.spawn_channel(name, channel_config).await {
-                    tracing::error!(channel = %name, error = %e, "Failed to spawn new channel");
-                }
-                channels = self.channels.lock().await;
-            }
+            tracing::warn!(
+                channel = %name,
+                "New channel detected after reload — restart jyc monitor to activate"
+            );
         }
 
         // For existing channels, patterns are read dynamically by MessageRouter.
-        // Connection parameter changes require restart — not handled in this step
+        // Connection parameter changes require restart — not handled here
         // (they are treated as a separate concern and require a full stop+spawn).
 
         drop(channels);
         self.update_shared_state().await;
-        Ok(())
-    }
-
-    /// Spawn a single channel. This is a placeholder — the full implementation
-    /// extracts the per-channel spawn logic from `monitor.rs::run()`.
-    async fn spawn_channel(
-        &self,
-        _name: &str,
-        _channel_config: &jyc_types::ChannelConfig,
-    ) -> anyhow::Result<()> {
-        let _workdir = &self.workdir;
-        // TODO: extract per-channel spawn logic from monitor.rs
-        // This will be filled in during Step 2 integration.
         Ok(())
     }
 
@@ -141,14 +116,9 @@ impl ChannelOrchestrator {
             .values()
             .map(|h| h.thread_manager.clone())
             .collect();
-        let infos: Vec<ChannelInfo> = channels
-            .values()
-            .map(|h| h.channel_info.clone())
-            .collect();
-        let dirs: Vec<std::path::PathBuf> = channels
-            .values()
-            .map(|h| h.workspace_dir.clone())
-            .collect();
+        let infos: Vec<ChannelInfo> = channels.values().map(|h| h.channel_info.clone()).collect();
+        let dirs: Vec<std::path::PathBuf> =
+            channels.values().map(|h| h.workspace_dir.clone()).collect();
         drop(channels);
 
         self.thread_managers.store(Arc::new(tms));
@@ -165,20 +135,22 @@ impl ChannelOrchestrator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
     use tempfile::TempDir;
 
     fn test_config() -> Arc<ArcSwap<AppConfig>> {
-        let config = AppConfig {
-            general: jyc_types::GeneralConfig::default(),
-            channels: HashMap::new(),
-            agent: jyc_types::AgentConfig::default(),
-            inspect: None,
-            attachments: None,
-            wecom: None,
-            mcps: Vec::new(),
-            scheduler: jyc_types::SchedulerConfig::default(),
-        };
+        let config: AppConfig = toml::from_str(
+            r#"
+[agent]
+mode = "agent"
+system_prompt = "test"
+
+[agent.providers.test]
+type = "openai-compatible"
+base_url = "http://test"
+api_key_env = "TEST_KEY"
+"#,
+        )
+        .unwrap();
         Arc::new(ArcSwap::from_pointee(config))
     }
 
@@ -207,5 +179,18 @@ mod tests {
 
         let infos = orch.channel_infos.load();
         assert!(infos.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_orchestrator_reload_detects_new_channels() {
+        let tmpdir = TempDir::new().unwrap();
+        let config = test_config();
+        let orch = ChannelOrchestrator::new(config.clone(), tmpdir.path());
+
+        // Reload with no changes should succeed
+        orch.reload().await.unwrap();
+
+        let tms = orch.thread_managers.load();
+        assert!(tms.is_empty());
     }
 }

--- a/crates/jyc-core/src/channel_orchestrator.rs
+++ b/crates/jyc-core/src/channel_orchestrator.rs
@@ -1,0 +1,211 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use jyc_types::AppConfig;
+use jyc_types::ChannelInfo;
+
+use crate::thread_manager::ThreadManager;
+
+/// Handle for a running channel, used by the orchestrator to manage lifecycle.
+pub struct ChannelHandle {
+    pub cancel: CancellationToken,
+    pub task: tokio::task::JoinHandle<()>,
+    pub thread_manager: Arc<ThreadManager>,
+    pub channel_info: ChannelInfo,
+    pub workspace_dir: std::path::PathBuf,
+}
+
+/// Manages the lifecycle of all channels (spawn, stop, reload).
+///
+/// When `reload()` is called, it diffs the new config against the running
+/// channels and performs the minimal set of operations:
+/// - **new channel** → `spawn_channel()`
+/// - **removed channel** → cancel token, wait for task exit, cleanup
+/// - **existing channel** → patterns are read dynamically by `MessageRouter`,
+///   no restart needed for pattern-only changes. Connection parameter changes
+///   (host, port, credentials) require restart — detected by comparing the
+///   channel config hash.
+pub struct ChannelOrchestrator {
+    channels: Mutex<HashMap<String, ChannelHandle>>,
+    config: Arc<ArcSwap<AppConfig>>,
+    thread_managers: Arc<ArcSwap<Vec<Arc<ThreadManager>>>>,
+    channel_infos: Arc<ArcSwap<Vec<ChannelInfo>>>,
+    workspace_dirs: Arc<ArcSwap<Vec<std::path::PathBuf>>>,
+    workdir: std::path::PathBuf,
+}
+
+impl ChannelOrchestrator {
+    pub fn new(config: Arc<ArcSwap<AppConfig>>, workdir: &Path) -> Self {
+        Self {
+            channels: Mutex::new(HashMap::new()),
+            config,
+            thread_managers: Arc::new(ArcSwap::from_pointee(Vec::new())),
+            channel_infos: Arc::new(ArcSwap::from_pointee(Vec::new())),
+            workspace_dirs: Arc::new(ArcSwap::from_pointee(Vec::new())),
+            workdir: workdir.to_path_buf(),
+        }
+    }
+
+    /// Shared view of thread managers for InspectContext.
+    pub fn thread_managers(&self) -> Arc<ArcSwap<Vec<Arc<ThreadManager>>>> {
+        self.thread_managers.clone()
+    }
+
+    /// Shared view of channel infos for InspectContext.
+    pub fn channel_infos(&self) -> Arc<ArcSwap<Vec<ChannelInfo>>> {
+        self.channel_infos.clone()
+    }
+
+    /// Shared view of workspace dirs for InspectContext.
+    pub fn workspace_dirs(&self) -> Arc<ArcSwap<Vec<std::path::PathBuf>>> {
+        self.workspace_dirs.clone()
+    }
+
+    /// Start all channels from the current config.
+    pub async fn start_all(&self) -> anyhow::Result<()> {
+        let cfg = self.config.load();
+        for (name, channel_config) in &cfg.channels {
+            if let Err(e) = self.spawn_channel(name, channel_config).await {
+                tracing::error!(channel = %name, error = %e, "Failed to spawn channel");
+            }
+        }
+        self.update_shared_state().await;
+        Ok(())
+    }
+
+    /// Reload: diff current config against running channels and apply changes.
+    pub async fn reload(&self) -> anyhow::Result<()> {
+        let cfg = self.config.load();
+        let mut channels = self.channels.lock().await;
+
+        let old_names: std::collections::HashSet<String> = channels.keys().cloned().collect();
+        let new_names: std::collections::HashSet<String> = cfg.channels.keys().cloned().collect();
+
+        // Stop removed channels
+        for name in old_names.difference(&new_names) {
+            if let Some(handle) = channels.remove(name) {
+                tracing::info!(channel = %name, "Stopping channel (removed from config)");
+                handle.cancel.cancel();
+                // Wait briefly for graceful shutdown
+                let _ = tokio::time::timeout(
+                    std::time::Duration::from_secs(5),
+                    handle.task,
+                )
+                .await;
+            }
+        }
+
+        // Start new channels
+        for name in new_names.difference(&old_names) {
+            if let Some(channel_config) = cfg.channels.get(name) {
+                tracing::info!(channel = %name, "Starting new channel");
+                drop(channels); // release lock before await
+                if let Err(e) = self.spawn_channel(name, channel_config).await {
+                    tracing::error!(channel = %name, error = %e, "Failed to spawn new channel");
+                }
+                channels = self.channels.lock().await;
+            }
+        }
+
+        // For existing channels, patterns are read dynamically by MessageRouter.
+        // Connection parameter changes require restart — not handled in this step
+        // (they are treated as a separate concern and require a full stop+spawn).
+
+        drop(channels);
+        self.update_shared_state().await;
+        Ok(())
+    }
+
+    /// Spawn a single channel. This is a placeholder — the full implementation
+    /// extracts the per-channel spawn logic from `monitor.rs::run()`.
+    async fn spawn_channel(
+        &self,
+        _name: &str,
+        _channel_config: &jyc_types::ChannelConfig,
+    ) -> anyhow::Result<()> {
+        let _workdir = &self.workdir;
+        // TODO: extract per-channel spawn logic from monitor.rs
+        // This will be filled in during Step 2 integration.
+        Ok(())
+    }
+
+    /// Update the shared ArcSwap views for InspectContext.
+    async fn update_shared_state(&self) {
+        let channels = self.channels.lock().await;
+        let tms: Vec<Arc<ThreadManager>> = channels
+            .values()
+            .map(|h| h.thread_manager.clone())
+            .collect();
+        let infos: Vec<ChannelInfo> = channels
+            .values()
+            .map(|h| h.channel_info.clone())
+            .collect();
+        let dirs: Vec<std::path::PathBuf> = channels
+            .values()
+            .map(|h| h.workspace_dir.clone())
+            .collect();
+        drop(channels);
+
+        self.thread_managers.store(Arc::new(tms));
+        self.channel_infos.store(Arc::new(infos));
+        self.workspace_dirs.store(Arc::new(dirs));
+
+        tracing::info!(
+            channel_count = self.thread_managers.load().len(),
+            "Updated shared state after reload"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    fn test_config() -> Arc<ArcSwap<AppConfig>> {
+        let config = AppConfig {
+            general: jyc_types::GeneralConfig::default(),
+            channels: HashMap::new(),
+            agent: jyc_types::AgentConfig::default(),
+            inspect: None,
+            attachments: None,
+            wecom: None,
+            mcps: Vec::new(),
+            scheduler: jyc_types::SchedulerConfig::default(),
+        };
+        Arc::new(ArcSwap::from_pointee(config))
+    }
+
+    #[tokio::test]
+    async fn test_orchestrator_new_channels() {
+        let tmpdir = TempDir::new().unwrap();
+        let config = test_config();
+        let orch = ChannelOrchestrator::new(config.clone(), tmpdir.path());
+
+        // Initially empty
+        let tms = orch.thread_managers.load();
+        assert!(tms.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_orchestrator_update_shared_state() {
+        let tmpdir = TempDir::new().unwrap();
+        let config = test_config();
+        let orch = ChannelOrchestrator::new(config, tmpdir.path());
+
+        // update_shared_state with empty channels should produce empty vecs
+        orch.update_shared_state().await;
+
+        let tms = orch.thread_managers.load();
+        assert!(tms.is_empty());
+
+        let infos = orch.channel_infos.load();
+        assert!(infos.is_empty());
+    }
+}

--- a/crates/jyc-core/src/lib.rs
+++ b/crates/jyc-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod activity_log_store;
 pub mod agent;
 pub mod attachment_storage;
+pub mod channel_orchestrator;
 pub mod chat_log_store;
 pub mod command;
 pub mod email_parser;

--- a/crates/jyc-core/src/message_router.rs
+++ b/crates/jyc-core/src/message_router.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use arc_swap::ArcSwap;
+
 use crate::message_storage::MessageStorage;
 use crate::thread_manager::ThreadManager;
 use jyc_types::{ChannelMatcher, ChannelPattern, InboundMessage};
@@ -8,33 +10,52 @@ use jyc_types::{ChannelMatcher, ChannelPattern, InboundMessage};
 ///
 /// Channel-agnostic: delegates pattern matching and thread name derivation
 /// to the `ChannelMatcher` provided by the caller.
+///
+/// Patterns are read dynamically from the live config on each route call,
+/// so changes to config.toml are effective immediately after reload.
 pub struct MessageRouter {
     thread_manager: Arc<ThreadManager>,
     storage: Arc<MessageStorage>,
+    config: Arc<ArcSwap<jyc_types::AppConfig>>,
+    channel_name: String,
 }
 
 impl MessageRouter {
-    pub fn new(thread_manager: Arc<ThreadManager>, storage: Arc<MessageStorage>) -> Self {
+    pub fn new(
+        thread_manager: Arc<ThreadManager>,
+        storage: Arc<MessageStorage>,
+        config: Arc<ArcSwap<jyc_types::AppConfig>>,
+        channel_name: String,
+    ) -> Self {
         Self {
             thread_manager,
             storage,
+            config,
+            channel_name,
         }
+    }
+
+    /// Read the current patterns for this channel from the live config.
+    fn patterns(&self) -> Vec<ChannelPattern> {
+        let cfg = self.config.load();
+        cfg.channels
+            .get(&self.channel_name)
+            .and_then(|c| c.patterns.clone())
+            .unwrap_or_default()
     }
 
     /// Route a message from any channel type.
     ///
     /// Pattern matching and thread name derivation are delegated to
     /// the channel-specific `ChannelMatcher` implementation.
-    pub async fn route(
-        &self,
-        matcher: &dyn ChannelMatcher,
-        mut message: InboundMessage,
-        patterns: &[ChannelPattern],
-    ) {
+    /// Patterns are read dynamically from the live config.
+    pub async fn route(&self, matcher: &dyn ChannelMatcher, mut message: InboundMessage) {
         let ch = &message.channel;
+        let patterns = self.patterns();
+        let patterns_ref: &[ChannelPattern] = &patterns;
 
         // 1. Pattern matching (channel-specific)
-        let pattern_match = match matcher.match_message(&message, patterns) {
+        let pattern_match = match matcher.match_message(&message, patterns_ref) {
             Some(m) => {
                 tracing::info!(
                     channel = %ch,
@@ -57,8 +78,7 @@ impl MessageRouter {
                         "No pattern matched, but storing for channel context"
                     );
                     // Store the message but don't process it
-                    self.store_unmatched_message(matcher, &message, patterns)
-                        .await;
+                    self.store_unmatched_message(matcher, &message).await;
                 } else {
                     tracing::debug!(
                         channel = %ch,
@@ -80,12 +100,12 @@ impl MessageRouter {
             .pattern_name
             .clone();
 
-        let thread_name = patterns
+        let thread_name = patterns_ref
             .iter()
             .find(|p| p.name == pattern_name)
             .and_then(|p| p.thread_name.clone())
             .unwrap_or_else(|| {
-                matcher.derive_thread_name(&message, patterns, pattern_match.as_ref())
+                matcher.derive_thread_name(&message, patterns_ref, pattern_match.as_ref())
             });
 
         tracing::info!(
@@ -97,7 +117,7 @@ impl MessageRouter {
 
         // 3. Get attachment config, template, and live_injection from the matched pattern
         let matched_pattern_name = pattern_name;
-        let matched_pattern = patterns.iter().find(|p| p.name == matched_pattern_name);
+        let matched_pattern = patterns_ref.iter().find(|p| p.name == matched_pattern_name);
         let attachment_config = matched_pattern.and_then(|p| p.attachments.clone());
         let live_injection = matched_pattern.map(|p| p.live_injection).unwrap_or(true);
 
@@ -157,10 +177,12 @@ impl MessageRouter {
         &self,
         matcher: &dyn ChannelMatcher,
         message: &InboundMessage,
-        patterns: &[ChannelPattern],
     ) {
+        let patterns = self.patterns();
+        let patterns_ref: &[ChannelPattern] = &patterns;
+
         // Derive thread name even for unmatched messages
-        let thread_name = matcher.derive_thread_name(message, patterns, None);
+        let thread_name = matcher.derive_thread_name(message, patterns_ref, None);
 
         tracing::info!(
             channel = %message.channel,

--- a/crates/jyc-core/src/message_router.rs
+++ b/crates/jyc-core/src/message_router.rs
@@ -36,7 +36,7 @@ impl MessageRouter {
     }
 
     /// Read the current patterns for this channel from the live config.
-    fn patterns(&self) -> Vec<ChannelPattern> {
+    pub fn patterns(&self) -> Vec<ChannelPattern> {
         let cfg = self.config.load();
         cfg.channels
             .get(&self.channel_name)

--- a/crates/jyc-core/tests/reload_test.rs
+++ b/crates/jyc-core/tests/reload_test.rs
@@ -1,0 +1,312 @@
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+
+/// Mock agent service for testing.
+struct MockAgent;
+
+#[async_trait::async_trait]
+impl jyc_core::agent::AgentService for MockAgent {
+    async fn base_url(&self) -> anyhow::Result<String> {
+        Ok("".to_string())
+    }
+
+    async fn process(
+        &self,
+        _message: &jyc_types::InboundMessage,
+        _thread_name: &str,
+        _thread_path: &Path,
+        _message_dir: &str,
+        _pending_rx: &mut tokio::sync::mpsc::Receiver<jyc_types::QueueItem>,
+        _thread_cancel: CancellationToken,
+    ) -> anyhow::Result<jyc_core::agent::AgentResult> {
+        Ok(jyc_core::agent::AgentResult {
+            reply_sent_by_tool: false,
+            reply_text: None,
+        })
+    }
+}
+
+/// Mock outbound adapter for testing.
+struct MockOutbound;
+
+#[async_trait::async_trait]
+impl jyc_types::OutboundAdapter for MockOutbound {
+    fn channel_type(&self) -> &str {
+        "mock"
+    }
+
+    async fn connect(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn disconnect(&self) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn clean_body(&self, raw_body: &str) -> String {
+        raw_body.to_string()
+    }
+
+    async fn send_reply(
+        &self,
+        _original: &jyc_types::InboundMessage,
+        _reply_text: &str,
+        _thread_path: &Path,
+        _message_dir: &str,
+        _attachments: Option<&[jyc_types::OutboundAttachment]>,
+    ) -> anyhow::Result<jyc_types::SendResult> {
+        Ok(jyc_types::SendResult {
+            message_id: "".to_string(),
+        })
+    }
+
+    async fn send_message(
+        &self,
+        _recipient: &str,
+        _subject: &str,
+        _body: &str,
+    ) -> anyhow::Result<jyc_types::SendResult> {
+        Ok(jyc_types::SendResult {
+            message_id: "".to_string(),
+        })
+    }
+}
+
+fn create_test_config(pattern_names: Vec<&str>) -> jyc_types::AppConfig {
+    let mut patterns = Vec::new();
+    for name in pattern_names {
+        patterns.push(jyc_types::ChannelPattern {
+            name: name.to_string(),
+            enabled: true,
+            rules: jyc_types::PatternRules::default(),
+            ..Default::default()
+        });
+    }
+
+    let mut channels = HashMap::new();
+    channels.insert(
+        "test_channel".to_string(),
+        jyc_types::ChannelConfig {
+            channel_type: "email".to_string(),
+            inbound: None,
+            outbound: None,
+            feishu: None,
+            gitee: None,
+            github: None,
+            wechat: None,
+            wecom: None,
+            wecom_kf: None,
+            wecom_bot: None,
+            monitor: None,
+            patterns: Some(patterns),
+            agent: None,
+            model: None,
+            small_model: None,
+            footer: None,
+            skills: None,
+            disabled_skills: None,
+            disabled_tools: None,
+            disabled_mcp_servers: None,
+            mcps: None,
+        },
+    );
+
+    jyc_types::AppConfig {
+        general: jyc_types::GeneralConfig::default(),
+        channels,
+        agent: jyc_types::AgentConfig {
+            enabled: false,
+            mode: "static".to_string(),
+            model: None,
+            plan_model: None,
+            build_model: None,
+            small_model: None,
+            system_prompt: None,
+            max_iterations: 200,
+            text: None,
+            attachments: None,
+            providers: HashMap::new(),
+            vision: None,
+        },
+        inspect: None,
+        attachments: None,
+        wecom: None,
+        mcps: Vec::new(),
+        scheduler: jyc_types::SchedulerConfig::default(),
+    }
+}
+
+#[tokio::test]
+async fn test_dynamic_pattern_reload() {
+    let tmpdir = TempDir::new().unwrap();
+
+    // Start metrics collector
+    let cancel = CancellationToken::new();
+    let metrics_collector = jyc_core::metrics::MetricsCollector::new(cancel.clone());
+    let (metrics_handle, _shared_stats, _metrics_task) = metrics_collector.start();
+
+    // Initial config with 1 pattern
+    let config1 = create_test_config(vec!["pattern1"]);
+    let config_swap = Arc::new(ArcSwap::from_pointee(config1));
+
+    // Create MessageStorage
+    let storage = Arc::new(jyc_core::message_storage::MessageStorage::new(tmpdir.path()));
+
+    // Create ThreadManager with mocks
+    let thread_manager = Arc::new(jyc_core::thread_manager::ThreadManager::new(
+        1,
+        10,
+        storage.clone(),
+        Arc::new(MockOutbound),
+        Arc::new(MockAgent),
+        cancel.clone(),
+        tmpdir.path().join("templates"),
+        config_swap.clone(),
+        "test_channel".to_string(),
+        "email".to_string(),
+        tmpdir.path().to_path_buf(),
+        metrics_handle,
+    ));
+
+    // Create MessageRouter
+    let router = jyc_core::message_router::MessageRouter::new(
+        thread_manager,
+        storage,
+        config_swap.clone(),
+        "test_channel".to_string(),
+    );
+
+    // Verify initial patterns
+    let patterns = router.patterns();
+    assert_eq!(patterns.len(), 1);
+    assert_eq!(patterns[0].name, "pattern1");
+
+    // Update config with 2 patterns
+    let config2 = create_test_config(vec!["pattern1", "pattern2"]);
+    config_swap.store(Arc::new(config2));
+
+    // Verify new patterns are read dynamically
+    let patterns = router.patterns();
+    assert_eq!(patterns.len(), 2);
+    assert_eq!(patterns[0].name, "pattern1");
+    assert_eq!(patterns[1].name, "pattern2");
+}
+
+#[tokio::test]
+async fn test_channel_orchestrator_reload() {
+    let tmpdir = TempDir::new().unwrap();
+
+    let config1 = create_test_config(vec!["pattern1"]);
+    let config_swap = Arc::new(ArcSwap::from_pointee(config1));
+
+    let orchestrator = jyc_core::channel_orchestrator::ChannelOrchestrator::new(
+        config_swap.clone(),
+        tmpdir.path(),
+    );
+
+    // Initially empty
+    let tms = orchestrator.thread_managers().load();
+    assert!(tms.is_empty());
+
+    // Update config: remove the channel
+    let config2 = jyc_types::AppConfig {
+        channels: HashMap::new(),
+        ..create_test_config(vec![])
+    };
+    config_swap.store(Arc::new(config2));
+
+    // Reload
+    orchestrator.reload().await.unwrap();
+
+    // Still empty (no channels registered, so nothing to remove)
+    let tms = orchestrator.thread_managers().load();
+    assert!(tms.is_empty());
+}
+
+#[tokio::test]
+async fn test_channel_orchestrator_register_and_remove() {
+    let tmpdir = TempDir::new().unwrap();
+
+    let config1 = create_test_config(vec!["pattern1"]);
+    let config_swap = Arc::new(ArcSwap::from_pointee(config1));
+
+    let orchestrator = jyc_core::channel_orchestrator::ChannelOrchestrator::new(
+        config_swap.clone(),
+        tmpdir.path(),
+    );
+
+    // Create a mock thread manager
+    let cancel = CancellationToken::new();
+    let metrics_collector = jyc_core::metrics::MetricsCollector::new(cancel.clone());
+    let (metrics_handle, _shared_stats, _metrics_task) = metrics_collector.start();
+
+    let storage = Arc::new(jyc_core::message_storage::MessageStorage::new(tmpdir.path()));
+    let thread_manager = Arc::new(jyc_core::thread_manager::ThreadManager::new(
+        1,
+        10,
+        storage,
+        Arc::new(MockOutbound),
+        Arc::new(MockAgent),
+        cancel.clone(),
+        tmpdir.path().join("templates"),
+        config_swap.clone(),
+        "test_channel".to_string(),
+        "email".to_string(),
+        tmpdir.path().to_path_buf(),
+        metrics_handle,
+    ));
+
+    // Register a channel
+    let channel_info = jyc_types::ChannelInfo {
+        name: "test_channel".to_string(),
+        channel_type: "email".to_string(),
+        active_workers: 0,
+        max_concurrent: 1,
+    };
+
+    orchestrator
+        .register_channel(
+            "test_channel".to_string(),
+            jyc_core::channel_orchestrator::ChannelHandle {
+                cancel: cancel.clone(),
+                thread_manager,
+                channel_info,
+                workspace_dir: tmpdir.path().to_path_buf(),
+            },
+        )
+        .await;
+
+    // Verify the channel is registered
+    let tms = orchestrator.thread_managers().load();
+    assert_eq!(tms.len(), 1);
+    assert_eq!(tms[0].channel_name(), "test_channel");
+
+    let infos = orchestrator.channel_infos().load();
+    assert_eq!(infos.len(), 1);
+    assert_eq!(infos[0].name, "test_channel");
+
+    // Update config: remove the channel
+    let config2 = jyc_types::AppConfig {
+        channels: HashMap::new(),
+        ..create_test_config(vec![])
+    };
+    config_swap.store(Arc::new(config2));
+
+    // Reload should detect the removed channel and update state
+    orchestrator.reload().await.unwrap();
+
+    // Verify the channel is removed from shared state
+    let tms = orchestrator.thread_managers().load();
+    assert!(tms.is_empty());
+
+    let infos = orchestrator.channel_infos().load();
+    assert!(infos.is_empty());
+
+    // Verify the cancel token was fired (channel should be shutting down)
+    assert!(cancel.is_cancelled());
+}

--- a/crates/jyc-core/tests/reload_test.rs
+++ b/crates/jyc-core/tests/reload_test.rs
@@ -155,7 +155,9 @@ async fn test_dynamic_pattern_reload() {
     let config_swap = Arc::new(ArcSwap::from_pointee(config1));
 
     // Create MessageStorage
-    let storage = Arc::new(jyc_core::message_storage::MessageStorage::new(tmpdir.path()));
+    let storage = Arc::new(jyc_core::message_storage::MessageStorage::new(
+        tmpdir.path(),
+    ));
 
     // Create ThreadManager with mocks
     let thread_manager = Arc::new(jyc_core::thread_manager::ThreadManager::new(
@@ -245,7 +247,9 @@ async fn test_channel_orchestrator_register_and_remove() {
     let metrics_collector = jyc_core::metrics::MetricsCollector::new(cancel.clone());
     let (metrics_handle, _shared_stats, _metrics_task) = metrics_collector.start();
 
-    let storage = Arc::new(jyc_core::message_storage::MessageStorage::new(tmpdir.path()));
+    let storage = Arc::new(jyc_core::message_storage::MessageStorage::new(
+        tmpdir.path(),
+    ));
     let thread_manager = Arc::new(jyc_core::thread_manager::ThreadManager::new(
         1,
         10,

--- a/crates/jyc-inspect/src/client.rs
+++ b/crates/jyc-inspect/src/client.rs
@@ -192,24 +192,26 @@ mod tests {
     use tokio_util::sync::CancellationToken;
 
     use crate::server::{InspectContext, InspectServer};
+    use arc_swap::ArcSwap;
     use jyc_types::ChannelInfo;
 
     fn test_context() -> Arc<InspectContext> {
         Arc::new(InspectContext {
-            thread_managers: vec![],
-            channels: vec![ChannelInfo {
+            thread_managers: Arc::new(ArcSwap::from_pointee(vec![])),
+            channels: Arc::new(ArcSwap::from_pointee(vec![ChannelInfo {
                 name: "test-ch".to_string(),
                 channel_type: "email".to_string(),
                 active_workers: 0,
                 max_concurrent: 0,
-            }],
+            }])),
             health_stats: Arc::new(Mutex::new(jyc_core::metrics::HealthStats::default())),
             activity_map: Arc::new(Mutex::new(HashMap::new())),
             start_time: Instant::now(),
             config_path: None,
             config: None,
-            workspace_dirs: vec![],
+            workspace_dirs: Arc::new(ArcSwap::from_pointee(vec![])),
             websocket_handlers: None,
+            reload_callback: None,
         })
     }
 
@@ -323,20 +325,21 @@ mod tests {
         .unwrap();
 
         let context = Arc::new(InspectContext {
-            thread_managers: vec![],
-            channels: vec![ChannelInfo {
+            thread_managers: Arc::new(ArcSwap::from_pointee(vec![])),
+            channels: Arc::new(ArcSwap::from_pointee(vec![ChannelInfo {
                 name: "test-ch".to_string(),
                 channel_type: "email".to_string(),
                 active_workers: 0,
                 max_concurrent: 0,
-            }],
+            }])),
             health_stats: Arc::new(Mutex::new(jyc_core::metrics::HealthStats::default())),
             activity_map: Arc::new(Mutex::new(HashMap::new())),
             start_time: Instant::now(),
             config_path: None,
             config: None,
-            workspace_dirs: vec![workspace_dir],
+            workspace_dirs: Arc::new(ArcSwap::from_pointee(vec![workspace_dir])),
             websocket_handlers: None,
+            reload_callback: None,
         });
 
         let cancel = CancellationToken::new();

--- a/crates/jyc-inspect/src/server.rs
+++ b/crates/jyc-inspect/src/server.rs
@@ -50,10 +50,10 @@ pub struct ThreadActivityState {
 
 /// Shared state accessible by the inspect server.
 pub struct InspectContext {
-    /// Per-channel thread managers
-    pub thread_managers: Vec<Arc<ThreadManager>>,
-    /// Channel info (name, type)
-    pub channels: Vec<ChannelInfo>,
+    /// Per-channel thread managers (dynamic — updated on reload)
+    pub thread_managers: Arc<ArcSwap<Vec<Arc<ThreadManager>>>>,
+    /// Channel info (name, type) (dynamic — updated on reload)
+    pub channels: Arc<ArcSwap<Vec<ChannelInfo>>>,
     /// Shared health stats from MetricsCollector
     pub health_stats: SharedHealthStats,
     /// Per-thread activity logs from SSE events
@@ -64,12 +64,14 @@ pub struct InspectContext {
     pub config_path: Option<PathBuf>,
     /// Swappable application config (for live reload)
     pub config: Option<Arc<ArcSwap<AppConfig>>>,
-    /// Per-channel workspace directories (parallel to channels)
-    pub workspace_dirs: Vec<PathBuf>,
+    /// Per-channel workspace directories (dynamic — updated on reload)
+    pub workspace_dirs: Arc<ArcSwap<Vec<PathBuf>>>,
     /// WebSocket handlers keyed by channel name.
     /// `GET /ws/my_channel` routes to `handlers["my_channel"]`.
     /// `GET /ws` (no channel) routes to the first available handler.
     pub websocket_handlers: Option<HashMap<String, Arc<dyn WebsocketHandler>>>,
+    /// Optional reload callback — invoked when config is reloaded.
+    pub reload_callback: Option<Arc<dyn Fn() + Send + Sync>>,
 }
 
 /// TCP-based inspect server.
@@ -288,6 +290,12 @@ impl InspectServer {
         config_swap.store(Arc::new(new_config));
         tracing::info!("Configuration reloaded successfully");
 
+        // Notify orchestrator if a reload callback is registered
+        if let Some(ref callback) = context.reload_callback {
+            tracing::debug!("Invoking reload callback");
+            callback();
+        }
+
         InspectResponse::ReloadResult {
             success: true,
             message: "configuration reloaded".to_string(),
@@ -324,14 +332,13 @@ impl InspectServer {
             };
         }
 
-        let agent_session_path = context
-            .workspace_dirs
+        let dirs = context.workspace_dirs.load();
+        let agent_session_path = dirs
             .iter()
             .map(|d| d.join(&thread_name).join(".jyc").join("agent-session.json"))
             .find(|p| p.exists());
 
-        let agent_context_path = context
-            .workspace_dirs
+        let agent_context_path = dirs
             .iter()
             .map(|d| d.join(&thread_name).join(".jyc").join("agent-context.json"))
             .find(|p| p.exists());
@@ -371,7 +378,8 @@ impl InspectServer {
         let mut active_workers = 0;
         let mut per_channel_workers: HashMap<String, (usize, usize)> = HashMap::new();
 
-        for tm in &context.thread_managers {
+        let tms = context.thread_managers.load();
+        for tm in tms.iter() {
             let tm_threads = tm.list_threads().await;
             total_threads += tm_threads.len();
             let stats = tm.get_stats().await;
@@ -403,11 +411,7 @@ impl InspectServer {
 
         // Read metrics
         let health = context.health_stats.lock().await;
-        let max_concurrent: usize = context
-            .thread_managers
-            .iter()
-            .map(|tm| tm.max_concurrent())
-            .sum();
+        let max_concurrent: usize = tms.iter().map(|tm| tm.max_concurrent()).sum();
         let stats = GlobalStats {
             active_workers,
             total_threads,
@@ -419,7 +423,8 @@ impl InspectServer {
         };
         drop(health);
 
-        let mut channels = context.channels.clone();
+        let channels = context.channels.load();
+        let mut channels: Vec<ChannelInfo> = channels.iter().cloned().collect();
         for ch in &mut channels {
             if let Some((aw, mc)) = per_channel_workers.get(&ch.name) {
                 ch.active_workers = *aw;
@@ -447,26 +452,28 @@ impl ActivityTracker {
     /// Persists activity entries to `.jyc/activity.jsonl` per thread.
     /// On startup, loads historical activity from disk.
     pub fn start(
-        thread_managers: Vec<Arc<ThreadManager>>,
+        thread_managers: Arc<ArcSwap<Vec<Arc<ThreadManager>>>>,
         activity_map: SharedActivityMap,
-        workspace_dirs: Vec<PathBuf>,
+        workspace_dirs: Arc<ArcSwap<Vec<PathBuf>>>,
         cancel: CancellationToken,
     ) -> tokio::task::JoinHandle<()> {
-        assert_eq!(
-            thread_managers.len(),
-            workspace_dirs.len(),
-            "thread_managers and workspace_dirs must have the same length"
-        );
         tokio::spawn(async move {
+            let subscribed: Arc<Mutex<HashSet<(String, String)>>> =
+                Arc::new(Mutex::new(HashSet::new()));
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(2));
+
             // Load historical activity from disk for all existing threads
-            for (tm_index, tm) in thread_managers.iter().enumerate() {
-                let workspace_dir = &workspace_dirs[tm_index];
+            let tms = thread_managers.load();
+            let dirs = workspace_dirs.load();
+            for (tm_index, tm) in tms.iter().enumerate() {
+                let workspace_dir = dirs.get(tm_index);
                 let channel = tm.channel_name().to_string();
                 let threads = tm.list_threads().await;
                 for thread in &threads {
-                    let thread_path = workspace_dir.join(&thread.name);
-                    if let Ok(entries) =
-                        ActivityLogStore::load_recent(&thread_path, MAX_ACTIVITY_ENTRIES)
+                    let thread_path = workspace_dir.map(|d| d.join(&thread.name));
+                    if let Some(ref path) = thread_path
+                        && let Ok(entries) =
+                            ActivityLogStore::load_recent(path, MAX_ACTIVITY_ENTRIES)
                         && !entries.is_empty()
                     {
                         let mut map = activity_map.lock().await;
@@ -484,17 +491,17 @@ impl ActivityTracker {
                     }
                 }
             }
-
-            let subscribed: Arc<Mutex<HashSet<(String, String)>>> =
-                Arc::new(Mutex::new(HashSet::new()));
-            let mut interval = tokio::time::interval(std::time::Duration::from_secs(2));
+            drop(tms);
+            drop(dirs);
 
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
                         // Discover new threads and subscribe to their event buses
-                        for (tm_index, tm) in thread_managers.iter().enumerate() {
-                            let workspace_dir = workspace_dirs.get(tm_index);
+                        let tms = thread_managers.load();
+                        let dirs = workspace_dirs.load();
+                        for (tm_index, tm) in tms.iter().enumerate() {
+                            let workspace_dir = dirs.get(tm_index);
                             let channel = tm.channel_name().to_string();
                             let threads = tm.list_threads().await;
                             for thread in threads {
@@ -929,20 +936,21 @@ mod tests {
 
     fn test_context() -> Arc<InspectContext> {
         Arc::new(InspectContext {
-            thread_managers: vec![],
-            channels: vec![ChannelInfo {
+            thread_managers: Arc::new(ArcSwap::from_pointee(vec![])),
+            channels: Arc::new(ArcSwap::from_pointee(vec![ChannelInfo {
                 name: "emf".to_string(),
                 channel_type: "github".to_string(),
                 active_workers: 0,
                 max_concurrent: 0,
-            }],
+            }])),
             health_stats: Arc::new(Mutex::new(jyc_core::metrics::HealthStats::default())),
             activity_map: Arc::new(Mutex::new(HashMap::new())),
             start_time: Instant::now(),
             config_path: None,
             config: None,
-            workspace_dirs: vec![],
+            workspace_dirs: Arc::new(ArcSwap::from_pointee(vec![])),
             websocket_handlers: None,
+            reload_callback: None,
         })
     }
 
@@ -1170,15 +1178,16 @@ mode = "agent"
         let config_swap = Arc::new(ArcSwap::from_pointee(initial_config));
 
         let ctx = Arc::new(InspectContext {
-            thread_managers: vec![],
-            channels: vec![],
+            thread_managers: Arc::new(ArcSwap::from_pointee(vec![])),
+            channels: Arc::new(ArcSwap::from_pointee(vec![])),
             health_stats: Arc::new(Mutex::new(jyc_core::metrics::HealthStats::default())),
             activity_map: Arc::new(Mutex::new(HashMap::new())),
             start_time: Instant::now(),
             config_path: Some(config_path.clone()),
             config: Some(config_swap.clone()),
-            workspace_dirs: vec![],
+            workspace_dirs: Arc::new(ArcSwap::from_pointee(vec![])),
             websocket_handlers: None,
+            reload_callback: None,
         });
 
         let cancel = CancellationToken::new();
@@ -1257,15 +1266,16 @@ mode = "agent"
         .unwrap();
 
         let ctx = Arc::new(InspectContext {
-            thread_managers: vec![],
-            channels: vec![],
+            thread_managers: Arc::new(ArcSwap::from_pointee(vec![])),
+            channels: Arc::new(ArcSwap::from_pointee(vec![])),
             health_stats: Arc::new(Mutex::new(jyc_core::metrics::HealthStats::default())),
             activity_map: Arc::new(Mutex::new(HashMap::new())),
             start_time: Instant::now(),
             config_path: None,
             config: None,
-            workspace_dirs: vec![workspace_dir],
+            workspace_dirs: Arc::new(ArcSwap::from_pointee(vec![workspace_dir])),
             websocket_handlers: None,
+            reload_callback: None,
         });
 
         let cancel = CancellationToken::new();
@@ -1352,15 +1362,16 @@ mode = "agent"
         let workspace_dir = tmp.path().to_path_buf();
 
         let ctx = Arc::new(InspectContext {
-            thread_managers: vec![],
-            channels: vec![],
+            thread_managers: Arc::new(ArcSwap::from_pointee(vec![])),
+            channels: Arc::new(ArcSwap::from_pointee(vec![])),
             health_stats: Arc::new(Mutex::new(jyc_core::metrics::HealthStats::default())),
             activity_map: Arc::new(Mutex::new(HashMap::new())),
             start_time: Instant::now(),
             config_path: None,
             config: None,
-            workspace_dirs: vec![workspace_dir],
+            workspace_dirs: Arc::new(ArcSwap::from_pointee(vec![workspace_dir])),
             websocket_handlers: None,
+            reload_callback: None,
         });
 
         let cancel = CancellationToken::new();

--- a/crates/jyc-inspect/src/server.rs
+++ b/crates/jyc-inspect/src/server.rs
@@ -1,6 +1,8 @@
 use arc_swap::ArcSwap;
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::future::Future;
 use std::path::PathBuf;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -48,6 +50,12 @@ pub struct ThreadActivityState {
     pub last_active_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+/// Callback invoked after config is swapped atomically during reload.
+/// Returns a Future so the caller can await the result and report errors
+/// to the user.
+pub type ReloadCallback =
+    Arc<dyn Fn() -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>> + Send + Sync>;
+
 /// Shared state accessible by the inspect server.
 pub struct InspectContext {
     /// Per-channel thread managers (dynamic — updated on reload)
@@ -70,8 +78,8 @@ pub struct InspectContext {
     /// `GET /ws/my_channel` routes to `handlers["my_channel"]`.
     /// `GET /ws` (no channel) routes to the first available handler.
     pub websocket_handlers: Option<HashMap<String, Arc<dyn WebsocketHandler>>>,
-    /// Optional reload callback — invoked when config is reloaded.
-    pub reload_callback: Option<Arc<dyn Fn() + Send + Sync>>,
+    /// Optional reload callback — invoked after config is swapped atomically.
+    pub reload_callback: Option<ReloadCallback>,
 }
 
 /// TCP-based inspect server.
@@ -293,7 +301,14 @@ impl InspectServer {
         // Notify orchestrator if a reload callback is registered
         if let Some(ref callback) = context.reload_callback {
             tracing::debug!("Invoking reload callback");
-            callback();
+            if let Err(e) = callback().await {
+                let msg = format!("config reloaded, but channel reload failed: {e:#}");
+                tracing::error!(error = %e, "Channel reload failed after config swap");
+                return InspectResponse::ReloadResult {
+                    success: false,
+                    message: msg,
+                };
+            }
         }
 
         InspectResponse::ReloadResult {

--- a/crates/jyc-services/src/imap/monitor.rs
+++ b/crates/jyc-services/src/imap/monitor.rs
@@ -5,7 +5,7 @@ use tokio_util::sync::CancellationToken;
 use crate::imap::client::ImapClient;
 use jyc_core::message_router::MessageRouter;
 use jyc_core::state_manager::StateManager;
-use jyc_types::{ChannelMatcher, ChannelPattern};
+use jyc_types::ChannelMatcher;
 use jyc_types::{ImapConfig, MonitorConfig};
 
 /// IMAP email monitor — connects to IMAP, fetches new emails, dispatches them.
@@ -19,7 +19,6 @@ pub struct ImapMonitor {
     channel_name: String,
     imap_config: ImapConfig,
     monitor_config: MonitorConfig,
-    patterns: Vec<ChannelPattern>,
     router: Arc<MessageRouter>,
     state_manager: StateManager,
     cancel: CancellationToken,
@@ -32,7 +31,6 @@ impl ImapMonitor {
         channel_name: String,
         imap_config: ImapConfig,
         monitor_config: MonitorConfig,
-        patterns: Vec<ChannelPattern>,
         router: Arc<MessageRouter>,
         state_manager: StateManager,
         cancel: CancellationToken,
@@ -42,7 +40,6 @@ impl ImapMonitor {
             channel_name,
             imap_config,
             monitor_config,
-            patterns,
             router,
             state_manager,
             cancel,
@@ -294,7 +291,7 @@ impl ImapMonitor {
 
         // Route through the message router (pattern match → thread queue)
         self.router
-            .route(&*self.matcher, message, &self.patterns)
+            .route(&*self.matcher, message)
             .await;
 
         Ok(())

--- a/crates/jyc-services/src/imap/monitor.rs
+++ b/crates/jyc-services/src/imap/monitor.rs
@@ -290,9 +290,7 @@ impl ImapMonitor {
         // thread_name override is configured on the pattern.
 
         // Route through the message router (pattern match → thread queue)
-        self.router
-            .route(&*self.matcher, message)
-            .await;
+        self.router.route(&*self.matcher, message).await;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Implements unified config hot-reload for channel patterns and InspectContext state, closing #338.

### Changes

- **MessageRouter**: Now reads patterns dynamically from  on every  call. Reloaded config changes take effect immediately for new messages.
- **ImapMonitor**: Removed static  field; patterns now come from live config via MessageRouter.
- **InspectContext**: , ,  changed from  to  for dynamic updates after reload.
- **GithubInboundAdapter**:  now reads patterns dynamically from live config. Added  fallback for unit tests.
- **GiteeInboundAdapter**: Removed unused  field and  method.
- **WebsocketInboundAdapter**:  now reads pattern names dynamically from live config.
- **handle_reload_config**: Added  invocation after successful config swap.
- **ChannelOrchestrator**: New component (placeholder) for future channel lifecycle management (spawn/cancel on reload).

### Testing

- All workspace tests pass (
running 114 tests
test agent_loop::guardrail_tests::empty_object_args_detected ... ok
test agent_loop::guardrail_tests::empty_slice_not_detected ... ok
test agent_loop::guardrail_tests::empty_string_args_detected ... ok
test agent_loop::guardrail_tests::mixed_args_not_all_empty ... ok
test agent_loop::guardrail_tests::non_empty_args_not_detected ... ok
test agent_loop::guardrail_tests::whitespace_only_args_detected ... ok
test agent_loop::render_raw_context_tests::skips_unknown_roles_and_empty_content ... ok
test agent_loop::render_raw_context_tests::renders_user_assistant_tool_sequence ... ok
test agent_loop::render_raw_context_tests::truncates_long_tool_results ... ok
test agent_loop::retry_tests::diag_2xx_with_send_error_is_retried ... ok
test agent_loop::retry_tests::gives_up_after_max_attempts ... ok
test agent_loop::retry_tests::non_transient_errors_fail_immediately ... ok
test integration_tests::test_agent_loop_simple ... ignored
test integration_tests::test_anthropic_streaming ... ignored
test provider::anthropic::tests::complete_error_includes_response_body_on_4xx ... ok
test provider::anthropic::tests::sanitize_input_schema_passes_through_clean_object ... ok
test provider::anthropic::tests::sanitize_input_schema_passes_through_non_object ... ok
test provider::anthropic::tests::sanitize_input_schema_passes_through_null ... ok
test provider::anthropic::tests::sanitize_input_schema_removes_all_composition_keywords ... ok
test provider::anthropic::tests::sanitize_input_schema_removes_all_of ... ok
test provider::anthropic::tests::sanitize_input_schema_removes_any_of ... ok
test provider::anthropic::tests::sanitize_input_schema_removes_one_of ... ok
test provider::classifier_tests::decode_body_error_no_diag_is_transient ... ok
test provider::classifier_tests::diag_status_2xx_is_transient ... ok
test provider::classifier_tests::diag_status_429_is_transient ... ok
test provider::classifier_tests::diag_status_4xx_is_terminal ... ok
test provider::classifier_tests::diag_status_5xx_is_terminal ... ok
test provider::classifier_tests::error_sending_request_is_transient ... ok
test provider::classifier_tests::extract_diag_status_429 ... ok
test provider::classifier_tests::extract_diag_status_basic ... ok
test provider::classifier_tests::extract_diag_status_missing_returns_none ... ok
test provider::classifier_tests::invalid_status_no_diag_is_terminal ... ok
test provider::dangling_tool_call_tests::extract_ids_anthropic_format ... ok
test provider::dangling_tool_call_tests::extract_ids_no_tool_calls ... ok
test provider::dangling_tool_call_tests::extract_ids_openai_format ... ok
test provider::dangling_tool_call_tests::multiple_assistant_messages_only_dangling_dropped ... ok
test provider::dangling_tool_call_tests::no_tool_calls_not_affected ... ok
test provider::dangling_tool_call_tests::openai_all_tool_results_present_kept ... ok
test provider::dangling_tool_call_tests::openai_complete_context_not_modified ... ok
test provider::dangling_tool_call_tests::openai_dangling_tool_call_dropped ... ok
test provider::dangling_tool_call_tests::openai_partial_tool_results_dropped ... ok
test provider::openai_compat::tests::complete_sends_custom_user_agent ... ok
test provider::openai_compat::tests::diagnostic_post_sends_custom_user_agent_on_error ... ok
test provider::openai_compat::tests::format_tool_result_prefixed_with_error ... ok
test provider::openai_compat::tests::format_tool_result_prefixed_with_success ... ok
test provider::openai_compat::tests::parse_tool_call_chunked_string_arguments ... ok
test provider::openai_compat::tests::parse_tool_call_object_arguments ... ok
test provider::openai_compat::tests::parse_tool_call_string_arguments ... ok
test service::tests::build_user_prompt_injects_build_mode_tag ... ok
test service::tests::channel_and_pattern_disabled_skills_merged ... ok
test service::tests::channel_and_pattern_disabled_tools_merged ... ok
test service::tests::channel_disabled_tools_works_without_pattern_match ... ok
test service::tests::channel_skills_applied_when_no_pattern_match ... ok
test service::tests::disabled_builtin_tools_alias_works ... ok
test service::tests::disabled_mcp_servers_filters_channel_configs ... ok
test service::tests::disabled_mcp_servers_skips_matching_server ... ok
test service::tests::disabled_tools_deduplicates_between_channel_and_pattern ... ok
test service::tests::disabled_tools_mixed_plain_and_server_prefix ... ok
test service::tests::disabled_tools_removes_builtin_and_bridge ... ok
test service::tests::disabled_tools_server_prefix_does_not_affect_builtin ... ok
test service::tests::discover_skills_exclude_filter_removes_matched ... ok
test service::tests::discover_skills_include_and_exclude_combined ... ok
test service::tests::discover_skills_include_filter_retains_only_matched ... ok
test service::tests::empty_disabled_tools_disables_nothing ... ok
test service::tests::enabled_tools_on_mcp_server_config_does_not_panic ... ok
test service::tests::fallback_to_config_model_when_no_pattern_matches ... ok
test service::tests::fallback_to_config_model_when_pattern_has_no_model ... ok
test service::tests::first_matching_pattern_wins_with_duplicate_names ... ok
test service::tests::no_filters_loads_all_skills ... ok
test service::tests::pattern_model_none_and_config_none_yields_none ... ok
test service::tests::pattern_model_override_is_resolved ... ok
test service::tests::pattern_skills_override_channel_skills ... ok
test tools::builtin::bash::tests::escaped_quote_inside_double_quotes ... ok
test tools::builtin::bash::tests::escaped_quote_outside_does_not_open_region ... ok
test tools::builtin::bash::tests::markdown_body_with_double_slash_skipped ... ok
test tools::builtin::bash::tests::mixed_quoted_and_unquoted ... ok
test tools::builtin::bash::tests::multiple_unquoted_paths_detected ... ok
test tools::builtin::bash::tests::quoted_path_skipped ... ok
test tools::builtin::bash::tests::relative_paths_ignored ... ok
test tools::builtin::bash::tests::single_quoted_path_skipped ... ok
test tools::builtin::bash::tests::unquoted_absolute_path_detected ... ok
test tools::builtin::bash::tests::unquoted_path_after_quoted_string_detected ... ok
test tools::mcp_client::tests::filter_tools_by_whitelist_empty_list_returns_nothing ... ok
test tools::mcp_client::tests::filter_tools_by_whitelist_filters_correctly ... ok
test tools::mcp_client::tests::filter_tools_by_whitelist_nonexistent_tools_returns_nothing ... ok
test tools::mcp_client::tests::filter_tools_by_whitelist_with_none_returns_all ... ok
test tools::registry::tests::default_registry_is_empty ... ok
test tools::registry::tests::definitions_returns_all_tools ... ok
test tools::registry::tests::execute_existing_tool ... ok
test tools::registry::tests::execute_missing_tool_returns_error ... ok
test tools::registry::tests::new_registry_is_empty ... ok
test tools::registry::tests::register_and_has_tool ... ok
test tools::registry::tests::remove_existing_tool ... ok
test tools::registry::tests::remove_nonexistent_is_noop ... ok
test types::tests::agent_config_default ... ok
test types::tests::content_block_text ... ok
test types::tests::content_block_tool_result ... ok
test types::tests::content_block_tool_use ... ok
test types::tests::image_source_base64 ... ok
test types::tests::image_source_url ... ok
test types::tests::message_assistant ... ok
test types::tests::message_text_skips_non_text_blocks ... ok
test types::tests::message_tool_result ... ok
test types::tests::message_tool_uses ... ok
test types::tests::message_user ... ok
test types::tests::message_user_with_blocks ... ok
test types::tests::model_config_default ... ok
test types::tests::provider_config_default ... ok
test types::tests::role_serde_roundtrip ... ok
test types::tests::stream_event_variants ... ok
test types::tests::tool_definition_serde ... ok
test types::tests::vision_config_serde ... ok
test vision::tests::test_request_body_format ... ok
test agent_loop::retry_tests::retries_transient_sse_errors_then_succeeds ... ok

test result: ok. 112 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 6.11s


running 74 tests
test filter_valid_messages::drops_assistant_with_reasoning_and_tool_calls_missing_results ... ok
test filter_valid_messages::drops_anthropic_assistant_with_tool_use_block_missing_results ... ok
test filter_valid_messages::drops_assistant_with_tool_calls_missing_results ... ok
test filter_valid_messages::keeps_anthropic_assistant_with_text_block ... ok
test filter_valid_messages::keeps_assistant_with_content ... ok
test filter_valid_messages::keeps_tool_messages ... ok
test filter_valid_messages::keeps_user_messages ... ok
test filter_valid_messages::mixed_conversation_filters_correctly ... ok
test filter_valid_messages::preserves_reasoning_content_on_all_assistant_turns ... ok
test filter_valid_messages::removes_anthropic_assistant_with_empty_content_array ... ok
test filter_valid_messages::removes_anthropic_assistant_with_empty_text_block ... ok
test filter_valid_messages::removes_assistant_with_empty_content_no_tool_calls ... ok
test filter_valid_messages::removes_assistant_with_empty_tool_calls ... ok
test filter_valid_messages::removes_assistant_with_null_content_no_tool_calls ... ok
test filter_valid_messages::removes_assistant_with_only_reasoning_content ... ok
test max_iterations::default_is_500 ... ok
test max_iterations::deserializes_explicit_value ... ok
test max_iterations::deserializes_from_toml_default ... ok
test mcp_bridge::reply_tool_rejects_empty_message ... ok
test mcp_bridge::send_message_attachment_not_found ... ok
test mcp_bridge::reply_tool_writes_signal_files ... ok
test mcp_bridge::send_message_rejects_empty_message ... ok
test mcp_bridge::send_message_cross_channel_with_attachments ... ok
test mcp_bridge::send_message_rejects_empty_recipient ... ok
test mcp_bridge::send_message_rejects_unknown_channel ... ok
test mcp_bridge::send_message_rejects_missing_outbounds_map ... ok
test mcp_bridge::send_message_requires_outbound ... ok
test mcp_bridge::send_message_sends_via_outbound ... ok
test mcp_bridge::send_message_with_channel_cross_channel ... ok
test parse_openai_chunk::stream_event_reasoning_delta ... ok
test mcp_bridge::send_message_with_attachments_success ... ok
test parse_openai_chunk::stream_event_text_delta ... ok
test parse_openai_chunk::stream_event_tool_use ... ok
test session::load_context_filters_invalid_assistant_messages ... ok
test session::load_context_discards_all_user_only_context ... ok
test session::load_context_returns_empty_when_no_session_file ... ok
test session::save_and_load_raw_context ... ok
test session::reset_session_deletes_session_file ... ok
test session::update_tokens_creates_session_file ... ok
test session::update_tokens_stores_latest_not_accumulated ... ok
test skills::format_includes_path ... ok
test skills::format_section_empty_returns_empty_string ... ok
test skills::empty_skills_dir_handled ... ok
test skills::malformed_skill_skipped ... ok
test skills::no_skills_dir_returns_empty ... ok
test skills::multi_path_discovery ... ok
test skills::parse_frontmatter_block_scalar_empty_returns_none ... ok
test skills::parse_frontmatter_block_scalar_pipe ... ok
test skills::parse_frontmatter_empty_values_returns_none ... ok
test skills::parse_frontmatter_missing_description_returns_none ... ok
test skills::parse_frontmatter_block_scalar_greater_than ... ok
test skills::parse_frontmatter_missing_name_returns_none ... ok
test skills::parse_frontmatter_no_delimiter_returns_none ... ok
test skills::parse_frontmatter_valid ... ok
test skills::same_name_priority ... ok
test small_model::default_is_none ... ok
test skills::single_skill_parsed ... ok
test small_model::deserializes_when_absent ... ok
test tool_registry::builtin_registry_has_all_tools ... ok
test small_model::deserializes_when_present ... ok
test tool_registry::registry_produces_definitions ... ok
test tool_registry::registry_unknown_tool_returns_error ... ok
test tools::bash_reports_error_on_failure ... ok
test tools::bash_executes_simple_command ... ok
test tools::bash_requires_command_param ... ok
test tools::edit_fails_on_multiple_matches ... ok
test tools::edit_fails_when_old_string_not_found ... ok
test tools::glob_finds_files ... ok
test tools::edit_replaces_text ... ok
test tools::grep_finds_matches ... ok
test tools::read_requires_file_path ... ok
test tools::read_file_with_content ... ok
test tools::send_to_thread_attachment_has_content ... ok
test tools::write_creates_file ... ok

test result: ok. 74 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 180 tests
test activity_log_store::tests::test_append_and_load_recent ... ok
test activity_log_store::tests::test_load_empty_file ... ok
test attachment_storage::tests::test_generate_attachment_filename_chinese_characters ... ok
test attachment_storage::tests::test_generate_attachment_filename_chinese_long_name ... ok
test attachment_storage::tests::test_generate_attachment_filename_preserves_extension ... ok
test attachment_storage::tests::test_generate_attachment_filename_truncates_long_name ... ok
test attachment_storage::tests::test_sanitize_attachment_filename_control_chars ... ok
test activity_log_store::tests::test_rotation ... ok
test attachment_storage::tests::test_sanitize_attachment_filename_normal ... ok
test attachment_storage::tests::test_sanitize_attachment_filename_path_traversal ... ok
test attachment_storage::tests::test_sanitize_attachment_filename_empty ... ok
test attachment_storage::tests::test_save_attachments_to_thread_directory ... ok
test channel_orchestrator::tests::test_orchestrator_update_shared_state ... ok
test chat_log_store::tests::test_append_message ... ok
test chat_log_store::tests::test_append_message_with_thread_json_fallback ... ok
test channel_orchestrator::tests::test_orchestrator_new_channels ... ok
test chat_log_store::tests::test_append_reply ... ok
test chat_log_store::tests::test_multiple_appends ... ok
test chat_log_store::tests::test_chat_log_store_creation ... ok
test command::cancel_handler::tests::test_cancel_handler_empty_thread_name ... ok
test command::cancel_handler::tests::test_cancel_handler_success ... ok
test command::cancel_handler::tests::test_cancel_no_active_token_is_noop ... ok
test command::cancel_handler::tests::test_cancel_triggers_token ... ok
test command::help_handler::tests::test_help_contains_commands ... ok
test command::mode_handler::tests::test_build_mode ... ok
test command::mode_handler::tests::test_plan_mode ... ok
test command::mode_handler::tests::test_plan_preserves_session ... ok
test command::model_handler::tests::test_invalid_model_format ... ok
test command::model_handler::tests::test_list_models ... ok
test command::model_handler::tests::test_list_models_empty_providers ... ok
test command::model_handler::tests::test_reset_clears_all_mode_overrides ... ok
test command::model_handler::tests::test_reset_model ... ok
test command::model_handler::tests::test_reset_model_no_override ... ok
test command::model_handler::tests::test_switch_model ... ok
test command::model_handler::tests::test_switch_model_in_plan_mode_writes_plan_override ... ok
test command::model_handler::tests::test_switch_model_in_build_mode_writes_build_override ... ok
test command::model_handler::tests::test_unknown_model ... ok
test command::model_handler::tests::test_unknown_provider ... ok
test command::new_handler::tests::test_new_deletes_activity_log ... ok
test command::new_handler::tests::test_new_with_history_only ... ok
test command::new_handler::tests::test_new_with_no_session_or_history ... ok
test command::new_handler::tests::test_new_with_session_and_history ... ok
test command::registry::tests::test_command_at_top_with_body ... ok
test command::new_handler::tests::test_new_with_session_only ... ok
test command::registry::tests::test_command_only_message ... ok
test command::registry::tests::test_multiple_commands ... ok
test command::registry::tests::test_results_summary ... ok
test command::registry::tests::test_no_commands ... ok
test command::registry::tests::test_unknown_command_is_body ... ok
test command::reset_handler::tests::test_reset_existing_session ... ok
test command::reset_handler::tests::test_reset_no_existing_session ... ok
test command::template_handler::tests::test_template_no_pattern_file ... ok
test email_parser::tests::test_build_footer_disabled_no_model_returns_empty ... ok
test email_parser::tests::test_build_footer_disabled_returns_empty ... ok
test email_parser::tests::test_build_footer_enabled_all_fields ... ok
test email_parser::tests::test_build_footer_enabled_with_model ... ok
test email_parser::tests::test_build_full_reply_text_footer_disabled ... ok
test email_parser::tests::test_build_full_reply_text_footer_enabled ... ok
test email_parser::tests::test_clean_crlf ... ok
test email_parser::tests::test_clean_excessive_blank_lines ... ok
test email_parser::tests::test_clean_null_bytes ... ok
test email_parser::tests::test_clean_trims ... ok
test email_parser::tests::test_derive_empty_subject ... ok
test email_parser::tests::test_derive_longest_prefix_first ... ok
test email_parser::tests::test_derive_prefix_with_separator ... ok
test email_parser::tests::test_derive_preserves_cjk ... ok
test email_parser::tests::test_derive_sanitizes_filename ... ok
test email_parser::tests::test_derive_simple ... ok
test email_parser::tests::test_derive_with_prefix_strip ... ok
test email_parser::tests::test_parse_stored_message ... ok
test email_parser::tests::test_parse_stored_reply_no_divider ... ok
test email_parser::tests::test_parse_stored_reply_simple ... ok
test email_parser::tests::test_strip_case_insensitive ... ok
test email_parser::tests::test_strip_chinese_forward ... ok
test email_parser::tests::test_strip_chinese_headers ... ok
test email_parser::tests::test_strip_chinese_reply ... ok
test email_parser::tests::test_strip_depth2_quotes ... ok
test email_parser::tests::test_strip_divider ... ok
test email_parser::tests::test_strip_fw ... ok
test email_parser::tests::test_strip_fwd ... ok
test email_parser::tests::test_strip_mixed_prefixes ... ok
test email_parser::tests::test_strip_nested_re ... ok
test email_parser::tests::test_strip_no_prefix ... ok
test email_parser::tests::test_strip_no_quotes ... ok
test email_parser::tests::test_strip_on_wrote_header ... ok
test email_parser::tests::test_strip_simple_re ... ok
test email_parser::tests::test_strip_trailing_separators_empty ... ok
test email_parser::tests::test_strip_trailing_separators_multiple ... ok
test email_parser::tests::test_strip_trailing_separators_none ... ok
test email_parser::tests::test_strip_trailing_separators_only_separators ... ok
test email_parser::tests::test_strip_trailing_separators_single ... ok
test email_parser::tests::test_strip_trailing_separators_with_whitespace ... ok
test email_parser::tests::test_strip_trailing_separators_within_body ... ok
test email_parser::tests::test_strip_with_spaces ... ok
test email_parser::tests::test_truncate_at_word_boundary ... ok
test email_parser::tests::test_truncate_short_text ... ok
test job_store::tests::test_create_and_get ... ok
test job_store::tests::test_create_duplicate_fails ... ok
test job_store::tests::test_delete ... ok
test job_store::tests::test_delete_nonexistent_returns_false ... ok
test command::template_handler::tests::test_template_success ... ok
test job_store::tests::test_list ... ok
test job_store::tests::test_list_empty ... ok
test job_store::tests::test_max_jobs_limit ... ok
test job_store::tests::test_update ... ok
test job_store::tests::test_update_nonexistent_fails ... ok
test job_store::tests::test_upsert_creates_new ... ok
test message_router::tests::test_different_topics_same_thread_with_override ... ok
test message_router::tests::test_live_injection_defaults_to_true ... ok
test job_store::tests::test_upsert_updates_existing ... ok
test message_router::tests::test_live_injection_extracted_from_pattern ... ok
test message_router::tests::test_live_injection_defaults_true_via_serde ... ok
test message_router::tests::test_live_injection_true_when_pattern_enables_it ... ok
test message_router::tests::test_live_injection_false_via_serde ... ok
test message_router::tests::test_thread_name_override_used_when_set ... ok
test message_router::tests::test_thread_name_derived_when_no_override ... ok
test message_storage::tests::test_store_and_read ... ok
test message_storage::tests::test_store_reply ... ok
test metrics::tests::test_metrics_collector_stops_on_cancel ... ok
test metrics::tests::test_metrics_handle_noop ... ok
test metrics::tests::test_metrics_collector_accumulates_stats ... ok
test metrics::tests::test_metrics_reply_by_fallback ... ok
test pending_delivery::tests::test_cancellation_stops_watcher ... ok
test pending_delivery::tests::test_delivers_when_signal_and_reply_exist ... ok
test pending_delivery::tests::test_no_delivery_with_empty_reply ... ok
test session_state::tests::read_input_tokens_from_file ... ok
test session_state::tests::read_input_tokens_invalid_json ... ok
test session_state::tests::read_input_tokens_no_file ... ok
test session_state::tests::read_input_tokens_zero_values ... ok
test session_state::tests::read_mode_override_existing ... ok
test session_state::tests::read_mode_override_missing ... ok
test session_state::tests::read_model_override_empty ... ok
test session_state::tests::read_model_override_existing ... ok
test session_state::tests::read_model_override_missing ... ok
test state_manager::tests::test_state_manager_reset ... ok
test state_manager::tests::test_state_manager_round_trip ... ok
test state_manager::tests::test_uid_validity ... ok
test static_agent::tests::base_url_returns_error ... ok
test static_agent::tests::new_service ... ok
test static_agent::tests::process_returns_static_text ... ok
test static_agent::tests::set_thread_event_bus_does_nothing ... ok
test template_utils::tests::test_copy_skips_existing_files ... ok
test template_utils::tests::test_copy_template_files ... ok
test thread_event::tests::llm_request_started_event ... ok
test thread_event::tests::processing_completed_event ... ok
test thread_event::tests::processing_progress_event ... ok
test thread_event::tests::processing_started_event ... ok
test thread_event::tests::session_status_event ... ok
test thread_event::tests::thinking_event ... ok
test thread_event::tests::tool_completed_event ... ok
test thread_event::tests::tool_started_event ... ok
test thread_event_bus::tests::closed_subscribers_are_pruned ... ok
test thread_event_bus::tests::events_delivered_in_order ... ok
test thread_event_bus::tests::multiple_subscribers_receive_all_events ... ok
test thread_json::tests::test_data_as_none_when_data_missing ... ok
test thread_json::tests::test_read_missing_file_returns_none ... ok
test thread_json::tests::test_write_and_read_roundtrip ... ok
test thread_json::tests::test_write_creates_jyc_dir ... ok
test thread_manager::has_active_queue_tests::test_has_active_queue_false_for_unknown_thread ... ok
test thread_manager::has_active_queue_tests::test_has_active_queue_true_after_enqueue ... ok
test thread_manager::template_init_tests::fresh_thread_writes_marker ... ok
test thread_manager::template_init_tests::matching_template_is_idempotent ... ok
test thread_manager::template_init_tests::template_mismatch_is_refused ... ok
test thread_manager::thread_json_tests::test_write_wecomkf_thread_json_creates_file ... ok
test thread_manager::thread_json_tests::test_write_wecomkf_thread_json_fallback_user_name ... ok
test thread_manager::thread_json_tests::test_write_wecomkf_thread_json_skips_without_external_userid ... ok
test thread_path::tests::test_attachment_saves_to_correct_thread_dir ... ok
test thread_path::tests::test_compute_repo_group_key ... ok
test thread_path::tests::test_jyc_dir_created_in_correct_location ... ok
test thread_path::tests::test_repo_group_backward_compatibility_no_field ... ok
test thread_path::tests::test_repo_group_set_via_serde ... ok
test thread_path::tests::test_resolve_shared_repo_dir ... ok
test thread_path::tests::test_resolve_workspace_email ... ok
test thread_path::tests::test_resolve_workspace_feishu ... ok
test thread_path::tests::test_storage_thread_path_from_chinese_subject ... ok
test thread_path::tests::test_storage_thread_path_from_config_override ... ok
test thread_path::tests::test_storage_thread_path_from_email_subject ... ok
test thread_path::tests::test_storage_thread_path_from_feishu_with_config_override ... ok
test thread_path::tests::test_symlink_creation_with_repo_group_key ... ok
test pending_delivery::tests::test_no_delivery_without_signal ... ok

test result: ok. 180 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 12.27s


running 18 tests
test client::tests::test_inspect_client_connection_refused ... ok
test client::tests::test_inspect_client_get_state ... ok
test client::tests::test_inspect_client_reset_session ... ok
test client::tests::test_inspect_client_reuses_connection ... ok
test server::tests::test_activity_map_disambiguates_same_named_threads_across_channels ... ok
test server::tests::test_event_to_activity_session_status_error ... ok
test server::tests::test_event_to_activity_session_status_error_with_attempt ... ok
test client::tests::test_inspect_client_reconnects_after_disconnect ... ok
test server::tests::test_idle_thread_clears_stale_processing_state ... ok
test server::tests::test_inspect_server_handles_unknown_method ... ok
test server::tests::test_inspect_server_handles_invalid_json ... ok
test server::tests::test_inspect_server_multiple_requests ... ok
test server::tests::test_inspect_server_reset_session ... ok
test server::tests::test_inspect_server_reset_session_missing_param ... ok
test server::tests::test_inspect_server_reset_session_no_existing_session ... ok
test server::tests::test_inspect_server_reset_session_path_traversal ... ok
test server::tests::test_inspect_server_responds_to_get_state ... ok
test server::tests::test_inspect_server_reload_config ... ok

test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.81s


running 4 tests
test context::tests::test_load_missing_channel ... ok
test context::tests::test_cleanup ... ok
test context::tests::test_load_missing_file ... ok
test context::tests::test_save_and_load ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 19 tests
test job_scheduler::tests::test_disabled_scheduler_returns_immediately ... ok
test job_scheduler::tests::test_next_sleep_duration_no_jobs ... ok
test job_scheduler::tests::test_next_sleep_duration_with_future_job ... ok
test job_scheduler::tests::test_next_sleep_duration_earliest_across_threads ... ok
test job_scheduler::tests::test_run_cycle_discovery_across_threads ... ok
test job_scheduler::tests::test_run_cycle_multi_workspace_discovery ... ok
test job_scheduler::tests::test_run_cycle_skips_pending_thread_without_jobs_dir ... ok
test job_scheduler::tests::test_run_cycle_skips_disabled_jobs ... ok
test smtp::client::tests::test_format_smtp_code_some ... ok
test smtp::client::tests::test_format_smtp_code_none ... ok
test smtp::client::tests::test_markdown_to_html ... ok
test smtp::client::tests::test_markdown_to_html_table ... ok
test smtp::client::tests::test_smtp_backoff_delay_attempt_1 ... ok
test smtp::client::tests::test_smtp_backoff_delay_attempt_2 ... ok
test smtp::client::tests::test_smtp_backoff_delay_attempt_3 ... ok
test smtp::client::tests::test_smtp_backoff_delay_capped ... ok
test smtp::client::tests::test_smtp_backoff_delay_large_attempt ... ok
test smtp::client::tests::test_smtp_backoff_delay_zero_attempt ... ok
test smtp::client::tests::test_html_to_markdown ... ok

test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s


running 68 tests
test config::config_loader_tests::test_expand_env_vars ... ok
test config::config_loader_tests::test_load_config_with_defaults ... ok
test config::config_loader_tests::test_load_minimal_config ... ok
test feishu_config::tests::test_config_deserialize ... ok
test feishu_config::tests::test_default_config ... ok
test gitee_config::tests::test_config_deserialize ... ok
test gitee_config::tests::test_config_deserialize_defaults ... ok
test gitee_config::tests::test_config_deserialize_enterprise_url ... ok
test gitee_config::tests::test_config_deserialize_poll_ci_status_default ... ok
test gitee_config::tests::test_config_deserialize_poll_ci_status_disabled ... ok
test gitee_config::tests::test_default_config ... ok
test github_config::tests::test_config_deserialize ... ok
test github_config::tests::test_config_deserialize_defaults ... ok
test github_config::tests::test_config_deserialize_enterprise_url ... ok
test github_config::tests::test_config_deserialize_poll_ci_status_default ... ok
test github_config::tests::test_config_deserialize_poll_ci_status_disabled ... ok
test github_config::tests::test_default_config ... ok
test inspect::tests::test_activity_entry_backward_compat_old_jsonl ... ok
test inspect::tests::test_activity_entry_with_severity ... ok
test inspect::tests::test_channel_info_backward_compat ... ok
test inspect::tests::test_inspect_request_serialize ... ok
test inspect::tests::test_inspect_response_error ... ok
test inspect::tests::test_inspect_response_reload_result ... ok
test inspect::tests::test_inspect_response_reset_session_result ... ok
test inspect::tests::test_inspect_state_default ... ok
test inspect::tests::test_inspect_state_serialize_roundtrip ... ok
test inspect::tests::test_severity_default_is_info ... ok
test inspect::tests::test_severity_serde_roundtrip ... ok
test inspect::tests::test_thread_status_display ... ok
test inspect::tests::test_thread_status_serde ... ok
test job::tests::test_mark_fired_one_time ... ok
test config::config_loader_tests::test_load_config_with_mcps ... ok
test job::tests::test_new_one_time_job ... ok
test job::tests::test_new_recurring_job ... ok
test job::tests::test_parse_cron_next_invalid ... ok
test job::tests::test_parse_cron_next_valid ... ok
test job::tests::test_mark_fired_recurring ... ok
test validation::tests::test_disabled_tools_empty_entry_fails ... ok
test validation::tests::test_disabled_mcp_servers_empty_entry_fails ... ok
test validation::tests::test_empty_channels_fails ... ok
test validation::tests::test_disabled_tools_valid_passes ... ok
test validation::tests::test_invalid_mcp_in_pattern ... ok
test validation::tests::test_invalid_mcp_local_no_command ... ok
test validation::tests::test_invalid_mcp_remote_no_url ... ok
test validation::tests::test_invalid_monitor_mode ... ok
test validation::tests::test_invalid_regex_in_pattern ... ok
test validation::tests::test_invalid_unified_attachment_config ... ok
test validation::tests::test_static_mode_requires_text ... ok
test validation::tests::test_pattern_disabled_tools_empty_entry_fails ... ok
test validation::tests::test_valid_config_passes ... ok
test validation::tests::test_unified_attachment_config ... ok
test validation::tests::test_wecom_missing_config_fails ... ok
test validation::tests::test_valid_mcp_in_pattern_passes ... ok
test validation::tests::test_wecom_missing_corp_secret_fails ... ok
test validation::tests::test_wecom_missing_token_fails ... ok
test wechat_config::tests::test_config_deserialize ... ok
test wechat_config::tests::test_default_config ... ok
test wecom_bot_config::tests::test_default_ws_url ... ok
test wecom_bot_config::tests::test_wecom_bot_config_defaults ... ok
test wecom_bot_config::tests::test_wecom_bot_config_minimal ... ok
test wecom_bot_config::tests::test_wecom_bot_config_serde ... ok
test wecom_config::tests::test_config_deserialize ... ok
test wecom_config::tests::test_default_global_config ... ok
test wecom_config::tests::test_global_config_deserialize ... ok
test wecom_kf_config::tests::test_deserialize_full ... ok
test wecom_kf_config::tests::test_deserialize_minimal ... ok
test wecom_kf_config::tests::test_deserialize_with_metadata ... ok
test validation::tests::test_wecom_valid_config_passes ... ok

test result: ok. 68 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.96s


running 24 tests
test attachment_validator::tests::test_validate_attachment_count_success ... ok
test attachment_validator::tests::test_validate_attachment_count_exceeded ... ok
test attachment_validator::tests::test_validate_attachment_count_zero_limit ... ok
test attachment_validator::tests::test_validate_outbound_attachments_count_exceeded ... ok
test attachment_validator::tests::test_validate_outbound_file_disabled ... ok
test attachment_validator::tests::test_validate_outbound_file_empty_allowed_extensions ... ok
test attachment_validator::tests::test_validate_outbound_attachments_success ... ok
test attachment_validator::tests::test_validate_outbound_file_extension_not_allowed ... ok
test attachment_validator::tests::test_validate_outbound_file_extension_without_dot ... ok
test attachment_validator::tests::test_validate_outbound_file_no_extension ... ok
test attachment_validator::tests::test_validate_outbound_file_success ... ok
test helpers::tests::test_extract_domain ... ok
test attachment_validator::tests::test_validate_outbound_file_too_large ... ok
test helpers::tests::test_parse_file_size_gb ... ok
test helpers::tests::test_parse_file_size_bytes ... ok
test helpers::tests::test_parse_file_size_invalid ... ok
test helpers::tests::test_parse_file_size_kb ... ok
test helpers::tests::test_sanitize_for_filesystem ... ok
test helpers::tests::test_truncate_str_ascii ... ok
test helpers::tests::test_truncate_str_boundary ... ok
test helpers::tests::test_truncate_str_multibyte ... ok
test helpers::tests::test_validate_regex_invalid ... ok
test helpers::tests::test_parse_file_size_mb ... ok
test helpers::tests::test_validate_regex_valid ... ok

test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s)
- Clippy clean ()
- The  has pre-existing type issues unrelated to this change.

### Documentation

-  records the full design and implementation plan.

### Related

Closes #338