### PR TITLE
fix: write .jyc/thread-name unconditionally, not only when template is set

### DIFF
--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -461,21 +461,25 @@ impl ThreadManager {
                             }
                         }
                     }
+                }
 
-                    let jyc_dir = thread_path.join(".jyc");
-                    if let Err(e) = tokio::fs::create_dir_all(&jyc_dir).await {
-                        tracing::warn!(error = %e, "Failed to create .jyc directory");
-                    }
-                    let pattern_file = jyc_dir.join("pattern");
-                    if let Err(e) = tokio::fs::write(&pattern_file, &item.pattern_match.pattern_name).await {
-                        tracing::warn!(error = %e, "Failed to write pattern file");
-                    }
-                    // Persist the logical thread name so custom thread_path
-                    // directories can be rediscovered after restart.
-                    let thread_name_file = jyc_dir.join("thread-name");
-                    if let Err(e) = tokio::fs::write(&thread_name_file, &thread_name).await {
-                        tracing::warn!(error = %e, "Failed to write thread-name file");
-                    }
+                // Always ensure .jyc/ directory and metadata files exist,
+                // even when no template is configured. This is critical for
+                // custom thread_path directories to be rediscovered after
+                // restart (via .jyc/thread-name).
+                let jyc_dir = thread_path.join(".jyc");
+                if let Err(e) = tokio::fs::create_dir_all(&jyc_dir).await {
+                    tracing::warn!(error = %e, "Failed to create .jyc directory");
+                }
+                let pattern_file = jyc_dir.join("pattern");
+                if let Err(e) = tokio::fs::write(&pattern_file, &item.pattern_match.pattern_name).await {
+                    tracing::warn!(error = %e, "Failed to write pattern file");
+                }
+                // Persist the logical thread name so custom thread_path
+                // directories can be rediscovered after restart.
+                let thread_name_file = jyc_dir.join("thread-name");
+                if let Err(e) = tokio::fs::write(&thread_name_file, &thread_name).await {
+                    tracing::warn!(error = %e, "Failed to write thread-name file");
                 }
 
                 // Acquire repo group lock to prevent concurrent initialization


### PR DESCRIPTION
## Problem

The `.jyc/pattern` and `.jyc/thread-name` file writes introduced in PR #350 were placed **inside** the `if let Some(template)` block. This means threads whose pattern has **no template configured** never get these files written. As a result, `restore_custom_thread_paths()` cannot find the `thread-name` file and the thread is still lost after restart.

## Fix

Move the `.jyc` directory creation + `pattern` + `thread-name` writes **outside** the template block so they always execute on first message processing, regardless of whether a template is configured.

## Test

Existing tests still pass (8/8). The `test_restore_custom_thread_paths_from_disk` test already covers the restore path.

```
cargo fmt --check     ✅
cargo clippy          ✅
cargo test            ✅ 8 passed
```