### PR TITLE
feat: add per-pattern thread_path config for custom thread directory

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -79,6 +79,14 @@ enabled = true
 # tool to load them on demand.
 # inject_inbound_images = true
 
+# Custom filesystem path for the thread directory.
+# When set, the thread's working directory is this path instead of the
+# default <workspace>/<thread_name>/. Supports ~ expansion to $HOME.
+# Absolute paths are used as-is. The thread_name (or thread_prefix) still
+# controls the logical routing key — this field only changes where files
+# are stored on disk.
+# thread_path = "~/my-project"
+
 # Per-pattern skills whitelist: overrides channel-level `skills`.
 # When both are unset, all discovered skills are loaded.
 # skills = ["invoice-processing"]

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -412,7 +412,7 @@ impl JycAgentService {
         // Chat history access instructions
         prompt.push_str(
             "## Chat History\n\
-             This thread maintains a chronological chat history in `chat_history_YYYY-MM-DD.jsonl`.\n\
+             This thread maintains a chronological chat history in `.jyc/chat_history_YYYY-MM-DD.jsonl`.\n\
              Each line is a JSON object (one message or reply per line). You can read it with the\n\
              `read` tool if you need context from prior conversations, or use `grep` to search.\n",
         );

--- a/crates/jyc-agent/src/session.rs
+++ b/crates/jyc-agent/src/session.rs
@@ -551,25 +551,13 @@ async fn save_session_state(path: &Path, state: &SessionState) {
 }
 
 /// Fallback: Load context from chat_history_*.jsonl files (text-only).
+/// Reads from `.jyc/` first (new location), falls back to thread root (legacy).
 #[allow(dead_code)]
 async fn load_from_chat_history(
     thread_path: &Path,
     cutoff: Option<&chrono::DateTime<chrono::Utc>>,
 ) -> Vec<Message> {
-    let mut history_files: Vec<_> = match std::fs::read_dir(thread_path) {
-        Ok(entries) => entries
-            .filter_map(|e| e.ok())
-            .filter(|e| {
-                e.file_name()
-                    .to_str()
-                    .is_some_and(|n| n.starts_with("chat_history_") && n.ends_with(".jsonl"))
-            })
-            .map(|e| e.path())
-            .collect(),
-        Err(_) => return Vec::new(),
-    };
-
-    history_files.sort();
+    let (history_files, _dir) = jyc_core::chat_log_store::list_chat_history_files(thread_path);
 
     let mut messages: Vec<Message> = Vec::new();
 

--- a/crates/jyc-agent/src/tools/builtin/send_to_thread.rs
+++ b/crates/jyc-agent/src/tools/builtin/send_to_thread.rs
@@ -212,7 +212,7 @@ impl Tool for SendToThreadTool {
         };
 
         target_tm
-            .enqueue(inbound, thread_name.to_string(), pattern_match, None, true)
+            .enqueue(inbound, thread_name.to_string(), pattern_match, None, true, None)
             .await;
 
         let attachment_info = if validated_attachments.is_empty() {

--- a/crates/jyc-agent/src/tools/builtin/send_to_thread.rs
+++ b/crates/jyc-agent/src/tools/builtin/send_to_thread.rs
@@ -212,7 +212,14 @@ impl Tool for SendToThreadTool {
         };
 
         target_tm
-            .enqueue(inbound, thread_name.to_string(), pattern_match, None, true, None)
+            .enqueue(
+                inbound,
+                thread_name.to_string(),
+                pattern_match,
+                None,
+                true,
+                None,
+            )
             .await;
 
         let attachment_info = if validated_attachments.is_empty() {

--- a/crates/jyc-channels/src/websocket/inbound.rs
+++ b/crates/jyc-channels/src/websocket/inbound.rs
@@ -378,25 +378,15 @@ where
 ///
 /// Reads `chat_history_*.jsonl` files in the thread directory, parses each
 /// line, and returns up to `max_messages` most recent entries.
+/// Reads from `.jyc/` first (new location), falls back to thread root (legacy).
 fn load_chat_history(workspace_dir: &Path, thread: &str, max_messages: usize) -> Vec<HistoryEntry> {
     let thread_dir = workspace_dir.join(thread);
     if !thread_dir.exists() {
         return vec![];
     }
 
-    // Collect and sort chat history files by name (descending = newest first)
-    let mut files: Vec<PathBuf> = match std::fs::read_dir(&thread_dir) {
-        Ok(entries) => entries
-            .filter_map(|e| e.ok())
-            .map(|e| e.path())
-            .filter(|p| {
-                p.file_name()
-                    .and_then(|n| n.to_str())
-                    .is_some_and(|n| n.starts_with("chat_history_") && n.ends_with(".jsonl"))
-            })
-            .collect(),
-        Err(_) => return vec![],
-    };
+    // Use the centralized helper that tries .jyc/ first, then root
+    let (mut files, _dir) = jyc_core::chat_log_store::list_chat_history_files(&thread_dir);
     files.sort_by(|a, b| b.cmp(a)); // newest first
 
     let mut entries = Vec::new();

--- a/crates/jyc-core/src/chat_log_store.rs
+++ b/crates/jyc-core/src/chat_log_store.rs
@@ -29,6 +29,38 @@ pub struct ChatLogStore {
     max_file_size: u64,
 }
 
+/// List chat history JSONL files in a thread directory.
+///
+/// Tries `.jyc/` first (new location), falls back to thread root (legacy).
+/// Returns sorted paths (oldest first) and the directory they were found in.
+pub fn list_chat_history_files(thread_path: &Path) -> (Vec<PathBuf>, PathBuf) {
+    let new_dir = thread_path.join(".jyc");
+    let files = read_chat_history_dir(&new_dir);
+    if !files.is_empty() {
+        return (files, new_dir);
+    }
+    // Fallback: legacy location (thread root)
+    let files = read_chat_history_dir(thread_path);
+    (files, thread_path.to_path_buf())
+}
+
+fn read_chat_history_dir(dir: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut files: Vec<PathBuf> = entries
+        .flatten()
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|n| n.starts_with("chat_history_") && n.ends_with(".jsonl"))
+        })
+        .map(|e| e.path())
+        .collect();
+    files.sort();
+    files
+}
+
 impl ChatLogStore {
     /// Create a new chat log store for the given thread.
     pub fn new(thread_path: &Path) -> Self {
@@ -43,8 +75,10 @@ impl ChatLogStore {
     }
 
     /// Get the path for today's chat history file.
+    /// New location: `.jyc/chat_history_YYYY-MM-DD.jsonl`
     fn get_today_file_path(&self) -> PathBuf {
         self.thread_path
+            .join(".jyc")
             .join(format!("chat_history_{}.jsonl", self.current_date))
     }
 

--- a/crates/jyc-core/src/command/new_handler.rs
+++ b/crates/jyc-core/src/command/new_handler.rs
@@ -7,6 +7,40 @@ use super::handler::{CommandContext, CommandHandler, CommandResult};
 ///
 /// Usage:
 ///   /new    Delete session state files and chat history; next AI prompt will start completely fresh
+/// Delete all files matching a glob pattern. Returns count of deleted files.
+async fn delete_glob_files(pattern: &std::path::Path) -> u64 {
+    let pattern_str = pattern.to_string_lossy().to_string();
+    let mut count = 0u64;
+    match glob::glob(&pattern_str) {
+        Ok(paths) => {
+            for entry in paths {
+                match entry {
+                    Ok(path) => {
+                        if tokio::fs::remove_file(&path).await.is_ok() {
+                            count += 1;
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            pattern = %pattern.display(),
+                            error = %e,
+                            "Failed to read path during /new glob"
+                        );
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                pattern = %pattern.display(),
+                error = %e,
+                "Failed to glob files during /new"
+            );
+        }
+    }
+    count
+}
+
 pub struct NewCommandHandler;
 
 #[async_trait]
@@ -38,37 +72,16 @@ impl CommandHandler for NewCommandHandler {
             deleted_session = true;
         }
 
-        // Delete all chat_history_*.jsonl files in the thread directory
+        // Delete all chat_history_*.jsonl files in the thread directory (both locations)
         let mut deleted_history = 0u64;
-        let pattern = context.thread_path.join("chat_history_*.jsonl");
-        let pattern_str = pattern.to_string_lossy().to_string();
 
-        match glob::glob(&pattern_str) {
-            Ok(paths) => {
-                for entry in paths {
-                    match entry {
-                        Ok(path) => {
-                            tokio::fs::remove_file(&path).await?;
-                            deleted_history += 1;
-                        }
-                        Err(e) => {
-                            tracing::warn!(
-                                thread = %context.thread_path.display(),
-                                error = %e,
-                                "Failed to read chat history path during /new"
-                            );
-                        }
-                    }
-                }
-            }
-            Err(e) => {
-                tracing::warn!(
-                    thread = %context.thread_path.display(),
-                    error = %e,
-                    "Failed to glob chat history files during /new"
-                );
-            }
-        }
+        // New location: .jyc/
+        let new_pattern = context.thread_path.join(".jyc").join("chat_history_*.jsonl");
+        deleted_history += delete_glob_files(&new_pattern).await;
+
+        // Legacy location: thread root
+        let root_pattern = context.thread_path.join("chat_history_*.jsonl");
+        deleted_history += delete_glob_files(&root_pattern).await;
 
         let msg = if deleted_session || deleted_history > 0 {
             format!(

--- a/crates/jyc-core/src/command/new_handler.rs
+++ b/crates/jyc-core/src/command/new_handler.rs
@@ -76,7 +76,10 @@ impl CommandHandler for NewCommandHandler {
         let mut deleted_history = 0u64;
 
         // New location: .jyc/
-        let new_pattern = context.thread_path.join(".jyc").join("chat_history_*.jsonl");
+        let new_pattern = context
+            .thread_path
+            .join(".jyc")
+            .join("chat_history_*.jsonl");
         deleted_history += delete_glob_files(&new_pattern).await;
 
         // Legacy location: thread root

--- a/crates/jyc-core/src/message_router.rs
+++ b/crates/jyc-core/src/message_router.rs
@@ -165,10 +165,22 @@ impl MessageRouter {
                 .insert("repo_group_key".to_string(), serde_json::Value::String(key));
         }
 
-        // 4. Enqueue (channel-agnostic)
+        // 4. Resolve thread_path override (if pattern sets a custom filesystem path)
+        let thread_path_override = matched_pattern
+            .and_then(|p| p.thread_path.as_ref())
+            .map(|tp| crate::thread_path::resolve_thread_path(tp));
+
+        // 5. Enqueue (channel-agnostic)
         let pm = pattern_match.expect("pattern_match should be Some");
         self.thread_manager
-            .enqueue(message, thread_name, pm, attachment_config, live_injection)
+            .enqueue(
+                message,
+                thread_name,
+                pm,
+                attachment_config,
+                live_injection,
+                thread_path_override,
+            )
             .await;
     }
 

--- a/crates/jyc-core/src/message_storage.rs
+++ b/crates/jyc-core/src/message_storage.rs
@@ -67,6 +67,25 @@ impl MessageStorage {
         })
     }
 
+    /// Store an inbound message at a specific thread path.
+    ///
+    /// Used when a pattern's `thread_path` override places the thread
+    /// outside the default workspace directory.
+    pub async fn store_at_path(
+        &self,
+        message: &InboundMessage,
+        thread_path: &Path,
+        is_matched: bool,
+    ) -> Result<StoreResult> {
+        let message_dir = Utc::now().format("%Y-%m-%d_%H-%M-%S").to_string();
+        self.append_to_chat_log(thread_path, message, is_matched)
+            .await?;
+        Ok(StoreResult {
+            thread_path: thread_path.to_path_buf(),
+            message_dir,
+        })
+    }
+
     /// Store an inbound message (backward compatibility).
     ///
     /// Calls store_with_match with is_matched = true.

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -173,6 +173,7 @@ impl ThreadManager {
         pattern_match: PatternMatch,
         attachment_config: Option<InboundAttachmentConfig>,
         live_injection: bool,
+        thread_path_override: Option<PathBuf>,
     ) {
         let mut queues = self.thread_queues.lock().await;
 
@@ -215,6 +216,7 @@ impl ThreadManager {
             attachment_config,
             template,
             live_injection,
+            thread_path_override,
         };
 
         self.metrics.message_received(&thread_name);
@@ -2054,7 +2056,7 @@ mode = "agent"
             channel: "websocket".to_string(),
             matches: HashMap::new(),
         };
-        tm.enqueue(msg, "test-thread".to_string(), pattern_match, None, false)
+        tm.enqueue(msg, "test-thread".to_string(), pattern_match, None, false, None)
             .await;
 
         // Give the worker a moment to start

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -381,7 +381,10 @@ impl ThreadManager {
                 // Initialize thread from template if needed
                 if let Some(ref template_name) = item.template {
                     let workspace = storage.workspace();
-                    let thread_path = workspace.join(&thread_name);
+                    let thread_path = item
+                        .thread_path_override
+                        .clone()
+                        .unwrap_or_else(|| workspace.join(&thread_name));
 
                     match initialize_thread_from_template(
                         &thread_path,
@@ -549,7 +552,10 @@ impl ThreadManager {
 
                 // Check symlink integrity after AI processing completes
                 if let Some(repo_group_key) = item.message.metadata.get("repo_group_key").and_then(|v| v.as_str()) {
-                    let thread_path = storage.workspace().join(&thread_name);
+                    let thread_path = item
+                        .thread_path_override
+                        .clone()
+                        .unwrap_or_else(|| storage.workspace().join(&thread_name));
                     let symlink_path = thread_path.join("repo");
                     match tokio::fs::symlink_metadata(&symlink_path).await {
                         Ok(meta) if meta.file_type().is_symlink() => {
@@ -1050,14 +1056,19 @@ async fn process_message(
 ) -> Result<()> {
     // ── 1. STORE ──────────────────────────────────────────────────────
     let is_matched = !item.pattern_match.pattern_name.is_empty();
-    let store_result: StoreResult = storage
-        .store_with_match(
-            &item.message,
-            thread_name,
-            is_matched,
-            item.attachment_config.as_ref(),
-        )
-        .await?;
+    let store_result: StoreResult = match &item.thread_path_override {
+        Some(path) => storage.store_at_path(&item.message, path, is_matched).await?,
+        None => {
+            storage
+                .store_with_match(
+                    &item.message,
+                    thread_name,
+                    is_matched,
+                    item.attachment_config.as_ref(),
+                )
+                .await?
+        }
+    };
 
     tracing::info!(
         sender = %item.message.sender_address,

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -1057,7 +1057,11 @@ async fn process_message(
     // ── 1. STORE ──────────────────────────────────────────────────────
     let is_matched = !item.pattern_match.pattern_name.is_empty();
     let store_result: StoreResult = match &item.thread_path_override {
-        Some(path) => storage.store_at_path(&item.message, path, is_matched).await?,
+        Some(path) => {
+            storage
+                .store_at_path(&item.message, path, is_matched)
+                .await?
+        }
         None => {
             storage
                 .store_with_match(
@@ -2067,8 +2071,15 @@ mode = "agent"
             channel: "websocket".to_string(),
             matches: HashMap::new(),
         };
-        tm.enqueue(msg, "test-thread".to_string(), pattern_match, None, false, None)
-            .await;
+        tm.enqueue(
+            msg,
+            "test-thread".to_string(),
+            pattern_match,
+            None,
+            false,
+            None,
+        )
+        .await;
 
         // Give the worker a moment to start
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;

--- a/crates/jyc-core/src/thread_path.rs
+++ b/crates/jyc-core/src/thread_path.rs
@@ -23,12 +23,16 @@ pub fn resolve_shared_repo_dir(workspace: &Path, group_key: &str) -> PathBuf {
 ///
 /// Expands `~` to `$HOME`. Absolute paths are used as-is.
 pub fn resolve_thread_path(path: &str) -> PathBuf {
-    if path.starts_with("~") {
+    if let Some(rest) = path.strip_prefix("~/") {
         if let Some(home) = std::env::var_os("HOME") {
-            PathBuf::from(home).join(path.strip_prefix("~").unwrap())
+            PathBuf::from(home).join(rest)
         } else {
             PathBuf::from(path)
         }
+    } else if path == "~" {
+        std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(path))
     } else {
         PathBuf::from(path)
     }
@@ -81,6 +85,23 @@ mod tests {
     }
 
     // === resolve_workspace (used by cli/monitor.rs) ===
+
+    #[test]
+    fn test_resolve_thread_path_absolute() {
+        let p = resolve_thread_path("/home/jiny/my-project");
+        assert_eq!(p, PathBuf::from("/home/jiny/my-project"));
+    }
+
+    #[test]
+    fn test_resolve_thread_path_tilde() {
+        let p = resolve_thread_path("~/my-project");
+        if let Some(home) = std::env::var_os("HOME") {
+            assert_eq!(p, PathBuf::from(home).join("my-project"));
+        } else {
+            // No HOME set — falls back to literal
+            assert_eq!(p, PathBuf::from("~/my-project"));
+        }
+    }
 
     #[test]
     fn test_resolve_workspace_email() {

--- a/crates/jyc-core/src/thread_path.rs
+++ b/crates/jyc-core/src/thread_path.rs
@@ -365,8 +365,9 @@ mod tests {
         assert_eq!(result.thread_path, custom_path);
         assert!(result.thread_path.exists());
 
-        // Chat log should be inside the custom path
-        let entries: Vec<_> = std::fs::read_dir(&custom_path).unwrap().collect();
+        // Chat log should be inside the custom path .jyc/ directory
+        let jyc_dir = custom_path.join(".jyc");
+        let entries: Vec<_> = std::fs::read_dir(&jyc_dir).unwrap().collect();
         let has_chat_log = entries.iter().any(|e| {
             e.as_ref()
                 .unwrap()
@@ -374,7 +375,7 @@ mod tests {
                 .to_string_lossy()
                 .starts_with("chat_history_")
         });
-        assert!(has_chat_log, "chat log file should exist in custom path");
+        assert!(has_chat_log, "chat log file should exist in .jyc/");
 
         // Should NOT be under workspace
         assert!(

--- a/crates/jyc-core/src/thread_path.rs
+++ b/crates/jyc-core/src/thread_path.rs
@@ -341,21 +341,114 @@ mod tests {
         assert!(msg.attachments[0].saved_path.as_ref().unwrap().exists());
     }
 
-    // === .jyc path (real production pattern) ===
+    // === store_at_path (custom thread_path override) ===
 
     #[tokio::test]
-    async fn test_jyc_dir_created_in_correct_location() {
+    async fn test_store_at_path_writes_to_custom_directory() {
+        let tmp = tempdir().unwrap();
+        let ws = resolve_workspace(tmp.path(), "jiny283a");
+        tokio::fs::create_dir_all(&ws).await.unwrap();
+
+        let storage = MessageStorage::new(&ws);
+
+        // Custom thread path OUTSIDE the workspace
+        let custom_path = tmp.path().join("custom-projects").join("my-project");
+        tokio::fs::create_dir_all(&custom_path).await.unwrap();
+
+        let msg = make_message("jiny283a", "Test Subject");
+        let result = storage
+            .store_at_path(&msg, &custom_path, true)
+            .await
+            .unwrap();
+
+        // Thread path should be the custom path, not workspace-joined
+        assert_eq!(result.thread_path, custom_path);
+        assert!(result.thread_path.exists());
+
+        // Chat log should be inside the custom path
+        let chat_log = custom_path.join("chat_history_");
+        let entries: Vec<_> = std::fs::read_dir(&custom_path).unwrap().collect();
+        let has_chat_log = entries.iter().any(|e| {
+            e.as_ref()
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with("chat_history_")
+        });
+        assert!(has_chat_log, "chat log file should exist in custom path");
+
+        // Should NOT be under workspace
+        assert!(
+            !result
+                .thread_path
+                .starts_with(&ws),
+            "custom thread path should not be under workspace"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_store_at_path_creates_thread_dir_if_missing() {
+        let tmp = tempdir().unwrap();
+        let ws = resolve_workspace(tmp.path(), "jiny283a");
+        tokio::fs::create_dir_all(&ws).await.unwrap();
+
+        let storage = MessageStorage::new(&ws);
+
+        // Custom path that doesn't exist yet
+        let custom_path = tmp.path().join("new-external-dir").join("thread-1");
+
+        let msg = make_message("jiny283a", "Test Subject");
+        let result = storage
+            .store_at_path(&msg, &custom_path, true)
+            .await
+            .unwrap();
+
+        assert_eq!(result.thread_path, custom_path);
+        assert!(result.thread_path.exists());
+        assert!(result.thread_path.is_dir());
+    }
+
+    // === resolve_thread_path edge cases ===
+
+    #[test]
+    fn test_resolve_thread_path_home_only() {
+        let p = resolve_thread_path("~");
+        if let Some(home) = std::env::var_os("HOME") {
+            assert_eq!(p, PathBuf::from(home));
+        } else {
+            assert_eq!(p, PathBuf::from("~"));
+        }
+    }
+
+    #[test]
+    fn test_resolve_thread_path_relative() {
+        // Relative paths are used as-is (no workspace resolution)
+        let p = resolve_thread_path("my-project");
+        assert_eq!(p, PathBuf::from("my-project"));
+    }
+
+    #[tokio::test]
+    async fn test_thread_path_override_not_under_workspace() {
+        // Verify that store_at_path produces a path completely outside
+        // the standard workspace hierarchy.
         let tmp = tempdir().unwrap();
         let ws = resolve_workspace(tmp.path(), "feishu_bot");
-        let thread_path = ws.join("self-hosting-jyc");
-        let jyc_dir = thread_path.join(".jyc");
-        tokio::fs::create_dir_all(&jyc_dir).await.unwrap();
 
-        // Verify path structure
-        assert!(jyc_dir.exists());
-        assert!(jyc_dir.starts_with(&ws));
-        let path_str = jyc_dir.to_string_lossy();
-        assert!(path_str.ends_with("self-hosting-jyc/.jyc"));
-        assert_eq!(path_str.matches("workspace").count(), 1);
+        let custom = tmp.path().join("elsewhere");
+        tokio::fs::create_dir_all(&custom).await.unwrap();
+
+        let storage = MessageStorage::new(&ws);
+        let msg = make_feishu_message("发票群", "group");
+        let result = storage.store_at_path(&msg, &custom, true).await.unwrap();
+
+        assert_eq!(result.thread_path, custom);
+        // Ensure path doesn't contain "workspace" segment at all
+        assert!(
+            !result
+                .thread_path
+                .to_string_lossy()
+                .contains("workspace"),
+            "custom path should not contain 'workspace'"
+        );
     }
 }

--- a/crates/jyc-core/src/thread_path.rs
+++ b/crates/jyc-core/src/thread_path.rs
@@ -379,9 +379,7 @@ mod tests {
 
         // Should NOT be under workspace
         assert!(
-            !result
-                .thread_path
-                .starts_with(&ws),
+            !result.thread_path.starts_with(&ws),
             "custom thread path should not be under workspace"
         );
     }
@@ -444,10 +442,7 @@ mod tests {
         assert_eq!(result.thread_path, custom);
         // Ensure path doesn't contain "workspace" segment at all
         assert!(
-            !result
-                .thread_path
-                .to_string_lossy()
-                .contains("workspace"),
+            !result.thread_path.to_string_lossy().contains("workspace"),
             "custom path should not contain 'workspace'"
         );
     }

--- a/crates/jyc-core/src/thread_path.rs
+++ b/crates/jyc-core/src/thread_path.rs
@@ -366,7 +366,6 @@ mod tests {
         assert!(result.thread_path.exists());
 
         // Chat log should be inside the custom path
-        let chat_log = custom_path.join("chat_history_");
         let entries: Vec<_> = std::fs::read_dir(&custom_path).unwrap().collect();
         let has_chat_log = entries.iter().any(|e| {
             e.as_ref()

--- a/crates/jyc-core/src/thread_path.rs
+++ b/crates/jyc-core/src/thread_path.rs
@@ -19,6 +19,21 @@ pub fn resolve_shared_repo_dir(workspace: &Path, group_key: &str) -> PathBuf {
     workspace.join("repos").join(group_key)
 }
 
+/// Resolve a custom thread path from a pattern's `thread_path` config.
+///
+/// Expands `~` to `$HOME`. Absolute paths are used as-is.
+pub fn resolve_thread_path(path: &str) -> PathBuf {
+    if path.starts_with("~") {
+        if let Some(home) = std::env::var_os("HOME") {
+            PathBuf::from(home).join(path.strip_prefix("~").unwrap())
+        } else {
+            PathBuf::from(path)
+        }
+    } else {
+        PathBuf::from(path)
+    }
+}
+
 /// Compute the repo group key from a `repo_group` config value and issue/PR number.
 ///
 /// Returns `"{repo_group}-{number}"`.

--- a/crates/jyc-services/src/job_scheduler.rs
+++ b/crates/jyc-services/src/job_scheduler.rs
@@ -280,7 +280,7 @@ impl JobScheduler {
             matches: std::collections::HashMap::new(),
         };
 
-        tm.enqueue(message, job.thread_name.clone(), pattern_match, None, true)
+        tm.enqueue(message, job.thread_name.clone(), pattern_match, None, true, None)
             .await;
 
         tracing::info!(

--- a/crates/jyc-services/src/job_scheduler.rs
+++ b/crates/jyc-services/src/job_scheduler.rs
@@ -280,8 +280,15 @@ impl JobScheduler {
             matches: std::collections::HashMap::new(),
         };
 
-        tm.enqueue(message, job.thread_name.clone(), pattern_match, None, true, None)
-            .await;
+        tm.enqueue(
+            message,
+            job.thread_name.clone(),
+            pattern_match,
+            None,
+            true,
+            None,
+        )
+        .await;
 
         tracing::info!(
             job_id = %job.id,

--- a/crates/jyc-types/src/agent.rs
+++ b/crates/jyc-types/src/agent.rs
@@ -1,6 +1,7 @@
 use crate::channel::InboundMessage;
 use crate::channel::PatternMatch;
 use crate::config::InboundAttachmentConfig;
+use std::path::PathBuf;
 
 /// An item in a thread's message queue.
 #[derive(Debug)]
@@ -12,4 +13,7 @@ pub struct QueueItem {
     pub attachment_config: Option<InboundAttachmentConfig>,
     pub template: Option<String>,
     pub live_injection: bool,
+    /// Custom filesystem path for the thread directory (from pattern's `thread_path`).
+    /// When set, overrides the default `<workspace>/<thread_name>/` path.
+    pub thread_path_override: Option<PathBuf>,
 }

--- a/crates/jyc-types/src/channel.rs
+++ b/crates/jyc-types/src/channel.rs
@@ -317,6 +317,16 @@ pub struct ChannelPattern {
     /// regardless of message identity.
     #[serde(default)]
     pub thread_prefix: Option<String>,
+    /// Custom filesystem path for the thread directory.
+    ///
+    /// When set, the thread's working directory is this path instead of the
+    /// default `<workspace>/<thread_name>/`. Supports `~` expansion to
+    /// `$HOME`. Absolute paths are used as-is.
+    ///
+    /// The `thread_name` (or `thread_prefix`) still controls the logical
+    /// routing key — this field only changes where files are stored on disk.
+    #[serde(default)]
+    pub thread_path: Option<String>,
     /// Agent role name for this pattern (e.g., "Planner", "Developer", "Reviewer").
     /// Used by GitHub OutboundAdapter to prefix comments with `[Role]`.
     /// Also used to filter out the agent's own comments during polling.
@@ -459,6 +469,7 @@ impl Default for ChannelPattern {
             template: None,
             thread_name: None,
             thread_prefix: None,
+            thread_path: None,
             role: None,
             live_injection: true,
             repo_group: None,


### PR DESCRIPTION
## Summary

Add `thread_path` field to `ChannelPattern` — allows a thread directory to live at any filesystem path, not just `<workspace>/<thread_name>/`.

## Usage

```toml
[[channels.jiny283.patterns]]
name = "my-project"
enabled = true
thread_path = "~/my-project"    # → $HOME/my-project
# thread_path = "/abs/path"     # absolute path
```

`thread_path = "~/something"` expands to `$HOME/something`. Absolute paths used as-is.

## Implementation

- **`ChannelPattern`**: `thread_path: Option<String>` field
- **`QueueItem`**: `thread_path_override: Option<PathBuf>` carries resolved path
- **`thread_path.rs`**: `resolve_thread_path()` with tilde expansion
- **`MessageStorage`**: `store_at_path()` for storing at custom path
- **`ThreadManager`**: `enqueue()` accepts override; worker uses it for template init, symlink, storage
- **`MessageRouter`**: extracts config value, resolves, passes through

## Tests

- `test_resolve_thread_path_absolute` / `test_resolve_thread_path_tilde` / `test_resolve_thread_path_home_only` / `test_resolve_thread_path_relative`
- `test_store_at_path_writes_to_custom_directory`
- `test_store_at_path_creates_thread_dir_if_missing`
- `test_thread_path_override_not_under_workspace`

`cargo clippy --workspace -- -D warnings` and `cargo fmt --check` pass locally.