### PR TITLE
fix: pre-create event bus for restored custom thread_path threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,10 @@ All notable changes to JYC will be documented in this file.
   first processed, its logical name is persisted to `.jyc/thread-name`. On
   startup, `restore_custom_thread_paths()` scans **only this TM's channel**
   patterns for `thread_path` overrides and reads `.jyc/thread-name` to rebuild
-  the mapping before `ActivityTracker` loads historical activity. (#350, #352)
+  the mapping before `ActivityTracker` loads historical activity. Restored
+  threads also get a pre-created event bus so the first message's activity
+  events are not lost to the ActivityTracker's 2-second subscription delay.
+  (#350, #352, #353)
 
 - **Dashboard chat pane shows stale content when switching threads.** When
   switching from thread A to thread B, if thread B had no chat history the

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -712,7 +712,9 @@ impl ThreadManager {
     ///
     /// Scans this ThreadManager's channel patterns for `thread_path` overrides.
     /// For each, checks if the directory exists and contains a `.jyc/thread-name`
-    /// file. If so, restores the mapping into the in-memory `thread_paths` map.
+    /// file. If so, restores the mapping into the in-memory `thread_paths` map
+    /// and pre-creates an event bus so the ActivityTracker can subscribe before
+    /// any messages arrive.
     ///
     /// Only patterns belonging to this TM's channel are scanned — each TM only
     /// restores its own threads to avoid cross-channel contamination.
@@ -740,13 +742,21 @@ impl ThreadManager {
                         continue;
                     }
                     let mut paths = self.thread_paths.lock().await;
-                    paths.entry(name).or_insert_with(|| {
+                    paths.entry(name.clone()).or_insert_with(|| {
                         tracing::info!(
                             path = %resolved.display(),
                             "Restored custom thread_path from disk"
                         );
                         resolved
                     });
+                    drop(paths);
+                    // Pre-create the event bus so the ActivityTracker can
+                    // subscribe before the first message arrives. Without this,
+                    // events from the first message are lost because the
+                    // ActivityTracker's 2s poll hasn't discovered the bus yet.
+                    if self.enable_events {
+                        self.get_or_create_event_bus(&name).await;
+                    }
                 }
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     // Directory exists but no thread-name file — not yet
@@ -2374,6 +2384,14 @@ mode = "agent"
         assert!(
             names.contains(&"my-custom-thread"),
             "list_threads should include restored custom-path thread"
+        );
+
+        // Event bus should be pre-created so ActivityTracker can subscribe
+        // before the first message arrives (avoids lost first-message events).
+        let bus = tm.get_event_bus("my-custom-thread").await;
+        assert!(
+            bus.is_some(),
+            "restore_custom_thread_paths should pre-create event bus"
         );
 
         tm.shutdown().await;


### PR DESCRIPTION
## Problem

After restart, the first message to a restored custom `thread_path` thread produces no activity events (neither on dashboard nor chat pane). Subsequent messages work fine.

### Root Cause

Timeline after restart:

1. `restore_custom_thread_paths()` restores the `thread_paths` mapping
2. `ActivityTracker::start()` runs — calls `list_threads()` — finds the restored thread
3. ActivityTracker tries `get_event_bus()` — returns `None` (no event bus created yet, thread is idle)
4. ActivityTracker skips subscription (no event bus, no active queue)
5. User sends first message → `enqueue()` → creates event bus → worker emits events
6. ActivityTracker's next tick (up to 2s later) discovers the event bus and subscribes

**The first message's events are emitted before the ActivityTracker subscribes → events lost.**

### Fix

In `restore_custom_thread_paths()`, after restoring the `thread_paths` mapping, pre-create the event bus for each restored thread. This way the ActivityTracker can subscribe immediately on its first tick, before any user message arrives.

Updated timeline:

```
restore_custom_thread_paths()
  → restore thread_paths mapping
  → pre-create event bus for each thread    ← NEW
ActivityTracker::start()
  → first tick: finds event bus → subscribes ✅
User sends message
  → events emitted → subscriber already listening ✅
```

### Test

Updated `test_restore_custom_thread_paths_from_disk` to also verify `get_event_bus()` returns `Some` after restore.

All 8 tests pass.

### Checklist

- [x] cargo fmt --check — pass
- [x] cargo clippy --workspace -- -D warnings — pass
- [x] Unit test updated and passing
- [x] CHANGELOG.md updated
