### PR TITLE
feat: add mode config at pattern level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to JYC will be documented in this file.
 
 ### Added
 
+- **Per-pattern `mode` config for initial agent mode.** New optional field
+  `mode` on `ChannelPattern` allows setting a default agent mode (`"plan"` or
+  `"build"`) per pattern. Resolution chain: `.jyc/mode-override` runtime file >
+  pattern `mode` > default `"build"`. (#356)
+
 - **`stop_after` parameter for reply tool.** The `jyc_reply_message` tool now
   accepts an optional `stop_after` boolean parameter (default `true` for backward
   compatibility). When `false`, the agent sends a progress update and continues

--- a/config.example.toml
+++ b/config.example.toml
@@ -62,6 +62,11 @@ folder = "INBOX"
 name = "xxx"
 enabled = true
 
+# Initial agent mode for threads matching this pattern. Valid values: "plan", "build".
+# When set, threads matching this pattern start in the specified mode, unless the
+# runtime `.jyc/mode-override` file takes priority. Default: "build".
+# mode = "plan"
+
 # Per-pattern model override: takes priority over channel-level and global
 # [agent].model, but below the runtime .jyc/model-override file.
 # model = "anthropic/claude-opus-4-6"

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -341,8 +341,7 @@ impl JycAgentService {
             matched_pattern.and_then(|name| self.patterns.iter().find(|p| p.name == name));
 
         // Mode resolution chain: .jyc/mode-override file > pattern.mode > default "build"
-        let mode_override =
-            mode_override.or_else(|| pattern.and_then(|p| p.mode.clone()));
+        let mode_override = mode_override.or_else(|| pattern.and_then(|p| p.mode.clone()));
 
         let include_list: Option<&[String]> = pattern
             .and_then(|p| p.skills.as_deref())
@@ -1131,8 +1130,7 @@ impl AgentService for JycAgentService {
             .as_deref()
             .and_then(|name| self.patterns.iter().find(|p| p.name == name));
         // Mode resolution chain: .jyc/mode-override file > pattern.mode > default "build"
-        let mode_override =
-            mode_override.or_else(|| pattern.and_then(|p| p.mode.clone()));
+        let mode_override = mode_override.or_else(|| pattern.and_then(|p| p.mode.clone()));
         // Pattern: try mode-specific field first, then generic model
         let pattern_override = pattern
             .and_then(|p| match mode_override.as_deref() {
@@ -1223,8 +1221,7 @@ impl AgentService for JycAgentService {
         );
         let current_mode = jyc_core::session_state::read_mode_override(thread_path).await;
         // Mode resolution chain: .jyc/mode-override file > pattern.mode > default "build"
-        let current_mode =
-            current_mode.or_else(|| pattern.and_then(|p| p.mode.clone()));
+        let current_mode = current_mode.or_else(|| pattern.and_then(|p| p.mode.clone()));
         let user_blocks =
             self.build_user_blocks(message, provider.supports_images(), current_mode.as_deref());
 
@@ -2092,9 +2089,7 @@ mod tests {
             mode: Some("plan".to_string()),
             ..ChannelPattern::default()
         };
-        let resolved = mode_override
-            .as_deref()
-            .or(pattern.mode.as_deref());
+        let resolved = mode_override.as_deref().or(pattern.mode.as_deref());
         assert_eq!(resolved, Some("plan"));
     }
 
@@ -2107,9 +2102,7 @@ mod tests {
             mode: Some("build".to_string()),
             ..ChannelPattern::default()
         };
-        let resolved = mode_override
-            .as_deref()
-            .or(pattern.mode.as_deref());
+        let resolved = mode_override.as_deref().or(pattern.mode.as_deref());
         assert_eq!(resolved, Some("build"));
     }
 
@@ -2138,9 +2131,7 @@ mod tests {
             mode: Some("plan".to_string()),
             ..ChannelPattern::default()
         };
-        let resolved = mode_override
-            .as_deref()
-            .or(pattern.mode.as_deref());
+        let resolved = mode_override.as_deref().or(pattern.mode.as_deref());
         assert_eq!(resolved, Some("build"));
     }
 

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -340,6 +340,10 @@ impl JycAgentService {
         let pattern =
             matched_pattern.and_then(|name| self.patterns.iter().find(|p| p.name == name));
 
+        // Mode resolution chain: .jyc/mode-override file > pattern.mode > default "build"
+        let mode_override =
+            mode_override.or_else(|| pattern.and_then(|p| p.mode.clone()));
+
         let include_list: Option<&[String]> = pattern
             .and_then(|p| p.skills.as_deref())
             .or(self.channel_skills.as_deref());
@@ -1126,6 +1130,9 @@ impl AgentService for JycAgentService {
             .matched_pattern
             .as_deref()
             .and_then(|name| self.patterns.iter().find(|p| p.name == name));
+        // Mode resolution chain: .jyc/mode-override file > pattern.mode > default "build"
+        let mode_override =
+            mode_override.or_else(|| pattern.and_then(|p| p.mode.clone()));
         // Pattern: try mode-specific field first, then generic model
         let pattern_override = pattern
             .and_then(|p| match mode_override.as_deref() {
@@ -1215,6 +1222,9 @@ impl AgentService for JycAgentService {
             "Full system prompt (enable RUST_LOG=trace to see)"
         );
         let current_mode = jyc_core::session_state::read_mode_override(thread_path).await;
+        // Mode resolution chain: .jyc/mode-override file > pattern.mode > default "build"
+        let current_mode =
+            current_mode.or_else(|| pattern.and_then(|p| p.mode.clone()));
         let user_blocks =
             self.build_user_blocks(message, provider.supports_images(), current_mode.as_deref());
 

--- a/crates/jyc-agent/src/service.rs
+++ b/crates/jyc-agent/src/service.rs
@@ -2082,4 +2082,110 @@ mod tests {
             "build mode prompt should contain BUILD tag, got: {build_prompt}"
         );
     }
+
+    #[test]
+    fn pattern_mode_plan_resolved_when_no_file_override() {
+        // Resolution chain: no file override → pattern.mode = "plan" → resolves to "plan"
+        let mode_override: Option<String> = None; // no file override
+        let pattern = ChannelPattern {
+            name: "test".to_string(),
+            mode: Some("plan".to_string()),
+            ..ChannelPattern::default()
+        };
+        let resolved = mode_override
+            .as_deref()
+            .or(pattern.mode.as_deref());
+        assert_eq!(resolved, Some("plan"));
+    }
+
+    #[test]
+    fn pattern_mode_build_resolved_when_no_file_override() {
+        // Resolution chain: no file override → pattern.mode = "build" → resolves to "build"
+        let mode_override: Option<String> = None; // no file override
+        let pattern = ChannelPattern {
+            name: "test".to_string(),
+            mode: Some("build".to_string()),
+            ..ChannelPattern::default()
+        };
+        let resolved = mode_override
+            .as_deref()
+            .or(pattern.mode.as_deref());
+        assert_eq!(resolved, Some("build"));
+    }
+
+    #[test]
+    fn pattern_mode_defaults_to_build_when_unset() {
+        // Resolution chain: no file override → pattern.mode = None → defaults to "build"
+        let mode_override: Option<String> = None; // no file override
+        let pattern = ChannelPattern {
+            name: "test".to_string(),
+            mode: None,
+            ..ChannelPattern::default()
+        };
+        let resolved = mode_override
+            .as_deref()
+            .or(pattern.mode.as_deref())
+            .unwrap_or("build");
+        assert_eq!(resolved, "build");
+    }
+
+    #[test]
+    fn file_override_takes_priority_over_pattern_mode() {
+        // Resolution chain: file override = "build" → pattern.mode = "plan" → resolves to "build"
+        let mode_override: Option<String> = Some("build".to_string()); // file override
+        let pattern = ChannelPattern {
+            name: "test".to_string(),
+            mode: Some("plan".to_string()),
+            ..ChannelPattern::default()
+        };
+        let resolved = mode_override
+            .as_deref()
+            .or(pattern.mode.as_deref());
+        assert_eq!(resolved, Some("build"));
+    }
+
+    #[test]
+    fn pattern_mode_plan_injects_plan_tag_in_user_prompt() {
+        let patterns = vec![ChannelPattern {
+            name: "my-pattern".to_string(),
+            mode: Some("plan".to_string()),
+            channel: ChannelType::default(),
+            ..ChannelPattern::default()
+        }];
+        let svc = service_with_patterns(None, patterns);
+        let message = InboundMessage {
+            id: "test-id".into(),
+            channel: "test".into(),
+            channel_uid: "uid".into(),
+            sender: "test-sender".into(),
+            sender_address: "test@example.com".into(),
+            recipients: vec![],
+            topic: "test".into(),
+            content: jyc_types::MessageContent {
+                text: Some("hello world".into()),
+                ..Default::default()
+            },
+            timestamp: chrono::Utc::now(),
+            thread_refs: None,
+            reply_to_id: None,
+            external_id: None,
+            attachments: vec![],
+            metadata: Default::default(),
+            matched_pattern: Some("my-pattern".to_string()),
+        };
+
+        // Simulate resolution chain: no file override, pattern has mode = "plan"
+        // This is what happens in build_system_prompt / process
+        let mode_override: Option<String> = None;
+        let pattern = svc.patterns.iter().find(|p| p.name == "my-pattern");
+        let resolved = mode_override
+            .as_deref()
+            .or(pattern.and_then(|p| p.mode.as_deref()));
+
+        let plan_prompt = svc.build_user_prompt_text(&message, resolved);
+        assert!(
+            plan_prompt.contains("CRITICAL: Current mode: PLAN (read-only"),
+            "plan mode prompt should contain PLAN tag, got: {plan_prompt}"
+        );
+    }
 }

--- a/crates/jyc-types/src/channel.rs
+++ b/crates/jyc-types/src/channel.rs
@@ -368,6 +368,12 @@ pub struct ChannelPattern {
     /// but below the runtime `.jyc/model-override` file.
     #[serde(default)]
     pub small_model: Option<String>,
+    /// Initial agent mode for threads matching this pattern.
+    /// Valid values: "plan" or "build".
+    /// Takes priority over the default "build" but below the runtime
+    /// `.jyc/mode-override` file.
+    #[serde(default)]
+    pub mode: Option<String>,
     /// Per-pattern MCP server configurations.
     ///
     /// When set to `Some(list)`, only these MCP servers are loaded for threads
@@ -478,6 +484,7 @@ impl Default for ChannelPattern {
             plan_model: None,
             build_model: None,
             small_model: None,
+            mode: None,
             mcps: None,
             disabled_tools: None,
             disabled_builtin_tools: None,


### PR DESCRIPTION
## Spec

Add a `mode` field to `ChannelPattern` config, allowing each pattern to specify an initial agent mode (`"plan"` or `"build"`). The mode is resolved at processing time: `.jyc/mode-override` runtime file takes priority (existing behavior), then the pattern-level `mode` config is used as fallback, and finally defaults to `"build"`. This enables patterns to start new threads in plan or build mode without requiring manual overrides.

Fixes #355

## Implementation Plan

### Step 1: Add `mode` field to `ChannelPattern` struct
**What:** In `crates/jyc-types/src/channel.rs`, add a new field `pub mode: Option<String>` to the `ChannelPattern` struct. Update the `Default` implementation to include `mode: None`.
**Why:** The struct needs to carry the mode config so it can be deserialized from `config.toml` and passed through the agent service.
**Verify:** `cargo check -p jyc-types` passes with no errors.

### Step 2: Pass pattern `mode` through agent service to mode resolution
**What:** In `crates/jyc-agent/src/service.rs`:
- In `build_system_prompt_with_skills()` (around line 332): after reading `.jyc/mode-override`, fall back to the matched pattern's `mode` field (look up pattern by `matched_pattern` name, already available as `pattern` variable at line 340-341) if the file override is `None`.
- In `process_message()` (around line 1087 and 1217): same fallback logic for `mode_override` / `current_mode`.
**Why:** The mode resolution chain needs the pattern-level `mode` as a fallback between the runtime file override and the default `"build"`.
**Verify:** 
- `cargo check --workspace` passes.
- `cargo test -p jyc-agent -- resolve_mode` passes (existing tests).

### Step 3: Add `mode` documentation in `config.example.toml`
**What:** In `config.example.toml`, add a comment inside the `[[channels.jiny283.patterns]]` section documenting the new `mode` field:
```toml
# Initial agent mode for threads matching this pattern. Valid values: "plan", "build".
# When set, threads start in this mode unless `.jyc/mode-override` exists (runtime override).
# Default: "build".
# mode = "plan"
```
**Why:** Users need documentation for the new config option. Follow the existing pattern of inline comments for config fields.
**Verify:** `cargo check --workspace` passes (no functional change, only comments).

### Step 4: Add tests for mode resolution
**What:** In `crates/jyc-agent/src/service.rs` tests (around line 1460 area), add test cases that verify:
- Pattern with `mode = "plan"` → agent gets PLAN mode when `.jyc/mode-override` is absent.
- Pattern with `mode = "build"` → agent gets BUILD mode.
- Pattern with no `mode` → defaults to BUILD mode.
- `.jyc/mode-override` exists → takes priority over pattern `mode`.
**Why:** Ensure the resolution chain works correctly for all combinations. Edge case coverage.
**Verify:** `cargo test -p jyc-agent -- build_system_prompt` passes for all new test cases.

## Design Decisions
- **Resolution chain**: `.jyc/mode-override` (runtime) > pattern `mode` (config) > default `"build"`. The file override remains highest priority so runtime mode switching still works.
- **No file write**: The config `mode` is resolved at processing time, not written to `.jyc/mode-override`. This keeps the runtime override mechanism clean — the config is purely a default.
- **Follows existing pattern**: Same approach as `plan_model`/`build_model` — config-level default with runtime override on top.