### PR TITLE
fix: clear chat messages when switching threads in dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ All notable changes to JYC will be documented in this file.
 
 ### Fixed
 
+- **Dashboard chat pane shows stale content when switching threads.** When
+  switching from thread A to thread B, if thread B had no chat history the
+  server skipped sending a `history` message, leaving thread A's messages
+  visible in the chat pane. `select_pattern()` now clears `chat_messages`
+  before subscribing to the new thread. (#349)
+
 - **Dashboard chat pane input not wrapping.** When typing in the chat pane
   input area, text exceeding the pane width was not automatically wrapped to
   the next line. The input paragraph now uses `Wrap { trim: true }` and the

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -227,6 +227,8 @@ impl App {
         self.chat_input.clear();
         self.chat_cursor = 0;
         self.chat_scroll = 0;
+        self.chat_messages.clear();
+        self.chat_messages.clear();
 
         let subscribe_msg = serde_json::json!({
             "type": "subscribe",

--- a/crates/jyc-cli/src/cli/dashboard.rs
+++ b/crates/jyc-cli/src/cli/dashboard.rs
@@ -2088,3 +2088,34 @@ fn format_last_active(value: Option<&str>) -> String {
     }
     dt.format("%b %d").to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn select_pattern_clears_chat_messages() {
+        let (_tx, rx) = tokio::sync::mpsc::unbounded_channel::<WsEvent>();
+        let mut app = App::new(rx);
+
+        // Simulate messages from a previous thread
+        app.chat_messages.push(ChatMessage {
+            sender: "user".to_string(),
+            text: "hello from thread A".to_string(),
+            timestamp: None,
+        });
+        app.chat_messages.push(ChatMessage {
+            sender: "ai".to_string(),
+            text: "reply from thread A".to_string(),
+            timestamp: None,
+        });
+        assert_eq!(app.chat_messages.len(), 2);
+
+        // Switch to a new thread
+        app.select_pattern("thread-b".to_string());
+
+        // Messages must be cleared so stale content doesn't leak across threads
+        assert!(app.chat_messages.is_empty());
+        assert_eq!(app.chat_thread.as_deref(), Some("thread-b"));
+    }
+}


### PR DESCRIPTION
## Problem

When switching the dashboard chat pane from thread A to thread B, if thread B has no chat history (empty `activity.jsonl`), the server skips sending a `history` message (guarded by `if !history.is_empty()`). The client's `chat_messages` vec still held thread A's content, causing stale messages from thread A to be displayed in thread B's chat pane.

## Fix

Add `self.chat_messages.clear()` in `select_pattern()` before subscribing to the new thread. This ensures the chat pane is always in a clean state when switching threads, regardless of whether the server sends history.

## Test

Added unit test `select_pattern_clears_chat_messages` that:
1. Populates `chat_messages` with simulated thread A messages
2. Calls `select_pattern("thread-b")`
3. Asserts `chat_messages` is empty and `chat_thread` is updated

```
cargo test dashboard::tests
test cli::dashboard::tests::select_pattern_clears_chat_messages ... ok
```

## Checklist

- [x] `cargo fmt --check` — pass
- [x] `cargo clippy --workspace -- -D warnings` — pass
- [x] Unit test added and passing
- [x] CHANGELOG.md updated