### PR TITLE
fix: cleanup stale custom thread_path entries when directory is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ All notable changes to JYC will be documented in this file.
 
 ### Fixed
 
+- **Stale custom `thread_path` threads linger in dashboard after close.** When a
+  thread directory was deleted (e.g. GitHub issue closed), the in-memory
+  `thread_paths` mapping was never cleaned up. `list_threads()` now prunes
+  entries whose `.jyc/` directory no longer exists, so closed threads disappear
+  from the dashboard immediately. (#354)
+
 - **Custom `thread_path` threads lost after restart.** Threads with a custom
   `thread_path` override disappeared from the thread list after process restart
   (e.g. Docker container restart). The in-memory `thread_paths` map was only

--- a/crates/jyc-core/src/thread_manager.rs
+++ b/crates/jyc-core/src/thread_manager.rs
@@ -802,8 +802,20 @@ impl ThreadManager {
 
         // Also include threads with custom `thread_path` overrides that live
         // outside the workspace directory (e.g. `~/projects/jyc`).
+        // Clean up entries whose directory has been deleted (e.g. thread closed).
         {
-            let paths = self.thread_paths.lock().await;
+            let mut paths = self.thread_paths.lock().await;
+            paths.retain(|name, path| {
+                let exists = path.join(".jyc").is_dir();
+                if !exists {
+                    tracing::info!(
+                        thread = %name,
+                        path = %path.display(),
+                        "Removed stale thread_path entry (directory no longer exists)"
+                    );
+                }
+                exists
+            });
             for name in paths.keys() {
                 if !thread_names.contains(name) {
                     thread_names.push(name.clone());
@@ -2465,6 +2477,50 @@ mode = "agent"
         assert!(
             paths.is_empty(),
             "Should skip paths without thread-name file"
+        );
+
+        tm.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_list_threads_cleans_stale_custom_path() {
+        let tmp = tempdir().unwrap();
+        let workspace = tmp.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let tm = make_test_tm(&workspace);
+
+        // Insert a custom path that doesn't exist on disk
+        let ghost_path = tmp.path().join("deleted-thread");
+        tokio::fs::create_dir_all(ghost_path.join(".jyc"))
+            .await
+            .unwrap();
+        tm.thread_paths
+            .lock()
+            .await
+            .insert("ghost".to_string(), ghost_path.clone());
+
+        // list_threads should include it while dir exists
+        let threads = tm.list_threads().await;
+        assert!(
+            threads.iter().any(|t| t.name == "ghost"),
+            "Should list thread while directory exists"
+        );
+
+        // Delete the directory
+        tokio::fs::remove_dir_all(&ghost_path).await.unwrap();
+
+        // list_threads should now clean it up
+        let threads = tm.list_threads().await;
+        assert!(
+            !threads.iter().any(|t| t.name == "ghost"),
+            "Should not list thread after directory deleted"
+        );
+
+        // thread_paths map should no longer contain the entry
+        let paths = tm.custom_thread_paths().await;
+        assert!(
+            !paths.contains_key("ghost"),
+            "Stale entry should be removed from thread_paths"
         );
 
         tm.shutdown().await;


### PR DESCRIPTION
## Problem

When a thread with a custom `thread_path` is closed (e.g. GitHub issue closed), the thread directory is deleted from disk. However, the `thread_paths` in-memory mapping is never cleaned up. As a result, `list_threads()` keeps returning the deleted thread — it shows as an orphan in the dashboard thread list until the process restarts.

### Root Cause

In `list_threads()`, the custom `thread_paths` entries were included **without checking if the directory still exists on disk**:

```rust
let paths = self.thread_paths.lock().await;
for name in paths.keys() {
    if !thread_names.contains(name) {
        thread_names.push(name.clone());  // no filesystem check!
    }
}
```

For workspace threads, the directory scan naturally skips deleted directories. But custom `thread_path` threads live outside the workspace, so the scan never finds them — they only come from the `thread_paths` map, which is never pruned.

### Fix

Use `retain()` to prune `thread_paths` entries whose `.jyc/` directory no longer exists:

```rust
paths.retain(|_name, path| path.join(".jyc").is_dir());
```

This runs every time `list_threads()` is called, so orphan entries are cleaned up immediately when the dashboard next refreshes.

### Test

Added `test_list_threads_cleans_stale_custom_path` — inserts a custom path into `thread_paths`, deletes the directory, calls `list_threads()`, asserts the thread is no longer listed.

### Checklist

- [x] cargo fmt --check — pass
- [x] cargo clippy --workspace -- -D warnings — pass
- [x] Unit test added and passing
- [x] CHANGELOG.md updated
