### PR TITLE
fix: reviewer cleanup ready-for-review label after review

### DIFF
--- a/templates/gitee-reviewer/AGENTS.md
+++ b/templates/gitee-reviewer/AGENTS.md
@@ -153,13 +153,6 @@ curl -s -X POST "https://gitee.com/api/v5/repos/{owner}/{repo}/pulls/{number}/co
   -d '{
     "body": "[Reviewer] Please address the review feedback."
   }'
-curl -s -X DELETE "https://gitee.com/api/v5/repos/{owner}/{repo}/issues/{number}/labels/ready-for-review?access_token=${GITEE_TOKEN}"
-curl -s -X POST "https://gitee.com/api/v5/repos/{owner}/{repo}/labels?access_token=${GITEE_TOKEN}" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "ready-for-dev", "color": "0E8A16"}' 2>/dev/null || true
-curl -s -X POST "https://gitee.com/api/v5/repos/{owner}/{repo}/issues/{number}/labels?access_token=${GITEE_TOKEN}" \
-  -H "Content-Type: application/json" \
-  -d '{"labels": ["ready-for-dev"]}'
 ```
 
 If approved:
@@ -170,10 +163,33 @@ curl -s -X POST "https://gitee.com/api/v5/repos/{owner}/{repo}/pulls/{number}/co
   -d '{
     "body": "[Reviewer] ## Review\n\nCode looks good. Approved.\n\n### Summary\n- <what was reviewed>\n- <any minor notes>"
   }'
-curl -s -X DELETE "https://gitee.com/api/v5/repos/{owner}/{repo}/issues/{number}/labels/ready-for-review?access_token=${GITEE_TOKEN}"
 ```
 
 > **⚠️ After approval, do NOT post any additional API comment — the approval review body above is the only output needed. A separate summary comment after approval is redundant and forbidden.**
+
+### 6. Cleanup (NON-NEGOTIABLE)
+
+After submitting your review, you MUST perform label cleanup to hand off to the next agent.
+
+**This step is NON-NEGOTIABLE.** The `ready-for-review` label MUST be removed in ALL cases — failing to do so prevents the next agent from being triggered by the label.
+
+**If changes were requested** — remove `ready-for-review` and add `ready-for-dev`:
+```bash
+cd repo
+curl -s -X DELETE "https://gitee.com/api/v5/repos/{owner}/{repo}/issues/{number}/labels/ready-for-review?access_token=${GITEE_TOKEN}"
+curl -s -X POST "https://gitee.com/api/v5/repos/{owner}/{repo}/labels?access_token=${GITEE_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "ready-for-dev", "color": "0E8A16"}' 2>/dev/null || true
+curl -s -X POST "https://gitee.com/api/v5/repos/{owner}/{repo}/issues/{number}/labels?access_token=${GITEE_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"labels": ["ready-for-dev"]}'
+```
+
+**If approved** — remove `ready-for-review`:
+```bash
+cd repo
+curl -s -X DELETE "https://gitee.com/api/v5/repos/{owner}/{repo}/issues/{number}/labels/ready-for-review?access_token=${GITEE_TOKEN}"
+```
 
 ## Rules
 - ALWAYS prefix every comment or review body with `[Reviewer]` — this is how the system identifies your comments and prevents self-loops
@@ -186,7 +202,7 @@ curl -s -X DELETE "https://gitee.com/api/v5/repos/{owner}/{repo}/issues/{number}
 - Do NOT modify code yourself — only review and comment
 - Do NOT merge the PR — that's the user's decision
 - Do NOT run `cargo build` or `npm run build` — use `cargo check` or `npm run lint` for lightweight verification. Full builds are the developer's responsibility, not the reviewer's.
-- ALWAYS remove the `ready-for-review` label after completing your review: DELETE label API
+- **⚠️ NON-NEGOTIABLE: ALWAYS remove the `ready-for-review` label after completing your review: DELETE label API. Failure to do so prevents the next agent from being triggered.**
 - Do NOT use the `jyc_question_ask_user` tool
 - Be constructive and objective in feedback
 - **Do NOT post a separate API comment after approving — the approval review body is the only output needed. A redundant summary comment after approval is forbidden.**

--- a/templates/github-reviewer/AGENTS.md
+++ b/templates/github-reviewer/AGENTS.md
@@ -154,9 +154,6 @@ Please address the issues above.
 EOF
 )"
 gh pr comment <number> --body "[Reviewer] Please address the review feedback."
-gh pr edit <number> --remove-label ready-for-review
-gh label create ready-for-dev --color "0E8A16" --description "PR ready for development" 2>/dev/null || true
-gh pr edit <number> --add-label "ready-for-dev"
 ```
 
 If approved:
@@ -172,10 +169,29 @@ Code looks good. Approved.
 - <any minor notes>
 EOF
 )"
-gh pr edit <number> --remove-label ready-for-review
 ```
 
 > **⚠️ After approval, do NOT post any additional `gh pr comment` — the approval review body above is the only output needed. A separate summary comment after approval is redundant and forbidden.**
+
+### 6. Cleanup (NON-NEGOTIABLE)
+
+After submitting your review, you MUST perform label cleanup to hand off to the next agent.
+
+**This step is NON-NEGOTIABLE.** The `ready-for-review` label MUST be removed in ALL cases — failing to do so prevents the next agent from being triggered by the label.
+
+**If changes were requested** — remove `ready-for-review` and add `ready-for-dev`:
+```bash
+cd repo
+gh pr edit <number> --remove-label ready-for-review
+gh label create ready-for-dev --color "0E8A16" --description "PR ready for development" 2>/dev/null || true
+gh pr edit <number> --add-label ready-for-dev
+```
+
+**If approved** — remove `ready-for-review`:
+```bash
+cd repo
+gh pr edit <number> --remove-label ready-for-review
+```
 
 ## Rules
 - ALWAYS prefix every comment or review body with `[Reviewer]` — this is how the system identifies your comments and prevents self-loops
@@ -188,7 +204,7 @@ gh pr edit <number> --remove-label ready-for-review
 - Do NOT modify code yourself — only review and comment
 - Do NOT merge the PR — that's the user's decision
 - Do NOT run `cargo build` or `npm run build` — use `cargo check` or `npm run lint` for lightweight verification. Full builds are the developer's responsibility, not the reviewer's.
-- ALWAYS remove the `ready-for-review` label after completing your review: `gh pr edit <number> --remove-label ready-for-review`
+- **⚠️ NON-NEGOTIABLE: ALWAYS remove the `ready-for-review` label after completing your review: `gh pr edit <number> --remove-label ready-for-review`. Failure to do so prevents the next agent from being triggered.**
 - Do NOT use the `jyc_question_ask_user` tool
 - Be constructive and objective in feedback
 - **Do NOT post a separate `gh pr comment` after approving — the approval review body is the only output needed. A redundant summary comment after approval is forbidden.**


### PR DESCRIPTION
## Spec

GitHub/Gitee reviewer agent 有时在 review 完成后没有删除 `ready-for-review` label。根因是标签删除指令嵌入在代码块中，没有被作为独立的工作流步骤显式呈现给 LLM。本 PR 在 reviewer 模板中添加独立的 "Cleanup" 步骤，确保每次 review 结束都删除 `ready-for-review` label。

Fixes #357

## Implementation Plan

### Step 1: 为 github-reviewer 添加 Step 6: Cleanup
**What:** 在 `templates/github-reviewer/AGENTS.md` 的 "Step 5: Submit Review" 之后添加新的 "Step 6: Cleanup" 步骤，将 `gh pr edit <number> --remove-label ready-for-review` 作为独立步骤呈现（而非嵌入在 bash 代码块中），并标注为 NON-NEGOTIABLE。
**Why:** LLM 更容易遗漏嵌入在代码块中的指令。将标签清理提取为自然语言描述的独立步骤，提升可靠性。
**Verify:** 阅读文件确认新增步骤清晰可读，逻辑完整。

### Step 2: 加强 github-reviewer Rules 中的标签清理规则
**What:** 在 `templates/github-reviewer/AGENTS.md` 的 Rules 部分，将已有的标签清理规则从普通列表项改为加粗或标记形式，使其更显眼。
**Why:** Rules 是 LLM 最后扫描的部分，加强视觉突出度可提升遵守率。
**Verify:** 阅读 Rules 部分确认标签清理规则比之前更显眼。

### Step 3: 同步修改到 gitee-reviewer
**What:** 对 `templates/gitee-reviewer/AGENTS.md` 做与 Step 1-2 相同的结构性修改（添加 Step 6: Cleanup、加强 Rules）。gitee-reviewer 使用 `curl -s -X DELETE ".../labels/ready-for-review..."` API 替代 `gh pr edit --remove-label`。
**Why:** 两个 reviewer 模板有相同问题，需同步修复。
**Verify:** 阅读文件确认与 github-reviewer 的改动在结构上一致。

## Design Decisions
- 不在 PR 关闭/合并时清理标签（用户明确排除此场景）
- 标签清理作为独立步骤而非嵌入代码块，提升 LLM 可靠性
- github-reviewer 和 gitee-reviewer 同步修改，保持一致性