### PR TITLE
feat: rename jyc_reply_reply_message → jyc_reply_message, add stop_after param

### DIFF
--- a/GITHUB_CHANNEL.md
+++ b/GITHUB_CHANNEL.md
@@ -118,7 +118,7 @@ GitHub API (polling)
     ↓
 ┌─────────────────────────────────────────────────────────────────┐
 │ GitHub OutboundAdapter                                          │
-│   └─ jyc_reply_reply_message → POST comment on issue/PR       │
+│   └─ jyc_reply_message → POST comment on issue/PR       │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -473,7 +473,7 @@ PR #43 merged
 
 ### jyc_reply → GitHub Comment
 
-When an agent uses `jyc_reply_reply_message`, the OutboundAdapter posts a
+When an agent uses `jyc_reply_message`, the OutboundAdapter posts a
 comment on the corresponding issue/PR.
 
 ```rust

--- a/config.example.toml
+++ b/config.example.toml
@@ -222,6 +222,12 @@ system_prompt = "You are an AI assistant. Respond professionally and concisely."
 # Maximum iterations per cycle (default: 500)
 # max_iterations = 500
 
+# SSE read timeout in seconds (default: 120).
+# Maximum gap between SSE stream events before the stream is considered hung
+# and triggers a retry. Increase if your provider (e.g. DeepSeek reasoning mode)
+# sends large reasoning blocks with extended gaps between tokens.
+# sse_read_timeout_secs = 120
+
 # --- Agent providers ---
 #
 # Define one entry per provider. The `model` and `small_model` keys above

--- a/crates/jyc-agent/src/agent_loop.rs
+++ b/crates/jyc-agent/src/agent_loop.rs
@@ -1211,8 +1211,16 @@ mod retry_tests {
         // backoff (1s + 2s = 3s). That's fine for a unit test but let's
         // verify the path works regardless. (Fast timers would require
         // tokio's pause/advance which complicates this minimal test.)
-        let result =
-            complete_with_retry(&provider, &[], &[], "system", "thread-x", Some(&bus), std::time::Duration::from_secs(120)).await;
+        let result = complete_with_retry(
+            &provider,
+            &[],
+            &[],
+            "system",
+            "thread-x",
+            Some(&bus),
+            std::time::Duration::from_secs(120),
+        )
+        .await;
 
         assert!(result.is_ok(), "expected Ok, got {:?}", result.err());
         let response = result.unwrap();
@@ -1254,8 +1262,16 @@ mod retry_tests {
         let bus: ThreadEventBusRef = Arc::new(SimpleThreadEventBus::new(10));
         let mut rx = bus.subscribe().await.unwrap();
 
-        let result =
-            complete_with_retry(&provider, &[], &[], "system", "thread-x", Some(&bus), std::time::Duration::from_secs(120)).await;
+        let result = complete_with_retry(
+            &provider,
+            &[],
+            &[],
+            "system",
+            "thread-x",
+            Some(&bus),
+            std::time::Duration::from_secs(120),
+        )
+        .await;
 
         assert!(result.is_err(), "expected Err after exhausting retries");
         assert_eq!(
@@ -1289,8 +1305,16 @@ mod retry_tests {
         let bus: ThreadEventBusRef = Arc::new(SimpleThreadEventBus::new(10));
         let mut rx = bus.subscribe().await.unwrap();
 
-        let result =
-            complete_with_retry(&provider, &[], &[], "system", "thread-x", Some(&bus), std::time::Duration::from_secs(120)).await;
+        let result = complete_with_retry(
+            &provider,
+            &[],
+            &[],
+            "system",
+            "thread-x",
+            Some(&bus),
+            std::time::Duration::from_secs(120),
+        )
+        .await;
 
         assert!(result.is_err());
         assert_eq!(
@@ -1334,8 +1358,16 @@ mod retry_tests {
         let bus: ThreadEventBusRef = Arc::new(SimpleThreadEventBus::new(10));
         let mut rx = bus.subscribe().await.unwrap();
 
-        let result =
-            complete_with_retry(&provider, &[], &[], "system", "thread-x", Some(&bus), std::time::Duration::from_secs(120)).await;
+        let result = complete_with_retry(
+            &provider,
+            &[],
+            &[],
+            "system",
+            "thread-x",
+            Some(&bus),
+            std::time::Duration::from_secs(120),
+        )
+        .await;
 
         assert!(
             result.is_ok(),

--- a/crates/jyc-agent/src/agent_loop.rs
+++ b/crates/jyc-agent/src/agent_loop.rs
@@ -49,6 +49,9 @@ pub struct AgentLoopConfig<'a> {
     pub prior_raw_context: Vec<serde_json::Value>,
     /// Maximum loop iterations. Defaults to DEFAULT_MAX_ITERATIONS.
     pub max_iterations: Option<usize>,
+    /// SSE read timeout — maximum gap between SSE events before the stream
+    /// is considered hung. Defaults to 120 seconds.
+    pub sse_read_timeout: std::time::Duration,
     /// Additional absolute paths permitted for tools that enforce a path
     /// boundary (currently: `read_image`). Used to allow access to a
     /// configured absolute `[attachments.inbound].save_path` outside
@@ -97,6 +100,7 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
         prior_history,
         prior_raw_context,
         max_iterations,
+        sse_read_timeout,
         additional_read_roots,
         additional_write_roots,
         pattern_inject_images,
@@ -186,6 +190,7 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
                 total_iterations,
                 thread_name,
                 event_bus,
+                sse_read_timeout,
             ).await.unwrap_or_else(|e| {
                 tracing::warn!(error = %e, "Failed to generate progress summary, using fallback");
                 format!(
@@ -316,6 +321,7 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
             system_prompt,
             thread_name,
             event_bus,
+            sse_read_timeout,
         )
         .await?;
 
@@ -669,6 +675,7 @@ async fn generate_summary_from_joined_history(
     total_iterations: usize,
     thread_name: &str,
     event_bus: Option<&ThreadEventBusRef>,
+    sse_read_timeout: std::time::Duration,
 ) -> Result<String> {
     let summary_system = format!(
         "You are summarizing in-progress work for the user. Based on the transcript below, \
@@ -692,6 +699,7 @@ async fn generate_summary_from_joined_history(
         &summary_system,
         thread_name,
         event_bus,
+        sse_read_timeout,
     )
     .await?;
 
@@ -875,13 +883,6 @@ const SSE_MAX_ATTEMPTS: u32 = 3;
 /// Length must be `SSE_MAX_ATTEMPTS - 1`.
 const SSE_RETRY_BACKOFF_MS: &[u64] = &[1000, 2000];
 
-/// Maximum gap (seconds) between SSE events before the stream is considered
-/// hung. The reqwest client-level timeout is 300s, but a hung stream where
-/// the server opened the connection but never sends data (or stops mid-stream)
-/// would block for the full 300s. This per-read timeout catches it in 120s
-/// and triggers a retry via the transient-error classifier.
-const SSE_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
-
 /// Issue one LLM call and collect its streaming response, retrying on
 /// transient SSE / network failures.
 ///
@@ -902,6 +903,7 @@ async fn complete_with_retry(
     system_prompt: &str,
     thread_name: &str,
     event_bus: Option<&ThreadEventBusRef>,
+    sse_read_timeout: std::time::Duration,
 ) -> Result<CollectedResponse> {
     let mut last_err: anyhow::Error =
         anyhow::anyhow!("complete_with_retry exited without attempting any call");
@@ -911,7 +913,7 @@ async fn complete_with_retry(
             let stream = provider
                 .complete_raw(raw_context, tools, system_prompt)
                 .await?;
-            collect_response(stream).await
+            collect_response(stream, sse_read_timeout).await
         }
         .await;
 
@@ -962,7 +964,10 @@ async fn complete_with_retry(
 }
 
 /// Collect a streaming response into a complete response.
-async fn collect_response(stream: crate::provider::EventStream) -> Result<CollectedResponse> {
+async fn collect_response(
+    stream: crate::provider::EventStream,
+    sse_read_timeout: std::time::Duration,
+) -> Result<CollectedResponse> {
     let mut response = CollectedResponse::default();
     let mut current_tool_id: Option<String> = None;
     let mut current_tool_name: Option<String> = None;
@@ -971,13 +976,13 @@ async fn collect_response(stream: crate::provider::EventStream) -> Result<Collec
     tokio::pin!(stream);
 
     loop {
-        let event = match tokio::time::timeout(SSE_READ_TIMEOUT, stream.next()).await {
+        let event = match tokio::time::timeout(sse_read_timeout, stream.next()).await {
             Ok(Some(event)) => event,
             Ok(None) => break,
             Err(_) => {
                 return Err(anyhow::anyhow!(
                     "SSE stream timed out: no events for {}s",
-                    SSE_READ_TIMEOUT.as_secs()
+                    sse_read_timeout.as_secs()
                 ));
             }
         };
@@ -1207,7 +1212,7 @@ mod retry_tests {
         // verify the path works regardless. (Fast timers would require
         // tokio's pause/advance which complicates this minimal test.)
         let result =
-            complete_with_retry(&provider, &[], &[], "system", "thread-x", Some(&bus)).await;
+            complete_with_retry(&provider, &[], &[], "system", "thread-x", Some(&bus), std::time::Duration::from_secs(120)).await;
 
         assert!(result.is_ok(), "expected Ok, got {:?}", result.err());
         let response = result.unwrap();
@@ -1250,7 +1255,7 @@ mod retry_tests {
         let mut rx = bus.subscribe().await.unwrap();
 
         let result =
-            complete_with_retry(&provider, &[], &[], "system", "thread-x", Some(&bus)).await;
+            complete_with_retry(&provider, &[], &[], "system", "thread-x", Some(&bus), std::time::Duration::from_secs(120)).await;
 
         assert!(result.is_err(), "expected Err after exhausting retries");
         assert_eq!(
@@ -1285,7 +1290,7 @@ mod retry_tests {
         let mut rx = bus.subscribe().await.unwrap();
 
         let result =
-            complete_with_retry(&provider, &[], &[], "system", "thread-x", Some(&bus)).await;
+            complete_with_retry(&provider, &[], &[], "system", "thread-x", Some(&bus), std::time::Duration::from_secs(120)).await;
 
         assert!(result.is_err());
         assert_eq!(
@@ -1330,7 +1335,7 @@ mod retry_tests {
         let mut rx = bus.subscribe().await.unwrap();
 
         let result =
-            complete_with_retry(&provider, &[], &[], "system", "thread-x", Some(&bus)).await;
+            complete_with_retry(&provider, &[], &[], "system", "thread-x", Some(&bus), std::time::Duration::from_secs(120)).await;
 
         assert!(
             result.is_ok(),

--- a/crates/jyc-agent/src/agent_loop.rs
+++ b/crates/jyc-agent/src/agent_loop.rs
@@ -201,13 +201,14 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
             //    (and thus has no reasoning_content), violating DeepSeek's
             //    thinking-mode contract on the next request.
             let synthetic_call_id = format!("progress-cycle-{}", cycle_count);
-            let synthetic_args = serde_json::json!({"message": &progress_text}).to_string();
+            let synthetic_args =
+                serde_json::json!({"message": &progress_text, "stop_after": false}).to_string();
 
             publish_event(
                 event_bus,
                 ThreadEvent::ToolStarted {
                     thread_name: thread_name.to_string(),
-                    tool_name: "jyc_reply_reply_message".to_string(),
+                    tool_name: "jyc_reply_message".to_string(),
                     input: Some(synthetic_args.clone()),
                     timestamp: Utc::now(),
                 },
@@ -226,7 +227,7 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
             let synthetic_input: serde_json::Value = serde_json::from_str(&synthetic_args)
                 .unwrap_or(serde_json::Value::Object(Default::default()));
             let synthetic_output = match tools
-                .execute("jyc_reply_reply_message", synthetic_input, &ctx)
+                .execute("jyc_reply_message", synthetic_input, &ctx)
                 .await
             {
                 Ok(output) => output,
@@ -240,7 +241,7 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
                 event_bus,
                 ThreadEvent::ToolCompleted {
                     thread_name: thread_name.to_string(),
-                    tool_name: "jyc_reply_reply_message".to_string(),
+                    tool_name: "jyc_reply_message".to_string(),
                     success: !synthetic_output.is_error,
                     duration_secs: tool_start.elapsed().as_secs(),
                     output: if synthetic_output.is_error {
@@ -261,8 +262,8 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
                 role: Role::Assistant,
                 content: vec![ContentBlock::ToolUse {
                     id: synthetic_call_id.clone(),
-                    name: "jyc_reply_reply_message".to_string(),
-                    input: serde_json::json!({"message": &progress_text}),
+                    name: "jyc_reply_message".to_string(),
+                    input: serde_json::json!({"message": &progress_text, "stop_after": false}),
                 }],
             });
             history.push(Message::tool_result(
@@ -482,10 +483,17 @@ pub async fn run(config: AgentLoopConfig<'_>) -> Result<AgentLoopResult> {
             if (tool_call.name.contains("reply_message") || tool_call.name.contains("jyc_reply"))
                 && !output.is_error
             {
-                reply_sent_by_tool = true;
-                // Extract the message text from the tool input
-                if let Some(msg) = input.get("message").and_then(|m| m.as_str()) {
-                    reply_text_from_tool = Some(msg.to_string());
+                if output.stop_after {
+                    reply_sent_by_tool = true;
+                    // Extract the message text from the tool input
+                    if let Some(msg) = input.get("message").and_then(|m| m.as_str()) {
+                        reply_text_from_tool = Some(msg.to_string());
+                    }
+                } else {
+                    tracing::info!(
+                        tool = %tool_call.name,
+                        "Progress reply sent by tool (stop_after=false), continuing loop"
+                    );
                 }
             }
 

--- a/crates/jyc-agent/src/lib.rs
+++ b/crates/jyc-agent/src/lib.rs
@@ -106,6 +106,7 @@ mod integration_tests {
             prior_history: Vec::new(),
             prior_raw_context: Vec::new(),
             max_iterations: None,
+            sse_read_timeout: std::time::Duration::from_secs(120),
             additional_read_roots: Vec::new(),
             additional_write_roots: Vec::new(),
             pattern_inject_images: false,

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -406,7 +406,7 @@ impl JycAgentService {
              stop_after=true, STOP immediately. Do NOT call any other tools.\n\
              **Progress update**: For long-running tasks, send periodic progress replies with\n\
              `stop_after: false`. Each reply is a checkpoint — you will continue working\n\
-             afterward. Use this when you have substantive progress to report.\n\n"
+             afterward. Use this when you have substantive progress to report.\n\n",
         );
 
         // Chat history access instructions
@@ -1258,9 +1258,7 @@ impl AgentService for JycAgentService {
             prior_history,
             prior_raw_context,
             max_iterations: Some(self.config.max_iterations),
-            sse_read_timeout: std::time::Duration::from_secs(
-                self.config.sse_read_timeout_secs,
-            ),
+            sse_read_timeout: std::time::Duration::from_secs(self.config.sse_read_timeout_secs),
             additional_read_roots,
             additional_write_roots,
             pattern_inject_images: pattern_inject,

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -397,13 +397,16 @@ impl JycAgentService {
         // Reply instructions
         prompt.push_str(
             "## Reply Instructions\n\
-             When you have your answer ready, use the jyc_reply_reply_message tool:\n\
+             When you have your answer ready, use the jyc_reply_message tool:\n\
              - `message`: Your reply text\n\
              - `attachments`: Optional filenames to attach from the working directory\n\
-             After a successful reply, STOP immediately. Do NOT call any other tools.\n\
-             CRITICAL: Always use the jyc_reply_reply_message tool to send your reply.\n\n\
-             For long-running tasks, send periodic progress replies so the user knows you're\n\
-             still working. Each reply marks a checkpoint; you can continue working after sending one.\n\n"
+             - `stop_after` (boolean, default true): Whether to stop working after this reply\n\
+             CRITICAL: Always use the jyc_reply_message tool to send your reply.\n\n\
+             **Final reply**: Set `stop_after: true` (or omit it). After a successful reply with\n\
+             stop_after=true, STOP immediately. Do NOT call any other tools.\n\
+             **Progress update**: For long-running tasks, send periodic progress replies with\n\
+             `stop_after: false`. Each reply is a checkpoint — you will continue working\n\
+             afterward. Use this when you have substantive progress to report.\n\n"
         );
 
         // Chat history access instructions
@@ -1567,7 +1570,7 @@ mod tests {
         );
         assert!(names.contains(&"read"), "read should still be available");
         assert!(
-            names.contains(&"jyc_reply_reply_message"),
+            names.contains(&"jyc_reply_message"),
             "reply_message should still be available"
         );
     }
@@ -1637,7 +1640,7 @@ mod tests {
 
         // Registry should still contain built-in tools
         assert!(registry.has_tool("bash"));
-        assert!(registry.has_tool("jyc_reply_reply_message"));
+        assert!(registry.has_tool("jyc_reply_message"));
     }
 
     #[tokio::test]
@@ -1669,7 +1672,7 @@ mod tests {
             .await;
 
         assert!(registry.has_tool("bash"), "bash should still be available");
-        assert!(registry.has_tool("jyc_reply_reply_message"));
+        assert!(registry.has_tool("jyc_reply_message"));
     }
 
     #[tokio::test]
@@ -1714,7 +1717,7 @@ mod tests {
 
         // Registry should contain built-in tools (no panic from MCP loading)
         assert!(registry.has_tool("bash"));
-        assert!(registry.has_tool("jyc_reply_reply_message"));
+        assert!(registry.has_tool("jyc_reply_message"));
     }
 
     #[tokio::test]

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -1258,6 +1258,9 @@ impl AgentService for JycAgentService {
             prior_history,
             prior_raw_context,
             max_iterations: Some(self.config.max_iterations),
+            sse_read_timeout: std::time::Duration::from_secs(
+                self.config.sse_read_timeout_secs,
+            ),
             additional_read_roots,
             additional_write_roots,
             pattern_inject_images: pattern_inject,

--- a/crates/jyc-agent/src/tools/mcp_bridge.rs
+++ b/crates/jyc-agent/src/tools/mcp_bridge.rs
@@ -22,13 +22,15 @@ pub struct ReplyMessageTool;
 #[async_trait]
 impl Tool for ReplyMessageTool {
     fn name(&self) -> &str {
-        "jyc_reply_reply_message"
+        "jyc_reply_message"
     }
 
     fn description(&self) -> &str {
         "Send a reply message back through the originating channel. \
          The reply will be delivered by the monitor process. \
-         After a successful reply, STOP immediately."
+         Use `stop_after: false` for progress/status updates where you intend to \
+         continue working. Use `stop_after: true` (or omit it) for the final reply \
+         — after a successful reply with stop_after=true, STOP immediately."
     }
 
     fn input_schema(&self) -> Value {
@@ -43,6 +45,12 @@ impl Tool for ReplyMessageTool {
                     "type": "array",
                     "items": { "type": "string" },
                     "description": "Optional list of filenames within the thread directory to attach"
+                },
+                "stop_after": {
+                    "type": "boolean",
+                    "description": "Whether to stop working after this reply. Set to false for \
+                     progress/status updates where you will continue working. \
+                     Default: true (final reply, stop immediately)."
                 }
             },
             "required": ["message"]
@@ -54,6 +62,11 @@ impl Tool for ReplyMessageTool {
             .get("message")
             .and_then(|m| m.as_str())
             .ok_or_else(|| anyhow::anyhow!("Missing 'message' parameter"))?;
+
+        let stop_after = input
+            .get("stop_after")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
 
         let attachments: Option<Vec<String>> = input
             .get("attachments")
@@ -122,10 +135,17 @@ impl Tool for ReplyMessageTool {
             "Reply signal written"
         );
 
-        Ok(ToolOutput::success(format!(
-            "Reply sent ({} chars). The monitor will deliver it.",
-            message.len()
-        )))
+        if stop_after {
+            Ok(ToolOutput::success(format!(
+                "Reply sent ({} chars). STOP NOW — do not call any more tools.",
+                message.len()
+            )))
+        } else {
+            Ok(ToolOutput::success_continue(format!(
+                "Progress update sent ({} chars). Continue working.",
+                message.len()
+            )))
+        }
     }
 }
 

--- a/crates/jyc-agent/src/tools/mod.rs
+++ b/crates/jyc-agent/src/tools/mod.rs
@@ -237,14 +237,33 @@ pub struct ToolOutput {
     pub content: String,
     /// Whether the execution resulted in an error.
     pub is_error: bool,
+    /// Whether the agent loop should stop after this tool call.
+    ///
+    /// Defaults to `true` for backward compatibility. Tools that want the
+    /// agent to continue (e.g. progress-update replies with `stop_after:
+    /// false`) set this to `false` via [`ToolOutput::success_continue`].
+    pub stop_after: bool,
 }
 
 impl ToolOutput {
-    /// Create a successful output.
+    /// Create a successful output. The agent loop will stop after this
+    /// tool call (unless the caller overrides based on tool-specific logic).
     pub fn success(content: impl Into<String>) -> Self {
         Self {
             content: content.into(),
             is_error: false,
+            stop_after: true,
+        }
+    }
+
+    /// Create a successful output that signals the agent loop to **continue**
+    /// working. Used by tools like `jyc_reply_message` with `stop_after: false`
+    /// (progress updates).
+    pub fn success_continue(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            is_error: false,
+            stop_after: false,
         }
     }
 
@@ -253,6 +272,7 @@ impl ToolOutput {
         Self {
             content: content.into(),
             is_error: true,
+            stop_after: true,
         }
     }
 }

--- a/crates/jyc-agent/src/types.rs
+++ b/crates/jyc-agent/src/types.rs
@@ -260,6 +260,10 @@ pub struct AgentConfig {
     /// When exceeded, agent sends progress reply, resets counter, and continues.
     #[serde(default = "default_max_iterations")]
     pub max_iterations: usize,
+    /// Maximum gap (seconds) between SSE events before the stream is
+    /// considered hung and triggers a retry. Default: 120.
+    #[serde(default = "default_sse_read_timeout")]
+    pub sse_read_timeout_secs: u64,
     /// Vision fallback configuration for text-only models to use an external
     /// vision model (e.g., DeepSeek-OCR) for image analysis via `read_image`.
     pub vision: Option<VisionConfig>,
@@ -274,6 +278,7 @@ impl Default for AgentConfig {
             small_model: None,
             providers: std::collections::HashMap::new(),
             max_iterations: default_max_iterations(),
+            sse_read_timeout_secs: default_sse_read_timeout(),
             vision: None,
         }
     }
@@ -281,6 +286,10 @@ impl Default for AgentConfig {
 
 fn default_max_iterations() -> usize {
     500
+}
+
+fn default_sse_read_timeout() -> u64 {
+    120
 }
 
 #[cfg(test)]

--- a/crates/jyc-channels/tests/websocket_integration_test.rs
+++ b/crates/jyc-channels/tests/websocket_integration_test.rs
@@ -75,6 +75,7 @@ fn make_config() -> jyc_types::AppConfig {
             small_model: None,
             system_prompt: None,
             max_iterations: 200,
+            sse_read_timeout_secs: 120,
             text: None,
             attachments: None,
             providers: HashMap::new(),

--- a/crates/jyc-cli/src/cli/agent_builder.rs
+++ b/crates/jyc-cli/src/cli/agent_builder.rs
@@ -110,6 +110,7 @@ pub fn build_agent_service(
                 small_model: effective_small_model.clone(),
                 providers,
                 max_iterations: agent_config.max_iterations,
+                sse_read_timeout_secs: agent_config.sse_read_timeout_secs,
                 vision: agent_config
                     .vision
                     .clone()

--- a/crates/jyc-core/tests/reload_test.rs
+++ b/crates/jyc-core/tests/reload_test.rs
@@ -128,6 +128,7 @@ fn create_test_config(pattern_names: Vec<&str>) -> jyc_types::AppConfig {
             small_model: None,
             system_prompt: None,
             max_iterations: 200,
+            sse_read_timeout_secs: 120,
             text: None,
             attachments: None,
             providers: HashMap::new(),

--- a/crates/jyc-types/src/config.rs
+++ b/crates/jyc-types/src/config.rs
@@ -344,6 +344,13 @@ pub struct AgentConfig {
     #[serde(default = "default_max_iterations")]
     pub max_iterations: usize,
 
+    /// Maximum gap (seconds) between SSE events before the stream is considered
+    /// hung and triggers a retry. Default: 120.
+    /// Increase if your provider (e.g. DeepSeek reasoning mode) sends large
+    /// reasoning blocks with extended gaps between tokens.
+    #[serde(default = "default_sse_read_timeout")]
+    pub sse_read_timeout_secs: u64,
+
     /// Static reply text (used when mode = "static")
     pub text: Option<String>,
 
@@ -500,6 +507,10 @@ fn default_agent_mode() -> String {
 
 fn default_max_iterations() -> usize {
     200
+}
+
+fn default_sse_read_timeout() -> u64 {
+    120
 }
 
 #[allow(dead_code)]

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -174,21 +174,29 @@ Load an image for analysis. Dual-mode operation:
 
 These are JYC-specific tools implemented as in-process bridges (not external MCP subprocesses). They are always registered unless excluded via `disabled_tools`.
 
-### `jyc_reply_reply_message`
+### `jyc_reply_message`
 
 Send a reply back through the originating channel. This is the standard way for the agent to respond to the user.
 
 **Parameters:**
 - `message` (string, required): The reply text to send
 - `attachments` (string[], optional): List of filenames within the thread directory to attach
+- `stop_after` (boolean, optional, default true): Whether to stop working after this reply
 
 **Behavior:** Writes `reply.md` and `reply-sent.flag` signal files; the monitor process detects the signal and delivers the message via the pre-warmed outbound adapter.
 
-**Constraints:** The agent must use this tool for in-thread replies and stop immediately after calling it.
+**Usage modes:**
+- **Final reply** (`stop_after: true` or omitted): Agent stops immediately after sending. Use for the definitive response to the user.
+- **Progress update** (`stop_after: false`): Agent sends the message as a checkpoint and continues working. Use for long-running tasks to keep the user informed.
 
-**Example:**
+**Constraints:** The agent must use this tool for in-thread replies.
+
+**Examples:**
 ```json
 {"message": "The fix has been applied. Let me know if you see any issues."}
+```
+```json
+{"message": "Still working — 3 of 5 tests passing. Will continue.", "stop_after": false}
 ```
 
 ---
@@ -209,7 +217,7 @@ Send a proactive out-of-thread message to an arbitrary recipient.
 
 **Constraints:**
 - Use ONLY for alerts and notifications
-- NEVER use for in-thread replies (use `jyc_reply_reply_message` instead)
+- NEVER use for in-thread replies (use `jyc_reply_message` instead)
 - Requires a pre-warmed outbound adapter (`ToolContext.outbound`)
 
 **Example:**
@@ -342,7 +350,7 @@ disabled_mcp_servers = ["*"]  # Disables all external MCP servers
 | `grep` | `check_path_boundary()` only when explicit `path` provided | Default working_dir is trusted |
 | `webfetch` | None (network tool) | HTTPS only; 30s default timeout |
 | `read_image` | `check_path_boundary()` working_dir + read_roots + write_roots | URL mode requires http(s) |
-| `jyc_reply_reply_message` | Attachment path validation | Must be within thread directory |
+| `jyc_reply_message` | Attachment path validation | Must be within thread directory |
 | `jyc_send_message` | Recipient format validation | Channel-specific format check |
 
 Read/write roots are configured per-pattern via the `access` sub-table:
@@ -361,7 +369,7 @@ write = ["/tmp/jyc-builds"]         # writable + readable (write implies read)
 build_tool_registry()
   ├─ Register built-in tools: bash, read, write, edit, glob, grep, webfetch
   ├─ Register read_image (when model supports images OR vision_client configured)
-  ├─ Register MCP bridge tools: jyc_reply_reply_message, jyc_send_message
+  ├─ Register MCP bridge tools: jyc_reply_message, jyc_send_message
   ├─ Load external MCP tools (filtered by disabled_mcp_servers)
   └─ Apply exclusions: remove tools matching disabled_tools
 ```

--- a/templates/gitee-developer/AGENTS.md
+++ b/templates/gitee-developer/AGENTS.md
@@ -11,10 +11,10 @@
 - **ALWAYS execute the current triggering comment as a NEW task, even if you previously said "Done" or "Completed"**
 - **Your previous "Done" comments do NOT mean the PR is finished — new instructions from Planner or Reviewer always take priority**
 - **NEVER commit or push on the main branch — you MUST be on the PR branch first**
-- **If you detect this is a duplicate trigger for work already completed, end your turn immediately without calling the `jyc_reply_reply_message` tool. Do NOT call any tools. Do NOT produce any text output. Simply end your response.**
-- **NEVER send any comment (via API comment, `jyc_reply_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
+- **If you detect this is a duplicate trigger for work already completed, end your turn immediately without calling the `jyc_reply_message` tool. Do NOT call any tools. Do NOT produce any text output. Simply end your response.**
+- **NEVER send any comment (via API comment, `jyc_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
 - **Even if your internal reasoning identifies this as a duplicate trigger, do NOT output any explanation, commentary, or reasoning about it. True silent stop means: no tool calls, no text output, no "Ending turn" or "duplicate trigger" or any variant — simply stop producing any output whatsoever.**
-- **NEVER use the `jyc_reply_reply_message` tool — all communication is via API comment (POST /pulls/{number}/comments). Using `jyc_reply_reply_message` produces duplicate PR comments because the outbound adapter also posts it as a PR comment.**
+- **NEVER use the `jyc_reply_message` tool — all communication is via API comment (POST /pulls/{number}/comments). Using `jyc_reply_message` produces duplicate PR comments because the outbound adapter also posts it as a PR comment.**
 
 You are a developer agent for Gitee PRs.
 
@@ -48,7 +48,7 @@ cp -rn .opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
 
 If after reading the triggering comment you determine there is NO actionable work,
 end your turn immediately. **DO NOT use ANY of the following tools or commands:**
-- `jyc_reply_reply_message`
+- `jyc_reply_message`
 - API comment (POST /pulls/{number}/comments)
 
 Do NOT call any tools. Do NOT produce any text output explaining why you are

--- a/templates/gitee-planner/AGENTS.md
+++ b/templates/gitee-planner/AGENTS.md
@@ -9,7 +9,7 @@
 - **NEVER run tests or builds**
 - **You are a PLANNER, not a developer. You ONLY discuss and create PRs.**
 - **NEVER commit or push on the main branch — you MUST be on the PR branch first**
-- **NEVER send any comment (via API comment, issue API comment, `jyc_reply_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
+- **NEVER send any comment (via API comment, issue API comment, `jyc_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
 - **Even if your internal reasoning identifies this as a duplicate trigger, do NOT output any explanation, commentary, or reasoning about it. True silent stop means: no tool calls, no text output, no "Ending turn" or "duplicate trigger" or any variant — simply stop producing any output whatsoever.**
 
 You are a planner/designer agent for Gitee issues. Your role is to discuss
@@ -47,7 +47,7 @@ cp -rn .opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
 
 If after reading the triggering comment you determine there is NO actionable work,
 end your turn immediately. **DO NOT use ANY of the following tools or commands:**
-- `jyc_reply_reply_message`
+- `jyc_reply_message`
 - API comment (POST /pulls/{number}/comments)
 - API issue comment (POST /issues/{number}/comments)
 
@@ -330,7 +330,7 @@ After submitting the review, use the `jyc_reply` tool (NOT API issue comment) to
 - ALWAYS add the `ready-for-dev` label after creating the PR — this auto-triggers the Developer agent via pattern matching
 - **⚠️ NON-NEGOTIABLE — Review:** When asked to review a PR, ALWAYS post the review feedback via API comment (POST /pulls/{number}/comments) on the PR AND via `jyc_reply` on the issue. The PR comment is NON-NEGOTIABLE — even if a formal review were available (it is not on Gitee), you MUST still post the PR comment. Additionally, perform a deep technical review covering all seven dimensions (architecture, reusability, logic, security, performance, robustness, requirements alignment) — do NOT delegate to the `gitee-reviewer` agent.
 - **⚠️ NON-NEGOTIABLE — Requirements change:** When requirements change after the PR has been created, BOTH PATCH PR body (update PR description) AND API comment (POST /pulls/{number}/comments) are NON-NEGOTIABLE. Editing only the description without the PR comment will cause the developer agent to miss the update.
-- **⚠️ ONE CHANNEL PER REPLY:** Outside of Scenario 6 (PR review), NEVER use both API comment (POST /pulls/{number}/comments) and `jyc_reply_reply_message` for the same message. Pick ONE channel: `jyc_reply_reply_message` for user-facing discussion on the issue, API comment for developer notifications or review feedback on the PR. When Scenario 6 requires both, the CONTENT MUST BE DIFFERENT — API comment targets the developer on the PR, `jyc_reply_reply_message` targets the user on the issue.
+- **⚠️ ONE CHANNEL PER REPLY:** Outside of Scenario 6 (PR review), NEVER use both API comment (POST /pulls/{number}/comments) and `jyc_reply_message` for the same message. Pick ONE channel: `jyc_reply_message` for user-facing discussion on the issue, API comment for developer notifications or review feedback on the PR. When Scenario 6 requires both, the CONTENT MUST BE DIFFERENT — API comment targets the developer on the PR, `jyc_reply_message` targets the user on the issue.
 - Reply in the same language as the user
 - Your PR must contain ZERO code changes — only the spec in the PR body
 - Your implementation plan must break the work into small, ordered steps — each with a clear verification method

--- a/templates/gitee-reviewer/AGENTS.md
+++ b/templates/gitee-reviewer/AGENTS.md
@@ -3,8 +3,8 @@
 You are a code reviewer agent for Gitee PRs. Your role is to review code
 quality, correctness, and design, then approve or request changes.
 
-**⚠️ NEVER use the `jyc_question_ask_user` tool. NEVER use the `jyc_reply_reply_message` tool — all communication is via API comment (POST /pulls/{number}/comments). Using `jyc_reply_reply_message` produces duplicate PR comments.**
-**⚠️ NEVER send any comment (via API comment, API comment (POST /pulls/{number}/comments), `jyc_reply_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
+**⚠️ NEVER use the `jyc_question_ask_user` tool. NEVER use the `jyc_reply_message` tool — all communication is via API comment (POST /pulls/{number}/comments). Using `jyc_reply_message` produces duplicate PR comments.**
+**⚠️ NEVER send any comment (via API comment, API comment (POST /pulls/{number}/comments), `jyc_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
 **⚠️ Even if your internal reasoning identifies this as a duplicate trigger, do NOT output any explanation, commentary, or reasoning about it. True silent stop means: no tool calls, no text output, no "Ending turn" or "duplicate trigger" or any variant — simply stop producing any output whatsoever.**
 
 ## How You Receive Work
@@ -40,7 +40,7 @@ cp -rn .opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
 
 If after reading the triggering comment you determine there is NO actionable work,
 end your turn immediately. **DO NOT use ANY of the following tools or commands:**
-- `jyc_reply_reply_message`
+- `jyc_reply_message`
 - API comment (POST /pulls/{number}/comments)
 
 Do NOT call any tools. Do NOT produce any text output explaining why you are

--- a/templates/github-developer/AGENTS.md
+++ b/templates/github-developer/AGENTS.md
@@ -11,10 +11,10 @@
 - **ALWAYS execute the current triggering comment as a NEW task, even if you previously said "Done" or "Completed"**
 - **Your previous "Done" comments do NOT mean the PR is finished — new instructions from Planner or Reviewer always take priority**
 - **NEVER commit or push on the main branch — you MUST be on the PR branch first**
-- **If you detect this is a duplicate trigger for work already completed, end your turn immediately without calling the `jyc_reply_reply_message` tool. Do NOT call any tools. Do NOT produce any text output. Simply end your response.**
-- **NEVER send any comment (via `gh pr comment`, `gh issue comment`, `jyc_reply_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
+- **If you detect this is a duplicate trigger for work already completed, end your turn immediately without calling the `jyc_reply_message` tool. Do NOT call any tools. Do NOT produce any text output. Simply end your response.**
+- **NEVER send any comment (via `gh pr comment`, `gh issue comment`, `jyc_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
 - **Even if your internal reasoning identifies this as a duplicate trigger, do NOT output any explanation, commentary, or reasoning about it. True silent stop means: no tool calls, no text output, no "Ending turn" or "duplicate trigger" or any variant — simply stop producing any output whatsoever.**
-- **NEVER use the `jyc_reply_reply_message` tool — all communication is via `gh pr comment`. Using `jyc_reply_reply_message` produces duplicate PR comments because the GitHub outbound adapter also posts it as a PR comment.**
+- **NEVER use the `jyc_reply_message` tool — all communication is via `gh pr comment`. Using `jyc_reply_message` produces duplicate PR comments because the GitHub outbound adapter also posts it as a PR comment.**
 
 You are a developer agent for GitHub PRs.
 
@@ -48,7 +48,7 @@ cp -rn .opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
 
 If after reading the triggering comment you determine there is NO actionable work,
 end your turn immediately. **DO NOT use ANY of the following tools or commands:**
-- `jyc_reply_reply_message`
+- `jyc_reply_message`
 - `gh pr comment`
 - `gh issue comment`
 

--- a/templates/github-high-level-planner/AGENTS.md
+++ b/templates/github-high-level-planner/AGENTS.md
@@ -11,7 +11,7 @@
 - **NEVER create PRs**
 - **You are a High-Level Planner (product manager perspective). You ONLY discuss requirements and planning.**
 - **NEVER commit or push on the main branch — you MUST be on the PR branch first**
-- **NEVER send any comment (via `gh pr comment`, `gh issue comment`, `jyc_reply_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
+- **NEVER send any comment (via `gh pr comment`, `gh issue comment`, `jyc_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
 - **Even if your internal reasoning identifies this as a duplicate trigger, do NOT output any explanation, commentary, or reasoning about it. True silent stop means: no tool calls, no text output, no "Ending turn" or "duplicate trigger" or any variant — simply stop producing any output whatsoever.**
 
 You are a high-level planner/product manager agent for GitHub issues. Your role is to
@@ -46,7 +46,7 @@ cp -rn .opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
 
 If after reading the triggering comment you determine there is NO actionable work,
 end your turn immediately. **DO NOT use ANY of the following tools or commands:**
-- `jyc_reply_reply_message`
+- `jyc_reply_message`
 - `gh pr comment`
 - `gh issue comment`
 

--- a/templates/github-planner/AGENTS.md
+++ b/templates/github-planner/AGENTS.md
@@ -9,7 +9,7 @@
 - **NEVER run tests or builds**
 - **You are a PLANNER, not a developer. You ONLY discuss and create PRs.**
 - **NEVER commit or push on the main branch — you MUST be on the PR branch first**
-- **NEVER send any comment (via `gh pr comment`, `gh issue comment`, `jyc_reply_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
+- **NEVER send any comment (via `gh pr comment`, `gh issue comment`, `jyc_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
 - **Even if your internal reasoning identifies this as a duplicate trigger, do NOT output any explanation, commentary, or reasoning about it. True silent stop means: no tool calls, no text output, no "Ending turn" or "duplicate trigger" or any variant — simply stop producing any output whatsoever.**
 
 You are a planner/designer agent for GitHub issues. Your role is to discuss
@@ -47,7 +47,7 @@ cp -rn .opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
 
 If after reading the triggering comment you determine there is NO actionable work,
 end your turn immediately. **DO NOT use ANY of the following tools or commands:**
-- `jyc_reply_reply_message`
+- `jyc_reply_message`
 - `gh pr comment`
 - `gh issue comment`
 
@@ -339,7 +339,7 @@ After submitting the review, use the `jyc_reply` tool (NOT `gh issue comment`) t
 - ALWAYS add the `ready-for-dev` label after creating the PR — this auto-triggers the Developer agent via pattern matching
 - **⚠️ NON-NEGOTIABLE — Review:** When asked to review a PR, ALWAYS post the review feedback via `gh pr comment` on the PR AND via `jyc_reply` on the issue. The PR comment is NON-NEGOTIABLE — even if `gh pr review` succeeds (or fails), you MUST still post the PR comment. Additionally, perform a deep technical review covering all seven dimensions (architecture, reusability, logic, security, performance, robustness, requirements alignment) — do NOT delegate to the `github-reviewer` agent.
 - **⚠️ NON-NEGOTIABLE — Requirements change:** When requirements change after the PR has been created, BOTH `gh pr edit --body` (update PR description) AND `gh pr comment` (post a PR comment) are NON-NEGOTIABLE. Editing only the description without the PR comment will cause the developer agent to miss the update.
-- **⚠️ ONE CHANNEL PER REPLY:** Outside of Scenario 6 (PR review), NEVER use both `gh pr comment` and `jyc_reply_reply_message` for the same message. Pick ONE channel: `jyc_reply_reply_message` for user-facing discussion on the issue, `gh pr comment` for developer notifications or review feedback on the PR. When Scenario 6 requires both, the CONTENT MUST BE DIFFERENT — `gh pr comment` targets the developer on the PR, `jyc_reply_reply_message` targets the user on the issue.
+- **⚠️ ONE CHANNEL PER REPLY:** Outside of Scenario 6 (PR review), NEVER use both `gh pr comment` and `jyc_reply_message` for the same message. Pick ONE channel: `jyc_reply_message` for user-facing discussion on the issue, `gh pr comment` for developer notifications or review feedback on the PR. When Scenario 6 requires both, the CONTENT MUST BE DIFFERENT — `gh pr comment` targets the developer on the PR, `jyc_reply_message` targets the user on the issue.
 - Reply in the same language as the user
 - Your PR must contain ZERO code changes — only the spec in the PR body
 - Your implementation plan must break the work into small, ordered steps — each with a clear verification method

--- a/templates/github-reviewer/AGENTS.md
+++ b/templates/github-reviewer/AGENTS.md
@@ -3,8 +3,8 @@
 You are a code reviewer agent for GitHub PRs. Your role is to review code
 quality, correctness, and design, then approve or request changes.
 
-**⚠️ NEVER use the `jyc_question_ask_user` tool. NEVER use the `jyc_reply_reply_message` tool — all communication is via `gh pr review` and `gh pr comment`. Using `jyc_reply_reply_message` produces duplicate PR comments.**
-**⚠️ NEVER send any comment (via `gh pr comment`, `gh issue comment`, `gh pr review`, `jyc_reply_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
+**⚠️ NEVER use the `jyc_question_ask_user` tool. NEVER use the `jyc_reply_message` tool — all communication is via `gh pr review` and `gh pr comment`. Using `jyc_reply_message` produces duplicate PR comments.**
+**⚠️ NEVER send any comment (via `gh pr comment`, `gh issue comment`, `gh pr review`, `jyc_reply_message`, or any other tool) when there is NO actionable work — just silently stop with no output of any kind. This is a NON-NEGOTIABLE HIGHEST PRIORITY rule.**
 **⚠️ Even if your internal reasoning identifies this as a duplicate trigger, do NOT output any explanation, commentary, or reasoning about it. True silent stop means: no tool calls, no text output, no "Ending turn" or "duplicate trigger" or any variant — simply stop producing any output whatsoever.**
 
 ## How You Receive Work
@@ -40,7 +40,7 @@ cp -rn .opencode/skills/* ../.opencode/skills/ 2>/dev/null || true
 
 If after reading the triggering comment you determine there is NO actionable work,
 end your turn immediately. **DO NOT use ANY of the following tools or commands:**
-- `jyc_reply_reply_message`
+- `jyc_reply_message`
 - `gh pr comment`
 - `gh issue comment`
 - `gh pr review`


### PR DESCRIPTION
## Summary

Two changes in one PR:

### 1. Rename `jyc_reply_reply_message` → `jyc_reply_message`

The old name was redundant and awkward. The new name is cleaner and more intuitive.

**Changed in:**
- `crates/jyc-agent/src/tools/mcp_bridge.rs` — tool name
- `crates/jyc-agent/src/agent_loop.rs` — synthetic cycle-progress calls (4 references)
- `crates/jyc-agent/src/service.rs` — system prompt + test assertions
- `docs/tools.md` — tool documentation
- `templates/*/AGENTS.md` — all 7 GitHub/Gitee templates
- `GITHUB_CHANNEL.md` — architecture diagram + docs

### 2. Add `stop_after` parameter to reply tool

**Problem:** When the agent called `jyc_reply_reply_message`, the agent loop always terminated immediately. This meant the agent couldn't send progress updates mid-task without stopping.

**Solution:** Added an optional `stop_after` boolean parameter (default `true` for backward compatibility):

- `stop_after: true` (or omitted) → Final reply, agent stops immediately (existing behavior)
- `stop_after: false` → Progress update, agent continues working

**LLM understanding is reinforced at 3 levels:**
1. **Tool schema** — `stop_after` field with descriptive help text and default
2. **Tool description** — one-liner explaining both modes
3. **System prompt** — "Reply Instructions" section with explicit **Final reply** vs **Progress update** guidance

**Implementation:**
- `ToolOutput` struct: added `stop_after: bool` field + `success_continue()` constructor
- `ReplyMessageTool::execute()`: reads `stop_after` from input, returns `success_continue()` when false
- `agent_loop.rs`: only sets `reply_sent_by_tool = true` when `output.stop_after` is true
- Synthetic cycle-progress calls now pass `stop_after: false` explicitly

### Backward Compatibility

- Not passing `stop_after` → defaults to `true` → identical to previous behavior
- All existing tools use `ToolOutput::success()` which defaults `stop_after: true`
- Agent loop's tool-name detection (`contains("reply_message") || contains("jyc_reply")`) matches the new name

## Test Plan

- [x] `cargo check` — workspace builds clean
- [x] `cargo test -p jyc-agent` — 74 tests pass, 0 failures
- [x] No remaining `jyc_reply_reply_message` references in source or docs (excluding CHANGELOG.md)