### PR TITLE
feat: colorize edit diff and multi-line write display in AI progress

### DIFF
--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -1549,6 +1549,38 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &mut App) {
                         out.push(format!("  +{line}"));
                     }
                     out
+                } else if let Ok(json) = serde_json::from_str::<serde_json::Value>(&a.text)
+                    && json.get("type").and_then(|t| t.as_str()) == Some("write")
+                {
+                    let file_path = json
+                        .get("file_path")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("?");
+                    let content = json.get("content").and_then(|v| v.as_str()).unwrap_or("");
+                    let mut out = Vec::new();
+                    // Header line
+                    if is_last {
+                        if elapsed.is_empty() {
+                            out.push(format!("⏳ {file_path}"));
+                        } else {
+                            out.push(format!("⏳ {file_path} {elapsed}"));
+                        }
+                    } else {
+                        out.push(format!("   {file_path}"));
+                    }
+                    // Content lines (truncated to avoid flooding the pane)
+                    let content_lines: Vec<&str> = content.split('\n').collect();
+                    let max_lines = 20;
+                    for line in content_lines.iter().take(max_lines) {
+                        out.push(format!("  +{line}"));
+                    }
+                    if content_lines.len() > max_lines {
+                        out.push(format!(
+                            "  … ({} more lines)",
+                            content_lines.len() - max_lines
+                        ));
+                    }
+                    out
                 } else {
                     // Plain text — split by newlines for display
                     let lines: Vec<&str> = a.text.split('\n').collect();
@@ -1571,9 +1603,14 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &mut App) {
                 };
 
                 for label in rendered_lines {
+                    let label_style = if label.starts_with("  -") {
+                        Style::default().fg(Color::DarkGray)
+                    } else {
+                        style
+                    };
                     all_lines.push(Line::from(vec![
                         Span::raw("  "),
-                        Span::styled(label, style),
+                        Span::styled(label, label_style),
                     ]));
                 }
             }

--- a/crates/jyc-inspect/src/server.rs
+++ b/crates/jyc-inspect/src/server.rs
@@ -826,6 +826,26 @@ fn event_to_activity(event: &ThreadEvent) -> ActivityEntry {
                     "new_string": new_str,
                 })
                 .to_string()
+            } else if tool_name == "write" {
+                // Store write data as JSON for multi-line rendering in AI progress.
+                let parsed: Option<serde_json::Value> =
+                    input.as_deref().and_then(|s| serde_json::from_str(s).ok());
+                let file_path = parsed
+                    .as_ref()
+                    .and_then(|v| v.get("file_path"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("?");
+                let content = parsed
+                    .as_ref()
+                    .and_then(|v| v.get("content"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                serde_json::json!({
+                    "type": "write",
+                    "file_path": file_path,
+                    "content": content,
+                })
+                .to_string()
             } else {
                 match input {
                     Some(inp) => format!("Tool: {tool_name} — {inp}"),
@@ -879,6 +899,27 @@ fn event_to_activity(event: &ThreadEvent) -> ActivityEntry {
                         "line_no": line_no,
                         "old_string": old_str,
                         "new_string": new_str,
+                        "duration_secs": duration_secs,
+                    })
+                    .to_string()
+                } else if tool_name == "write" {
+                    // Store write data as JSON for multi-line rendering in AI progress.
+                    let parsed: Option<serde_json::Value> =
+                        input.as_deref().and_then(|s| serde_json::from_str(s).ok());
+                    let file_path = parsed
+                        .as_ref()
+                        .and_then(|v| v.get("file_path"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("?");
+                    let content = parsed
+                        .as_ref()
+                        .and_then(|v| v.get("content"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    serde_json::json!({
+                        "type": "write",
+                        "file_path": file_path,
+                        "content": content,
                         "duration_secs": duration_secs,
                     })
                     .to_string()


### PR DESCRIPTION
## Changes

### 1. Edit diff 分色 (dashboard.rs)
- AI progress 中 edit 的 old string 行（`-` 前缀）显示为灰色（`Color::DarkGray`，无斜体）
- new string 行（`+` 前缀）保持原有黄色 + 斜体样式不变

### 2. Write tool 多行显示 (server.rs + dashboard.rs)
- **server.rs**: ToolStarted 和 ToolCompleted 新增 `write` 分支，将 `file_path` + `content` 存为 JSON（与 edit 同模式），供 dashboard 解析渲染
- **dashboard.rs**: AI progress 解析 write JSON，多行显示内容（`+` 前缀），超 20 行截断显示 `… (N more lines)`
- activity pane 保持原样不变

## Files Changed
- `crates/jyc-cli/src/cli/dashboard.rs` — 渲染逻辑（分色 + write 多行）
- `crates/jyc-inspect/src/server.rs` — write 事件 JSON 化

## Checklist
- [x] `cargo fmt --check` ✅
- [x] `cargo clippy --workspace -- -D warnings` ✅