### PR TITLE
feat: chat pane separator line and duration display fix

### DIFF
--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -1561,7 +1561,9 @@ fn render_chat_conversation(frame: &mut Frame, area: Rect, app: &mut App) {
 
         // Separator line between user and AI within a group
         if !is_user && prev_sender == Some("user") {
-            all_lines.push(Line::from(vec![Span::styled("│", dim_style)]));
+            let width = chunks[0].width as usize;
+            let sep = format!("├{}", "─".repeat(width.saturating_sub(1)));
+            all_lines.push(Line::from(vec![Span::styled(sep, dim_style)]));
         }
 
         // Render message: all bars use the same dim style

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -688,7 +688,7 @@ fn format_group_elapsed(start: &Option<String>, end: &Option<String>) -> String 
     };
     let elapsed = end_dt.signed_duration_since(start_dt);
     let secs = elapsed.num_seconds();
-    if secs < 0 {
+    if secs <= 0 {
         return String::new();
     }
     if secs < 60 {


### PR DESCRIPTION
## Changes

### 1. Horizontal separator between user and AI messages
- Replace the bare `│` separator with `├─────...` filling the pane width
- Provides a clear visual boundary between user input and AI response within each chat group

### 2. Hide `╰─` duration when ≤ 0 seconds
- `format_group_elapsed` now returns empty string when `secs <= 0` instead of `secs < 0`
- The `╰─` footer only shows duration when it is actually > 0

## Visual

Before:
```
╭─ 14:30
│ You: hello
│
│ AI: hi there
╰─ 0s
```

After:
```
╭─ 14:30
│ You: hello
├──────────────────
│ AI: hi there
╰─
```
